### PR TITLE
[HOT-FIX] Update ppdet to return polygons.

### DIFF
--- a/depthai_nodes/ml/messages/__init__.py
+++ b/depthai_nodes/ml/messages/__init__.py
@@ -2,6 +2,7 @@ from .classification import Classifications
 from .clusters import Cluster, Clusters
 from .composite import CompositeMessage
 from .img_detections import (
+    CornerDetections,
     ImgDetectionExtended,
     ImgDetectionsExtended,
 )
@@ -23,4 +24,5 @@ __all__ = [
     "Clusters",
     "Cluster",
     "CompositeMessage",
+    "CornerDetections",
 ]

--- a/depthai_nodes/ml/messages/creators/__init__.py
+++ b/depthai_nodes/ml/messages/creators/__init__.py
@@ -4,7 +4,11 @@ from .classification import (
     create_multi_classification_message,
 )
 from .clusters import create_cluster_message
-from .detection import create_detection_message, create_line_detection_message
+from .detection import (
+    create_corner_detection_message,
+    create_detection_message,
+    create_line_detection_message,
+)
 from .image import create_image_message
 from .keypoints import create_hand_keypoints_message, create_keypoints_message
 from .map import create_map_message
@@ -27,4 +31,5 @@ __all__ = [
     "create_classification_sequence_message",
     "create_cluster_message",
     "create_multi_classification_message",
+    "create_corner_detection_message",
 ]

--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -3,6 +3,8 @@ from typing import List, Tuple, Union
 import depthai as dai
 import numpy as np
 
+from .keypoints import Keypoints
+
 
 class ImgDetectionExtended(dai.ImgDetection):
     """ImgDetectionExtended class for storing image detection with keypoints and masks.
@@ -137,3 +139,98 @@ class ImgDetectionsExtended(dai.Buffer):
                     "Each detection must be an instance of ImgDetectionExtended"
                 )
         self._detections = value
+
+
+class CornerDetections(dai.Buffer):
+    """Detection Class for storing object detections in corner format.
+
+    Attributes
+    ----------
+    detections: List[Keypoints]
+        List of detections in keypoint format.
+
+    labels: List[int]
+        List of labels for each detection
+    """
+
+    def __init__(self):
+        """Initializes the CornerDetections object."""
+        dai.Buffer.__init__(self)
+        self._detections: List[Keypoints] = []
+        self._scores: List[float] = None
+        self._labels: List[int] = None
+
+    @property
+    def detections(self) -> List[Keypoints]:
+        """Returns the detections.
+
+        @return: List of detections.
+        @rtype: List[Keypoints]
+        """
+        return self._detections
+
+    @detections.setter
+    def detections(self, value: List[Keypoints]):
+        """Sets the detections.
+
+        @param value: List of detections.
+        @type value: List[Keypoints]
+        @raise TypeError: If the detections are not a list.
+        @raise TypeError: If each detection is not an instance of Keypoints.
+        """
+        if not isinstance(value, list):
+            raise TypeError("Detections must be a list")
+        for item in value:
+            if not isinstance(item, Keypoints):
+                raise TypeError("Each detection must be an instance of Keypoints")
+        self._detections = value
+
+    @property
+    def labels(self) -> List[int]:
+        """Returns the labels.
+
+        @return: List of labels.
+        @rtype: List[int]
+        """
+        return self._labels
+
+    @labels.setter
+    def labels(self, value: List[int]):
+        """Sets the labels.
+
+        @param value: List of labels.
+        @type value: List[int]
+        @raise TypeError: If the labels are not a list.
+        @raise TypeError: If each label is not an integer.
+        """
+        if not isinstance(value, list):
+            raise TypeError("Labels must be a list")
+        for item in value:
+            if not isinstance(item, int):
+                raise TypeError("Each label must be an integer")
+        self._labels = value
+
+    @property
+    def scores(self) -> List[float]:
+        """Returns the scores.
+
+        @return: List of scores.
+        @rtype: List[float]
+        """
+        return self._scores
+
+    @scores.setter
+    def scores(self, value: List[float]):
+        """Sets the scores.
+
+        @param value: List of scores.
+        @type value: List[float]
+        @raise TypeError: If the scores are not a list.
+        @raise TypeError: If each score is not a float.
+        """
+        if not isinstance(value, list):
+            raise TypeError("Scores must be a list")
+        for item in value:
+            if not isinstance(item, float):
+                raise TypeError("Each score must be a float")
+        self._scores = value

--- a/depthai_nodes/ml/parsers/ppdet.py
+++ b/depthai_nodes/ml/parsers/ppdet.py
@@ -91,7 +91,6 @@ class PPTextDetectionParser(dai.node.ThreadedHostNode):
                 self.max_detections,
             )
 
-
             message = create_corner_detection_message(bboxes, scores)
             message.setTimestamp(output.getTimestamp())
 

--- a/depthai_nodes/ml/parsers/ppdet.py
+++ b/depthai_nodes/ml/parsers/ppdet.py
@@ -91,7 +91,6 @@ class PPTextDetectionParser(dai.node.ThreadedHostNode):
                 self.max_detections,
             )
 
-            # bboxes = corners2xyxy(bboxes)
 
             message = create_corner_detection_message(bboxes, scores)
             message.setTimestamp(output.getTimestamp())

--- a/depthai_nodes/ml/parsers/ppdet.py
+++ b/depthai_nodes/ml/parsers/ppdet.py
@@ -1,7 +1,7 @@
 import depthai as dai
 
-from ..messages.creators import create_detection_message
-from .utils import corners2xyxy, parse_paddle_detection_outputs
+from ..messages.creators import create_corner_detection_message
+from .utils import parse_paddle_detection_outputs
 
 
 class PPTextDetectionParser(dai.node.ThreadedHostNode):
@@ -91,9 +91,9 @@ class PPTextDetectionParser(dai.node.ThreadedHostNode):
                 self.max_detections,
             )
 
-            bboxes = corners2xyxy(bboxes)
+            # bboxes = corners2xyxy(bboxes)
 
-            message = create_detection_message(bboxes, scores)
+            message = create_corner_detection_message(bboxes, scores)
             message.setTimestamp(output.getTimestamp())
 
             self.out.send(message)

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">41%</text>
-        <text x="80" y="14">41%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">40%</text>
+        <text x="80" y="14">40%</text>
     </g>
 </svg>


### PR DESCRIPTION
This PR updated ppdet Parser to return a polygons instead of ImgDetections. The polygons are saved as `Keypoints` objects. This is done through the new `create_corner_detection_message` which is also available for other general detection models.

This hotfix does not include tests.