### PR TITLE
Parser v2 example

### DIFF
--- a/depthai_nodes/ml/parsers/__init__.py
+++ b/depthai_nodes/ml/parsers/__init__.py
@@ -9,6 +9,7 @@ from .map_output import MapOutputParser
 from .mediapipe_hand_landmarker import MPHandLandmarkParser
 from .mediapipe_palm_detection import MPPalmDetectionParser
 from .mlsd import MLSDParser
+from .parser import Parser
 from .ppdet import PPTextDetectionParser
 from .ppocr import PaddleOCRParser
 from .scrfd import SCRFDParser
@@ -39,4 +40,5 @@ __all__ = [
     "PaddleOCRParser",
     "LaneDetectionParser",
     "MultiClassificationParser",
+    "Parser",
 ]

--- a/depthai_nodes/ml/parsers/classification.py
+++ b/depthai_nodes/ml/parsers/classification.py
@@ -58,7 +58,6 @@ class ClassificationParser(Parser):
         self,
         heads: Union[List, Dict],
         head_name: str = "",
-        is_softmax: bool = True,
     ):
         super().build(heads, head_name)
 
@@ -68,22 +67,10 @@ class ClassificationParser(Parser):
                 f"Only one output layer supported for Classification, got {output_layers} layers."
             )
         self.output_layer_name = output_layers[0]
+        self.classes = self.head_config["classes"]
+        self.n_classes = self.head_config["n_classes"]
+        self.is_softmax = self.head_config["is_softmax"]
 
-        try:
-            self.classes = self.head_config["classes"]
-        except KeyError:
-            print(
-                "No classes provided in nn_archive metadata. Please provide 'classes' in the nn_archive."
-            )
-
-        try:
-            self.n_classes = self.head_config["n_classes"]
-        except KeyError:
-            print(
-                "No n_classes provided in nn_archive metadata. Please provide number of classes in the nn_archive."
-            )
-
-        self.is_softmax = is_softmax
         return self
 
     def setClasses(self, classes: List[str]):

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -11,28 +11,60 @@ class Parser(dai.node.ThreadedHostNode):
         self.input = self.createInput()
         self.out = self.createOutput()
 
-        self.head_configs: Dict = {}
+        self.head_config: Dict = {}
 
-    def build(self, head_metadata: Union[List, Dict], name: str = ""):
-        """Initial build method for all parsers."""
+    def build(self, heads: Union[List, Dict], head_name: str = ""):
+        """Initial build method for all parsers. The method sets the head configuration
+        for the parser.
 
-        if isinstance(head_metadata, list):
-            if len(head_metadata) == 0:
-                raise ValueError("No heads parsed from archive")
-            if len(head_metadata) > 1 and name == "":
-                raise ValueError("Multiple heads detected, please specify head name")
-            head = head_metadata[0]
-            if name != "":
+        Attributes
+        ----------
+        heads : Union[List, Dict]
+            List of all archive head objects: [<depthai.nn_archive.v1.Head object>, ...]
+            or a dictionary containing the head metadata.
+        head_name : str
+            The name of the head to use. If multiple heads are available in the archive, the name must be specified.
+
+        Returns
+        -------
+        Parser
+            Returns the parser object with the head configuration set.
+        """
+
+        if isinstance(heads, list):
+            if len(heads) == 0:
+                raise ValueError("No heads available in the nn_archive.")
+
+            head = heads[0]
+
+            if len(heads) > 1 and head_name == "":
+                current_parser = self.__class__.__name__
+                parser_names_in_archive = [head.parser for head in heads]
+                num_matches = parser_names_in_archive.count(current_parser)
+                if num_matches == 0:
+                    raise ValueError(
+                        f"No heads available for {current_parser} in the nn_archive."
+                    )
+                elif num_matches == 1:
+                    head = [head for head in heads if head.parser == current_parser][0]
+                else:
+                    raise ValueError(
+                        "Multiple heads detected, please specify a head name."
+                    )
+
+            if head_name != "":
                 head_candidates = [
                     head
-                    for head in head_metadata
-                    if head.metadata.extraParams["name"] == name
+                    for head in heads
+                    if head.metadata.extraParams["name"] == head_name
                 ]
                 if len(head_candidates) == 0:
