### PR TITLE
feat: add DM-Count parser

### DIFF
--- a/depthai_nodes/ml/messages/__init__.py
+++ b/depthai_nodes/ml/messages/__init__.py
@@ -7,6 +7,7 @@ from .keypoints import HandKeypoints, Keypoints
 from .lines import Line, Lines
 from .misc import AgeGender
 from .segmentation import SegmentationMasks
+from .mapping import Map2D
 
 __all__ = [
     "ImgDetectionExtended",

--- a/depthai_nodes/ml/messages/__init__.py
+++ b/depthai_nodes/ml/messages/__init__.py
@@ -5,6 +5,7 @@ from .img_detections import (
 )
 from .keypoints import HandKeypoints, Keypoints
 from .lines import Line, Lines
+from .mapping import Map2D
 from .misc import AgeGender
 from .segmentation import SegmentationMasks
 
@@ -18,4 +19,5 @@ __all__ = [
     "Classifications",
     "SegmentationMasks",
     "AgeGender",
+    "Map2D",
 ]

--- a/depthai_nodes/ml/messages/__init__.py
+++ b/depthai_nodes/ml/messages/__init__.py
@@ -7,7 +7,6 @@ from .keypoints import HandKeypoints, Keypoints
 from .lines import Line, Lines
 from .misc import AgeGender
 from .segmentation import SegmentationMasks
-from .mapping import Map2D
 
 __all__ = [
     "ImgDetectionExtended",

--- a/depthai_nodes/ml/messages/creators/__init__.py
+++ b/depthai_nodes/ml/messages/creators/__init__.py
@@ -1,4 +1,5 @@
 from .classification import create_classification_message
+from .density import create_density_message
 from .depth import create_depth_message
 from .detection import create_detection_message, create_line_detection_message
 from .image import create_image_message
@@ -7,7 +8,6 @@ from .misc import create_age_gender_message
 from .segmentation import create_sam_message, create_segmentation_message
 from .thermal import create_thermal_message
 from .tracked_features import create_tracked_features_message
-from .density import create_density_message
 
 __all__ = [
     "create_image_message",

--- a/depthai_nodes/ml/messages/creators/__init__.py
+++ b/depthai_nodes/ml/messages/creators/__init__.py
@@ -7,6 +7,7 @@ from .misc import create_age_gender_message
 from .segmentation import create_sam_message, create_segmentation_message
 from .thermal import create_thermal_message
 from .tracked_features import create_tracked_features_message
+from .density import create_density_message
 
 __all__ = [
     "create_image_message",
@@ -21,4 +22,5 @@ __all__ = [
     "create_classification_message",
     "create_sam_message",
     "create_age_gender_message",
+    "create_density_message",
 ]

--- a/depthai_nodes/ml/messages/creators/density.py
+++ b/depthai_nodes/ml/messages/creators/density.py
@@ -1,0 +1,40 @@
+import depthai as dai
+import numpy as np
+
+from ...messages import Map2D
+
+def create_density_message(
+    density_map: np.ndarray
+) -> dai.ImgFrame:
+    """Create a DepthAI message for a density map.
+
+    @param density_map: A NumPy array representing the density map with shape HW or NHW/HWN.
+        Here N stands for batch dimension.
+    @type density_map: np.array
+    @return: An Map2D object containing the density information.
+    @rtype: Map2D
+    @raise ValueError: If the density map is not a NumPy array.
+    @raise ValueError: If the density map is not 2D or 3D.
+    @raise ValueError: If the 3D density map shape is not NHW or HWN.
+    """
+
+    if not isinstance(density_map, np.ndarray):
+        raise ValueError(f"Expected numpy array, got {type(density_map)}.")
+
+    if not (len(density_map.shape) == 2 or len(density_map.shape) == 3) :
+        raise ValueError(f"Expected 2D or 3D input, got {len(density_map.shape)}D input.")
+    
+    if len(density_map.shape) == 3:
+        if density_map.shape[0] == 1:
+            density_map = density_map[0, :, :]  # NHW to HW
+        elif density_map.shape[2] == 1:
+            density_map = density_map[:, :, 0]  # HWN to HW
+        else:
+            raise ValueError(
+                f"Unexpected density map shape. Expected NHW or HWN, got {density_map.shape}."
+            )
+
+    map = Map2D()
+    map.map = density_map
+
+    return map

--- a/depthai_nodes/ml/messages/creators/density.py
+++ b/depthai_nodes/ml/messages/creators/density.py
@@ -3,13 +3,12 @@ import numpy as np
 
 from ...messages import Map2D
 
-def create_density_message(
-    density_map: np.ndarray
-) -> dai.ImgFrame:
+
+def create_density_message(density_map: np.ndarray) -> dai.ImgFrame:
     """Create a DepthAI message for a density map.
 
-    @param density_map: A NumPy array representing the density map with shape HW or NHW/HWN.
-        Here N stands for batch dimension.
+    @param density_map: A NumPy array representing the density map with shape HW or
+        NHW/HWN. Here N stands for batch dimension.
     @type density_map: np.array
     @return: An Map2D object containing the density information.
     @rtype: Map2D
@@ -21,9 +20,11 @@ def create_density_message(
     if not isinstance(density_map, np.ndarray):
         raise ValueError(f"Expected numpy array, got {type(density_map)}.")
 
-    if not (len(density_map.shape) == 2 or len(density_map.shape) == 3) :
-        raise ValueError(f"Expected 2D or 3D input, got {len(density_map.shape)}D input.")
-    
+    if not (len(density_map.shape) == 2 or len(density_map.shape) == 3):
+        raise ValueError(
+            f"Expected 2D or 3D input, got {len(density_map.shape)}D input."
+        )
+
     if len(density_map.shape) == 3:
         if density_map.shape[0] == 1:
             density_map = density_map[0, :, :]  # NHW to HW

--- a/depthai_nodes/ml/messages/mapping.py
+++ b/depthai_nodes/ml/messages/mapping.py
@@ -1,0 +1,28 @@
+import depthai as dai
+import numpy as np
+
+
+class Map2D(dai.Buffer):
+    def __init__(self):
+        super().__init__()
+        self._map: np.ndarray = None
+        self._width: int = None
+        self._height: int = None
+
+    @property
+    def map(self) -> np.ndarray:
+        return self._map
+
+    @map.setter
+    def map(self, map: np.ndarray):
+        if not isinstance(map, np.ndarray):
+            raise TypeError(
+                f"map must be of type np.ndarray, instead got {type(map)}."
+            )
+        if not len(map.shape) == 2:
+            raise ValueError("array must be a 2D array")
+        if map.dtype != np.float32:
+                raise ValueError("array must be an array of floats")
+        self._map = map
+        self._width = map.shape[1]
+        self._height = map.shape[0]

--- a/depthai_nodes/ml/messages/mapping.py
+++ b/depthai_nodes/ml/messages/mapping.py
@@ -24,3 +24,11 @@ class Map2D(dai.Buffer):
         self._map = map
         self._width = map.shape[1]
         self._height = map.shape[0]
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    @property
+    def height(self) -> int:
+        return self._height

--- a/depthai_nodes/ml/messages/mapping.py
+++ b/depthai_nodes/ml/messages/mapping.py
@@ -16,13 +16,11 @@ class Map2D(dai.Buffer):
     @map.setter
     def map(self, map: np.ndarray):
         if not isinstance(map, np.ndarray):
-            raise TypeError(
-                f"map must be of type np.ndarray, instead got {type(map)}."
-            )
+            raise TypeError(f"map must be of type np.ndarray, instead got {type(map)}.")
         if not len(map.shape) == 2:
             raise ValueError("array must be a 2D array")
         if map.dtype != np.float32:
-                raise ValueError("array must be an array of floats")
+            raise ValueError("array must be an array of floats")
         self._map = map
         self._width = map.shape[1]
         self._height = map.shape[0]

--- a/depthai_nodes/ml/parsers/__init__.py
+++ b/depthai_nodes/ml/parsers/__init__.py
@@ -1,5 +1,6 @@
 from .age_gender import AgeGenderParser
 from .classification import ClassificationParser
+from .dmcount import DMCountParser
 from .fastsam import FastSAMParser
 from .hrnet import HRNetParser
 from .image_output import ImageOutputParser
@@ -15,7 +16,6 @@ from .thermal_image import ThermalImageParser
 from .xfeat import XFeatParser
 from .yolo import YOLOExtendedParser
 from .yunet import YuNetParser
-from .dmcount import DMCountParser
 
 __all__ = [
     "ImageOutputParser",

--- a/depthai_nodes/ml/parsers/__init__.py
+++ b/depthai_nodes/ml/parsers/__init__.py
@@ -15,6 +15,7 @@ from .thermal_image import ThermalImageParser
 from .xfeat import XFeatParser
 from .yolo import YOLOExtendedParser
 from .yunet import YuNetParser
+from .dmcount import DMCountParser
 
 __all__ = [
     "ImageOutputParser",
@@ -34,4 +35,5 @@ __all__ = [
     "FastSAMParser",
     "AgeGenderParser",
     "HRNetParser",
+    "DMCountParser",
 ]

--- a/depthai_nodes/ml/parsers/dmcount.py
+++ b/depthai_nodes/ml/parsers/dmcount.py
@@ -2,8 +2,10 @@ import depthai as dai
 
 from ..messages.creators import create_density_message
 
+
 class DMCountParser(dai.node.ThreadedHostNode):
-    """Parser class for parsing the output of the DM-Count crowd density estimation model.
+    """Parser class for parsing the output of the DM-Count crowd density estimation
+    model.
 
     Attributes
     ----------
@@ -40,7 +42,7 @@ class DMCountParser(dai.node.ThreadedHostNode):
                     f"Expected 1 output layer, got {len(output_layer_names)}."
                 )
 
-            density_map = output.getTensor(output_layer_names[0], dequantize=True)[0,0]
+            density_map = output.getTensor(output_layer_names[0], dequantize=True)[0, 0]
 
             density_message = create_density_message(density_map)
 

--- a/depthai_nodes/ml/parsers/dmcount.py
+++ b/depthai_nodes/ml/parsers/dmcount.py
@@ -42,7 +42,10 @@ class DMCountParser(dai.node.ThreadedHostNode):
                     f"Expected 1 output layer, got {len(output_layer_names)}."
                 )
 
-            density_map = output.getTensor(output_layer_names[0], dequantize=True)[0, 0]
+            density_map = output.getTensor(output_layer_names[0], dequantize=True)
+
+            if density_map.shape[0] == 1:
+                density_map = density_map[0] # remove batch dimension
 
             density_message = create_density_message(density_map)
 

--- a/depthai_nodes/ml/parsers/dmcount.py
+++ b/depthai_nodes/ml/parsers/dmcount.py
@@ -45,7 +45,7 @@ class DMCountParser(dai.node.ThreadedHostNode):
             density_map = output.getTensor(output_layer_names[0], dequantize=True)
 
             if density_map.shape[0] == 1:
-                density_map = density_map[0] # remove batch dimension
+                density_map = density_map[0]  # remove batch dimension
 
             density_message = create_density_message(density_map)
 

--- a/depthai_nodes/ml/parsers/dmcount.py
+++ b/depthai_nodes/ml/parsers/dmcount.py
@@ -1,0 +1,47 @@
+import depthai as dai
+
+from ..messages.creators import create_density_message
+
+class DMCountParser(dai.node.ThreadedHostNode):
+    """Parser class for parsing the output of the DM-Count crowd density estimation model.
+
+    Attributes
+    ----------
+    input : Node.Input
+        Node's input. It is a linking point to which the Neural Network's output is linked. It accepts the output of the Neural Network node.
+    out : Node.Output
+        Parser sends the processed network results to this output in a form of DepthAI message. It is a linking point from which the processed network results are retrieved.
+
+    Output Message/s
+    ----------------
+    **Type**: Map2D
+
+    **Description**: Density message containing the density map. The density map is represented with Map2D object.
+    """
+
+    def __init__(
+        self,
+    ):
+        """Initializes the DMCountParser node."""
+        dai.node.ThreadedHostNode.__init__(self)
+        self.input = self.createInput()
+        self.out = self.createOutput()
+
+    def run(self):
+        while self.isRunning():
+            try:
+                output: dai.NNData = self.input.get()
+            except dai.MessageQueue.QueueException:
+                break  # Pipeline was stopped
+
+            output_layer_names = output.getAllLayerNames()
+            if len(output_layer_names) != 1:
+                raise ValueError(
+                    f"Expected 1 output layer, got {len(output_layer_names)}."
+                )
+
+            density_map = output.getTensor(output_layer_names[0], dequantize=True)[0,0]
+
+            density_message = create_density_message(density_map)
+
+            self.out.send(density_message)


### PR DESCRIPTION
Adding parser support for [DM-Count](https://github.com/cvlab-stonybrook/DM-Count/tree/master) crowd density estimation model. Moreover, I'm introducing a new message type for 2D numpy arrays of float values. It's used here to represent a density map but could also be re-used elsewhere in the library (e.g. for depth maps but this should go in a separate PR as we might actually also be able to merge the density and depth parsers - this is also why I'm not including any tests in this PR, as I want to have it passed to de-block experiments team and address this in the next PR). 