### PR TITLE
Lane detection parser.

### DIFF
--- a/depthai_nodes/ml/messages/__init__.py
+++ b/depthai_nodes/ml/messages/__init__.py
@@ -1,4 +1,5 @@
 from .classification import Classifications
+from .clusters import Cluster, Clusters
 from .img_detections import (
     ImgDetectionExtended,
     ImgDetectionsExtended,
@@ -20,4 +21,6 @@ __all__ = [
     "SegmentationMasks",
     "AgeGender",
     "Map2D",
+    "Clusters",
+    "Cluster",
 ]

--- a/depthai_nodes/ml/messages/clusters.py
+++ b/depthai_nodes/ml/messages/clusters.py
@@ -1,0 +1,107 @@
+from typing import List
+
+import depthai as dai
+
+
+class Cluster(dai.Buffer):
+    """Cluster class for storing a cluster.
+
+    Attributes
+    ----------
+    label : int
+        Label of the cluster.
+    points : List[dai.Point2f]
+        List of points in the cluster.
+    """
+
+    def __init__(self):
+        """Initializes the Cluster object."""
+        super().__init__()
+        self._label: int = None
+        self.points: List[dai.Point2f] = []
+
+    @property
+    def label(self) -> int:
+        """Returns the label of the cluster.
+
+        @return: Label of the cluster.
+        @rtype: int
+        """
+        return self._label
+
+    @label.setter
+    def label(self, value: int):
+        """Sets the label of the cluster.
+
+        @param value: Label of the cluster.
+        @type value: int
+        @raise TypeError: If the label is not an integer.
+        """
+        if not isinstance(value, int):
+            raise TypeError(f"label must be of type int, instead got {type(value)}.")
+        self._label = value
+
+    @property
+    def points(self) -> List[dai.Point2f]:
+        """Returns the points in the cluster.
+
+        @return: List of points in the cluster.
+        @rtype: List[dai.Point2f]
+        """
+        return self._points
+
+    @points.setter
+    def points(self, value: List[dai.Point2f]):
+        """Sets the points in the cluster.
+
+        @param value: List of points in the cluster.
+        @type value: List[dai.Point2f]
+        @raise TypeError: If the points are not a list.
+        @raise TypeError: If each point is not of type dai.Point2f.
+        """
+        if not isinstance(value, List):
+            raise TypeError("points must be a list.")
+        for point in value:
+            if not isinstance(point, dai.Point2f):
+                raise TypeError("All items in points must be of type dai.Point2f.")
+        self._points = value
+
+
+class Clusters(dai.Buffer):
+    """Clusters class for storing clusters.
+
+    Attributes
+    ----------
+    clusters : List[Cluster]
+        List of clusters.
+    """
+
+    def __init__(self):
+        """Initializes the Clusters object."""
+        super().__init__()
+        self._clusters: List[Cluster] = []
+
+    @property
+    def clusters(self) -> List[Cluster]:
+        """Returns the clusters.
+
+        @return: List of clusters.
+        @rtype: List[Cluster]
+        """
+        return self._clusters
+
+    @clusters.setter
+    def clusters(self, value: List[Cluster]):
+        """Sets the clusters.
+
+        @param value: List of clusters.
+        @type value: List[Cluster]
+        @raise TypeError: If the clusters are not a list.
+        @raise TypeError: If each cluster is not of type Cluster.
+        """
+        if not isinstance(value, List):
+            raise TypeError("clusters must be a list.")
+        for cluster in value:
+            if not isinstance(cluster, Cluster):
+                raise TypeError("All items in clusters must be of type Cluster.")
+        self._clusters = value

--- a/depthai_nodes/ml/messages/creators/__init__.py
+++ b/depthai_nodes/ml/messages/creators/__init__.py
@@ -1,4 +1,5 @@
 from .classification import create_classification_message
+from .clusters import create_cluster_message
 from .detection import create_detection_message, create_line_detection_message
 from .image import create_image_message
 from .keypoints import create_hand_keypoints_message, create_keypoints_message
@@ -19,4 +20,5 @@ __all__ = [
     "create_sam_message",
     "create_age_gender_message",
     "create_map_message",
+    "create_cluster_message",
 ]

--- a/depthai_nodes/ml/messages/creators/clusters.py
+++ b/depthai_nodes/ml/messages/creators/clusters.py
@@ -1,0 +1,53 @@
+from typing import List, Union
+
+import depthai as dai
+
+from ...messages import Cluster, Clusters
+
+
+def create_cluster_message(clusters: List[List[List[Union[float, int]]]]) -> Clusters:
+    """Create a DepthAI message for clusters.
+
+    @param clusters: List of clusters. Each cluster is a list of points with x and y
+        coordinates.
+    @type clusters: List[List[List[Union[float, int]]]]
+    @return: Clusters message containing the detected clusters.
+    @rtype: Clusters
+    @raise TypeError: If the clusters are not a list.
+    @raise TypeError: If each cluster is not a list.
+    @raise TypeError: If each point is not a list.
+    @raise TypeError: If each value in the point is not an int or float.
+    """
+
+    if not isinstance(clusters, list):
+        raise TypeError(f"clusters must be a list, got {type(clusters)}")
+    for cluster in clusters:
+        if not isinstance(cluster, list):
+            raise TypeError(f"All clusters must be of type List, got {type(cluster)}")
+        for point in cluster:
+            if isinstance(point, list):
+                raise TypeError(
+                    f"All points in clusters must be of type List, got {type(point)}"
+                )
+            if len(point) != 2:
+                raise ValueError(f"Each point must have 2 values, got {len(point)}")
+            for value in point:
+                if not isinstance(value, (float, int)):
+                    raise TypeError(
+                        f"All items in points must be of type int or float, got {type(value)}"
+                    )
+
+    message = Clusters()
+    temp = []
+    for i, cluster in enumerate(clusters):
+        temp_cluster = Cluster()
+        temp_cluster.label = i
+        temp_cluster.points = [
+            dai.Point2f(float(point[0]), float(point[1])) for point in cluster
+        ]
+
+        temp.append(temp_cluster)
+
+    message.clusters = temp
+
+    return message

--- a/depthai_nodes/ml/parsers/__init__.py
+++ b/depthai_nodes/ml/parsers/__init__.py
@@ -4,6 +4,7 @@ from .fastsam import FastSAMParser
 from .hrnet import HRNetParser
 from .image_output import ImageOutputParser
 from .keypoints import KeypointParser
+from .lane_detection import LaneDetectionParser
 from .map_output import MapOutputParser
 from .mediapipe_hand_landmarker import MPHandLandmarkParser
 from .mediapipe_palm_detection import MPPalmDetectionParser
@@ -32,4 +33,5 @@ __all__ = [
     "AgeGenderParser",
     "HRNetParser",
     "MapOutputParser",
+    "LaneDetectionParser",
 ]

--- a/depthai_nodes/ml/parsers/lane_detection.py
+++ b/depthai_nodes/ml/parsers/lane_detection.py
@@ -1,0 +1,115 @@
+import depthai as dai
+import numpy as np
+
+from ..messages.creators import create_cluster_message
+from .utils.ufld import decode_ufld
+
+
+class LaneDetectionParser(dai.node.ThreadedHostNode):
+    """
+    Parser class for Ultra-Fast-Lane-Detection model. It expects one ouput layer containing the lane detection results.
+    It supports two versions of the model: CuLane and TuSimple. Results are representented with clusters of points.
+
+    Attributes
+    ----------
+    input : Node.Input
+        Node's input. It is a linking point to which the Neural Network's output is linked. It accepts the output of the Neural Network node.
+    out : Node.Output
+        Parser sends the processed network results to this output in a form of DepthAI message. It is a linking point from which the processed network results are retrieved.
+    row_anchors : List[int]
+        List of row anchors.
+    griding_num : int
+        Griding number.
+    cls_num_per_lane : int
+        Number of points per lane.
+    input_shape : Tuple[int, int]
+        Input shape.
+    """
+
+    def __init__(
+        self,
+        row_anchors=None,
+        griding_num=None,
+        cls_num_per_lane=None,
+        input_shape=(288, 800),
+    ):
+        """Initializes the lane detection parser node.
+
+        @param row_anchors: List of row anchors.
+        @type row_anchors: List[int]
+        @param griding_num: Griding number.
+        @type griding_num: int
+        @param cls_num_per_lane: Number of points per lane.
+        @type cls_num_per_lane: int
+        @param input_shape: Input shape.
+        @type input_shape: Tuple[int, int]
+        """
+        dai.node.ThreadedHostNode.__init__(self)
+        self.input = self.createInput()
+        self.out = self.createOutput()
+        self.row_anchors = row_anchors
+        self.griding_num = griding_num
+        self.cls_num_per_lane = cls_num_per_lane
+        self.input_shape = input_shape
+
+    def setRowAnchors(self, row_anchors):
+        """Set the row anchors for the lane detection model.
+
+        @param row_anchors: List of row anchors.
+        @type row_anchors: List[int]
+        """
+        self.row_anchors = row_anchors
+
+    def setGridingNum(self, griding_num):
+        """Set the griding number for the lane detection model.
+
+        @param griding_num: Griding number.
+        @type griding_num: int
+        """
+        self.griding_num = griding_num
+
+    def setClsNumPerLane(self, cls_num_per_lane):
+        """Set the number of points per lane for the lane detection model.
+
+        @param cls_num_per_lane: Number of classes per lane.
+        @type cls_num_per_lane: int
+        """
+        self.cls_num_per_lane = cls_num_per_lane
+
+    def setInputShape(self, input_shape):
+        """Set the input shape for the lane detection model.
+
+        @param input_shape: Input shape.
+        @type input_shape: Tuple[int, int]
+        """
+        self.input_shape = input_shape
+
+    def run(self):
+        if self.row_anchors is None:
+            raise ValueError("Row anchors must be specified!")
+        if self.griding_num is None:
+            raise ValueError("Griding number must be specified!")
+        if self.cls_num_per_lane is None:
+            raise ValueError("Number of points per lane must be specified!")
+
+        while self.isRunning():
+            try:
+                output: dai.NNData = self.input.get()
+            except dai.MessageQueue.QueueException:
+                break  # Pipeline was stopped
+
+            tensor = output.getFirstTensor(dequantize=True).astype(np.float32)
+            y = tensor[0]
+
+            points = decode_ufld(
+                anchors=self.row_anchors,
+                griding_num=self.griding_num,
+                cls_num_per_lane=self.cls_num_per_lane,
+                INPUT_WIDTH=self.input_shape[1],
+                INPUT_HEIGHT=self.input_shape[0],
+                y=y,
+            )
+
+            message = create_cluster_message(points)
+            message.setTimestamp(output.getTimestamp())
+            self.out.send(message)

--- a/depthai_nodes/ml/parsers/utils/ufld.py
+++ b/depthai_nodes/ml/parsers/utils/ufld.py
@@ -1,0 +1,47 @@
+from typing import List, Tuple
+
+import numpy as np
+
+
+def softmax(x):
+    ex = np.exp(x)
+    return ex / np.sum(ex, axis=0)
+
+
+def decode_ufld(
+    anchors: List[int],
+    griding_num: int,
+    cls_num_per_lane: int,
+    INPUT_WIDTH: int,
+    INPUT_HEIGHT: int,
+    y: np.ndarray,
+) -> List[List[Tuple[int, int]]]:
+    col_sample = np.linspace(0, INPUT_WIDTH - 1, griding_num)
+    col_sample_w = col_sample[1] - col_sample[0]
+    img_w, img_h = INPUT_WIDTH, INPUT_HEIGHT
+
+    out_j = y
+    out_j = out_j[:, ::-1, :]
+    prob = softmax(out_j[:-1, :, :])
+
+    idx = np.arange(griding_num) + 1
+    idx = idx.reshape(-1, 1, 1)
+    loc = np.sum(prob * idx, axis=0)
+    out_j = np.argmax(out_j, axis=0)
+    loc[out_j == griding_num] = 0
+    out_j = loc
+
+    points = [[] for _ in range(out_j.shape[1])]
+
+    for i in range(out_j.shape[1]):
+        if np.sum(out_j[:, i] != 0) > 2:
+            for k in range(out_j.shape[0]):
+                if out_j[k, i] > 0:
+                    ppp = (
+                        int(out_j[k, i] * col_sample_w * img_w / INPUT_WIDTH) - 1,
+                        int(img_h * (anchors[cls_num_per_lane - 1 - k] / INPUT_HEIGHT))
+                        - 1,
+                    )
+                    points[i].append(ppp)
+
+    return points

--- a/examples/utils/parser.py
+++ b/examples/utils/parser.py
@@ -109,6 +109,7 @@ def setup_land_detection_parser(parser: LaneDetectionParser, params: dict):
     except Exception:
         print(
             "This NN archive does not have required metadata for LaneDetectionParser. Skipping setup..."
+        )
 
 
 def setup_fastsam_parser(parser: FastSAMParser, params: dict):

--- a/examples/utils/parser.py
+++ b/examples/utils/parser.py
@@ -3,7 +3,7 @@ import depthai as dai
 from depthai_nodes.ml.parsers import (
     ClassificationParser,
     KeypointParser,
-    MonocularDepthParser,
+    LaneDetectionParser,
     MPPalmDetectionParser,
     SCRFDParser,
     SegmentationParser,
@@ -62,22 +62,6 @@ def setup_classification_parser(parser: ClassificationParser, params: dict):
         )
 
 
-def setup_monocular_depth_parser(parser: MonocularDepthParser, params: dict):
-    """Setup the monocular depth parser with the required metadata."""
-    try:
-        depth_type = params["depth_type"]
-        depth_limit = params["depth_limit"]
-        if depth_type == "relative":
-            parser.setRelativeDepthType()
-        else:
-            parser.setMetricDepthType()
-        parser.setDepthLimit(depth_limit)
-    except Exception:
-        print(
-            "This NN archive does not have required metadata for MonocularDepthParser. Skipping setup..."
-        )
-
-
 def setup_xfeat_parser(parser: XFeatParser, params: dict):
     """Setup the XFeat parser with the required metadata."""
     try:
@@ -112,6 +96,21 @@ def setup_palm_detection_parser(parser: MPPalmDetectionParser, params: dict):
         )
 
 