-                    raise ValueError("Head name not found in archive")
+                    raise ValueError(
+                        f"No head with name {head_name} specified in nn_archive."
+                    )
                 if len(head_candidates) > 1:
                     raise ValueError(
-                        "Multiple heads with the same name found in archive, please specify a unique head name"
+                        f"Multiple heads with name {head_name} found in nn_archive, please specify a unique name."
                     )
                 head = head_candidates[0]
 
@@ -40,20 +72,19 @@ class Parser(dai.node.ThreadedHostNode):
             metadata = head.metadata
             outputs = head.outputs
 
-            if parser_name is None:
-                raise ValueError("Head does not have a parser specified.")
             if outputs is None:
-                raise ValueError("Head does not have any outputs.")
-            if metadata is None:
-                raise ValueError("Head does not have any metadata.")
+                raise ValueError(
+                    f"{head_name} head does not have any outputs specified."
+                )
 
             head_dictionary = {}
             head_dictionary["parser"] = parser_name
             head_dictionary["outputs"] = outputs
-            head_dictionary.update(metadata.extraParams)
-            self.head_configs = head_dictionary
+            if metadata is not None:
+                head_dictionary.update(metadata.extraParams)
+            self.head_config = head_dictionary
 
         else:
-            self.head_configs = head_metadata
+            self.head_config = heads
 
         return self

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -1,0 +1,59 @@
+from typing import Dict, List, Union
+
+import depthai as dai
+
+
+class Parser(dai.node.ThreadedHostNode):
+    """Base class for all parsers."""
+
+    def __init__(self):
+        super().__init__()
+        self.input = self.createInput()
+        self.out = self.createOutput()
+
+        self.head_configs: Dict = {}
+
+    def build(self, head_metadata: Union[List, Dict], name: str = ""):
+        """Initial build method for all parsers."""
+
+        if isinstance(head_metadata, list):
+            if len(head_metadata) == 0:
+                raise ValueError("No heads parsed from archive")
+            if len(head_metadata) > 1 and name == "":
+                raise ValueError("Multiple heads detected, please specify head name")
+            head = head_metadata[0]
+            if name != "":
+                head_candidates = [
+                    head
+                    for head in head_metadata
+                    if head.metadata.extraParams["name"] == name
+                ]
+                if len(head_candidates) == 0:
+                    raise ValueError("Head name not found in archive")
+                if len(head_candidates) > 1:
+                    raise ValueError(
+                        "Multiple heads with the same name found in archive, please specify a unique head name"
+                    )
+                head = head_candidates[0]
+
+            parser_name = head.parser
+            metadata = head.metadata
+            outputs = head.outputs
+
+            if parser_name is None:
+                raise ValueError("Head does not have a parser specified.")
+            if outputs is None:
+                raise ValueError("Head does not have any outputs.")
+            if metadata is None:
+                raise ValueError("Head does not have any metadata.")
+
+            head_dictionary = {}
+            head_dictionary["parser"] = parser_name
+            head_dictionary["outputs"] = outputs
+            head_dictionary.update(metadata.extraParams)
+            self.head_configs = head_dictionary
+
+        else:
+            self.head_configs = head_metadata
+
+        return self

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -49,7 +49,7 @@ class Parser(dai.node.ThreadedHostNode):
                     head = [head for head in heads if head.parser == current_parser][0]
                 else:
                     raise ValueError(
-                        "Multiple heads detected, please specify a head name."
+                        f"Multiple heads with parser= {current_parser} detected, please specify a head name."
                     )
 
             if head_name != "":

--- a/depthai_nodes/ml/parsers/ppocr.py
+++ b/depthai_nodes/ml/parsers/ppocr.py
@@ -4,10 +4,10 @@ import depthai as dai
 import numpy as np
 
 from ..messages.creators import create_classification_sequence_message
-from .classification import ClassificationParser
+from .classification import Parser
 
 
-class PaddleOCRParser(ClassificationParser):
+class PaddleOCRParser(Parser):
     """Postprocessing logic for PaddleOCR text recognition model.
 
     Attributes


### PR DESCRIPTION
This PR adds an updated Parser v2 example. New additions are: 

- A base `Parser` class that all other classes will inherit. 
- Updated sytax using `.build()` to be more in line with dai v3 syntax, the .build method accepts a list of dai.nn_archive.v1.Head objects or a Dictionary. If Head objects are parsed, they are converted to a dictionary.

Docstrings will be updated once the functionality is finalized. Variable names also can be adjusted.