+def setup_land_detection_parser(parser: LaneDetectionParser, params: dict):
+    """Setup the Lane Detection parser with the required metadata."""
+    try:
+        row_ancors = params["row_anchors"]
+        griding_num = params["griding_num"]
+        cls_num_per_lane = params["cls_num_per_lane"]
+        parser.setRowAnchors(row_ancors)
+        parser.setGridingNum(griding_num)
+        parser.setClsNumPerLane(cls_num_per_lane)
+    except Exception:
+        print(
+            "This NN archive does not have required metadata for LaneDetectionParser. Skipping setup..."
+        )
+
+
 def setup_parser(parser: dai.ThreadedNode, nn_archive: dai.NNArchive, parser_name: str):
     """Setup the parser with the NN archive."""
 
@@ -127,11 +126,11 @@ def setup_parser(parser: dai.ThreadedNode, nn_archive: dai.NNArchive, parser_nam
         setup_keypoint_parser(parser, extraParams)
     elif parser_name == "ClassificationParser":
         setup_classification_parser(parser, extraParams)
-    elif parser_name == "MonocularDepthParser":
-        setup_monocular_depth_parser(parser, extraParams)
     elif parser_name == "XFeatParser":
         setup_xfeat_parser(parser, extraParams)
     elif parser_name == "YOLOExtendedParser":
         setup_yolo_extended_parser(parser, extraParams)
     elif parser_name == "MPPalmDetectionParser":
         setup_palm_detection_parser(parser, extraParams)
+    elif parser_name == "LaneDetectionParser":
+        setup_land_detection_parser(parser, extraParams)

--- a/examples/visualization/detection.py
+++ b/examples/visualization/detection.py
@@ -6,10 +6,10 @@ from depthai_nodes.ml.messages import Clusters, ImgDetectionsExtended, Lines
 
 from .colors import get_yolo_colors
 from .messages import (
+    parse_cluster_message,
     parse_detection_message,
     parse_line_detection_message,
     parse_yolo_kpts_message,
-    parser_cluster_message,
 )
 
 
@@ -182,7 +182,7 @@ def visualize_lane_detections(
     frame: dai.ImgFrame, message: Clusters, extraParams: dict
 ):
     """Visualizes the lines on the frame."""
-    clusters = parser_cluster_message(message)
+    clusters = parse_cluster_message(message)
 
     for cluster in clusters:
         for point in cluster.points:

--- a/examples/visualization/detection.py
+++ b/examples/visualization/detection.py
@@ -2,13 +2,14 @@ import cv2
 import depthai as dai
 import numpy as np
 
-from depthai_nodes.ml.messages import ImgDetectionsExtended, Lines
+from depthai_nodes.ml.messages import Clusters, ImgDetectionsExtended, Lines
 
 from .colors import get_yolo_colors
 from .messages import (
     parse_detection_message,
     parse_line_detection_message,
     parse_yolo_kpts_message,
+    parser_cluster_message,
 )
 
 
@@ -170,6 +171,37 @@ def visualize_yolo_extended(
     if task == "segmentation":
         frame = cv2.addWeighted(overlay, 0.8, frame, 0.5, 0, None)
     cv2.imshow("YOLO Pose Estimation", frame)
+    if cv2.waitKey(1) == ord("q"):
+        cv2.destroyAllWindows()
+        return True
+
+    return False
+
+
+def visualize_lane_detections(
+    frame: dai.ImgFrame, message: Clusters, extraParams: dict
+):
+    """Visualizes the lines on the frame."""
+    clusters = parser_cluster_message(message)
+
+    for cluster in clusters:
+        for point in cluster.points:
+            x = int(point.x)
+            y = int(point.y)
+            cv2.circle(frame, (x, y), 3, (0, 255, 0), -1)
+
+    # draw lines between points
+    for cluster in clusters:
+        for i in range(len(cluster.points) - 1):
+            cv2.line(
+                frame,
+                (int(cluster.points[i].x), int(cluster.points[i].y)),
+                (int(cluster.points[i + 1].x), int(cluster.points[i + 1].y)),
+                (0, 255, 0),
+                2,
+            )
+
+    cv2.imshow("Lane Detection", frame)
     if cv2.waitKey(1) == ord("q"):
         cv2.destroyAllWindows()
         return True

--- a/examples/visualization/mapping.py
+++ b/examples/visualization/mapping.py
@@ -1,6 +1,7 @@
 from .classification import visualize_age_gender, visualize_classification
 from .detection import (
     visualize_detections,
+    visualize_lane_detections,
     visualize_line_detections,
     visualize_yolo_extended,
 )
@@ -25,4 +26,5 @@ parser_mapping = {
     "MonocularDepthParser": visualize_image,
     "AgeGenderParser": visualize_age_gender,
     "YOLOExtendedParser": visualize_yolo_extended,
+    "LaneDetectionParser": visualize_lane_detections,
 }

--- a/examples/visualization/messages.py
+++ b/examples/visualization/messages.py
@@ -65,7 +65,7 @@ def parse_yolo_kpts_message(message: ImgDetectionsExtended):
     return detections
 
 
-def parser_cluster_message(message: Clusters):
+def parse_cluster_message(message: Clusters):
     """Parses the cluster message and returns the clusters."""
     clusters = message.clusters
     return clusters

--- a/examples/visualization/messages.py
+++ b/examples/visualization/messages.py
@@ -71,7 +71,7 @@ def parse_cluster_message(message: Clusters):
     clusters = message.clusters
     return clusters
 
-  
+
 def parse_fast_sam_message(message: SegmentationMasks):
     """Parses the fast sam message and returns the masks."""
     masks = message.masks

--- a/examples/visualization/messages.py
+++ b/examples/visualization/messages.py
@@ -3,6 +3,7 @@ import depthai as dai
 from depthai_nodes.ml.messages import (
     AgeGender,
     Classifications,
+    Clusters,
     ImgDetectionsExtended,
     Keypoints,
     Lines,
@@ -62,3 +63,9 @@ def parse_yolo_kpts_message(message: ImgDetectionsExtended):
     """Parses the yolo keypoints message and returns the keypoints."""
     detections = message.detections
     return detections
+
+
+def parser_cluster_message(message: Clusters):
+    """Parses the cluster message and returns the clusters."""
+    clusters = message.clusters
+    return clusters

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">40%</text>
-        <text x="80" y="14">40%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">41%</text>
+        <text x="80" y="14">41%</text>
     </g>
 </svg>

--- a/tests/unittests/test_creators/test_clusters.py
+++ b/tests/unittests/test_creators/test_clusters.py
@@ -1,0 +1,62 @@
+import pytest
+
+from depthai_nodes.ml.messages.creators.clusters import create_cluster_message
+
+
+def test_non_list_input():
+    with pytest.raises(TypeError):
+        create_cluster_message(1)
+
+
+def test_non_list_of_clusters_input():
+    with pytest.raises(TypeError):
+        create_cluster_message([1, 2, 3])
+
+
+def test_clusters_input_int():
+    clusters = [[(1, 2), (3, 4), (5, 6)], [(7, 8), (9, 10), (11, 12)]]
+    create_cluster_message(clusters)
+
+
+def test_clusters_input_float():
+    clusters = [
+        [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)],
+        [(7.0, 8.0), (9.0, 10.0), (11.0, 12.0)],
+    ]
+    create_cluster_message(clusters)
+
+
+def test_clusters_input_mixed():
+    clusters = [[(1, 2), (3, 4), (5, 6)], [(7.0, 8.0), (9.0, 10.0), (11.0, 12.0)]]
+    create_cluster_message(clusters)
+
+
+def test_clusters_input_empty():
+    clusters = []
+    create_cluster_message(clusters)
+
+
+def test_clusters_input_empty_cluster():
+    clusters = [[]]
+    create_cluster_message(clusters)
+
+
+def test_clusters_input_empty_point():
+    with pytest.raises(TypeError):
+        clusters = [[[]]]
+        create_cluster_message(clusters)
+
+
+def test_clusters_input_empty_point_value():
+    with pytest.raises(TypeError):
+        clusters = [[[1, 2], []]]
+        create_cluster_message(clusters)
+
+
+def test_clusters_input_point_shape():
+    with pytest.raises(ValueError):
+        clusters = [
+            [(1, 2, 3), (3, 4, 5), (5, 6, 7)],
+            [(7, 8, 9), (9, 10, 11), (11, 12, 13)],
+        ]
+        create_cluster_message(clusters)


### PR DESCRIPTION
This PR adds a Lane Detection parser for Super-fast-lane-detection models. There are two versions of the model so parser requires some parameters. The output of the parser are clusters of points. Each cluster represents one lane. So, for the easiest message representation, I suggest a new message type - Clusters.

PR also adds tests for cluster message and support in general example. MonocularDepthParser is removed from general example because of #57.