### PR TITLE
Parsers-V2: Refactor Base Parser

### DIFF
--- a/depthai_nodes/ml/parsers/__init__.py
+++ b/depthai_nodes/ml/parsers/__init__.py
@@ -1,4 +1,5 @@
 from .age_gender import AgeGenderParser
+from .base_parser import BaseParser
 from .classification import ClassificationParser, MultiClassificationParser
 from .fastsam import FastSAMParser
 from .hrnet import HRNetParser
@@ -41,4 +42,5 @@ __all__ = [
     "LaneDetectionParser",
     "MultiClassificationParser",
     "Parser",
+    "BaseParser",
 ]

--- a/depthai_nodes/ml/parsers/__init__.py
+++ b/depthai_nodes/ml/parsers/__init__.py
@@ -10,7 +10,7 @@ from .map_output import MapOutputParser
 from .mediapipe_hand_landmarker import MPHandLandmarkParser
 from .mediapipe_palm_detection import MPPalmDetectionParser
 from .mlsd import MLSDParser
-from .parser import Parser
+from .parser_generator import ParserGenerator
 from .ppdet import PPTextDetectionParser
 from .ppocr import PaddleOCRParser
 from .scrfd import SCRFDParser
@@ -41,6 +41,6 @@ __all__ = [
     "PaddleOCRParser",
     "LaneDetectionParser",
     "MultiClassificationParser",
-    "Parser",
+    "ParserGenerator",
     "BaseParser",
 ]

--- a/depthai_nodes/ml/parsers/base_parser.py
+++ b/depthai_nodes/ml/parsers/base_parser.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Dict, Union
+from typing import Any, Dict
 
 import depthai as dai
 
@@ -9,7 +9,20 @@ class BaseMeta(ABCMeta, type(dai.node.ThreadedHostNode)):
 
 
 class BaseParser(dai.node.ThreadedHostNode, metaclass=BaseMeta):
-    """Base parser class for neural network output parsers."""
+    """Base class for neural network output parsers. This class serves as a foundation
+    for specific parser implementations used to postprocess the outputs of neural
+    network models. Each parser is attached to a model "head" that governs the parsing
+    process as it contains all the necessary information for the parser to function
+    correctly. Subclasses should implement `build` method to correctly set all
+    parameters of the parser and the `run` method to define the parsing logic.
+
+    Attributes
+    ----------
+    input : Node.Input
+        Node's input. It is a linking point to which the Neural Network's output is linked. It accepts the output of the Neural Network node.
+    out : Node.Output
+        Parser sends the processed network results to this output in a form of DepthAI message. It is a linking point from which the processed network results are retrieved.
+    """
 
     def __init__(self):
         super().__init__()
@@ -25,9 +38,25 @@ class BaseParser(dai.node.ThreadedHostNode, metaclass=BaseMeta):
         pass
 
     @abstractmethod
-    def build(self, head: Union[dai.NNArchive, Dict]):
+    def build(self, head_config: Dict[str, Any]):
+        """Sets the head configuration for the specified head.
+
+        Attributes
+        ----------
+        head_config : Dict
+            A dictionary containing configuration details relevant to the parser, including parameters and settings required for output parsing.
+        """
         pass
 
     @abstractmethod
     def run(self):
+        """Parses the output from the neural network head.
+
+        This method should be overridden by subclasses to implement the specific parsing logic.
+        It accepts arbitrary keyword arguments for flexibility.
+        Args:
+            **kwargs: Arbitrary keyword arguments for the parsing process.
+        Returns:
+            The parsed output message, as defined by the logic in the subclass.
+        """
         pass

--- a/depthai_nodes/ml/parsers/base_parser.py
+++ b/depthai_nodes/ml/parsers/base_parser.py
@@ -1,0 +1,33 @@
+from abc import ABCMeta, abstractmethod
+from typing import Dict, Union
+
+import depthai as dai
+
+
+class BaseMeta(ABCMeta, type(dai.node.ThreadedHostNode)):
+    pass
+
+
+class BaseParser(dai.node.ThreadedHostNode, metaclass=BaseMeta):
+    """Base parser class for neural network output parsers."""
+
+    def __init__(self):
+        super().__init__()
+
+    @property
+    @abstractmethod
+    def input(self) -> dai.Node.Input:
+        pass
+
+    @property
+    @abstractmethod
+    def output(self) -> dai.Node.Output:
+        pass
+
+    @abstractmethod
+    def build(self, head: Union[dai.NNArchive, Dict]):
+        pass
+
+    @abstractmethod
+    def run(self):
+        pass

--- a/depthai_nodes/ml/parsers/classification.py
+++ b/depthai_nodes/ml/parsers/classification.py
@@ -43,7 +43,7 @@ class ClassificationParser(BaseParser):
     ):
         super().__init__()
         self.output_layer_name = output_layer_name
-        self.classes = classes if classes is not None else []
+        self.classes = classes or []
         self.n_classes = n_classes
         self.is_softmax = is_softmax
 

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -13,7 +13,6 @@ class Parser(dai.node.ThreadedHostNode):
 
     def __init__(self):
         super().__init__()
-        pass
 
     def build(
         self, nn_archive: dai.NNArchive, head__index: int = None
@@ -45,7 +44,7 @@ class Parser(dai.node.ThreadedHostNode):
         parsers = {}
         pipeline = self.getParentPipeline()
 
-        for index, head in zip(heads, indexes):
+        for index, head in zip(indexes, heads):
             parser_name = head.parser
             parser = globals().get(parser_name)
 

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -102,7 +102,7 @@ class Parser(dai.node.ThreadedHostNode):
 
         else:
             raise ValueError(
-                f"Provided heads must be of type Dict or List[Dict] not {type(heads)}."
+                f"Provided heads must be of type Dict or List not {type(heads)}."
             )
 
         return self

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -17,7 +17,7 @@ class Parser(dai.node.ThreadedHostNode):
 
     def build(
         self, nn_archive: dai.NNArchive, head__index: int = None
-    ) -> Dict[BaseParser]:
+    ) -> Dict[int, BaseParser]:
         """Instantiates parsers based on the provided model archive.
 
         Attributes

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -7,11 +7,12 @@ from .base_parser import BaseParser
 from .utils import decode_head
 
 
-class Parser:
+class Parser(dai.node.ThreadedHostNode):
     """General interface for instantiating parsers based on the provided model
     archive."""
 
     def __init__(self):
+        super().__init__()
         pass
 
     def build(
@@ -39,6 +40,7 @@ class Parser:
         if head__index:
             heads = [heads[head__index]]
         parsers = []
+        pipeline = self.getParentPipeline()
 
         for head in heads:
             parser_name = head.parser
@@ -50,6 +52,6 @@ class Parser:
 
             parser = parser()
             head = decode_head(head)
-            parsers.append(parser.build(head))
+            parsers.append(pipeline.create(parser).build(head))
 
         return parsers

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -15,7 +15,7 @@ class Parser(dai.node.ThreadedHostNode):
         super().__init__()
 
     def build(
-        self, nn_archive: dai.NNArchive, head__index: int = None
+        self, nn_archive: dai.NNArchive, head_index: int = None
     ) -> Dict[int, BaseParser]:
         """Instantiates parsers based on the provided model archive.
 
@@ -37,9 +37,9 @@ class Parser(dai.node.ThreadedHostNode):
         if len(heads) == 0:
             raise ValueError("No heads defined in the NN Archive.")
 
-        if head__index:
-            heads = [heads[head__index]]
-            indexes = [head__index]
+        if head_index:
+            heads = [heads[head_index]]
+            indexes = [head_index]
 
         parsers = {}
         pipeline = self.getParentPipeline()

--- a/depthai_nodes/ml/parsers/parser.py
+++ b/depthai_nodes/ml/parsers/parser.py
@@ -4,7 +4,21 @@ import depthai as dai
 
 
 class Parser(dai.node.ThreadedHostNode):
-    """Base class for all parsers."""
+    """Base class for neural network output parsers.
+
+    This class serves as a foundation for specific parser implementations used to postprocess the outputs of neural network models.
+    Each parser is attached to a model "head" that governs the parsing process as it contains all the necessary information for the parser to function correctly.
+    Subclasses should implement the `run` method to define the parsing logic.
+
+    Attributes
+    ----------
+    input : Node.Input
+        Node's input. It is a linking point to which the Neural Network's output is linked. It accepts the output of the Neural Network node.
+    out : Node.Output
+        Parser sends the processed network results to this output in a form of DepthAI message. It is a linking point from which the processed network results are retrieved.
+    head_config : Dict
+        A dictionary containing configuration details relevant to the parser, including parameters and settings required for output parsing.
+    """
 
     def __init__(self):
         super().__init__()
@@ -13,17 +27,15 @@ class Parser(dai.node.ThreadedHostNode):
 
         self.head_config: Dict = {}
 
-    def build(self, heads: Union[List, Dict], head_name: str = ""):
-        """Initial build method for all parsers. The method sets the head configuration
-        for the parser.
+    def build(self, heads: Union[List, Dict], head_name: str = None):
+        """Sets the head configuration for the specified head.
 
         Attributes
         ----------
         heads : Union[List, Dict]
-            List of all archive head objects: [<depthai.nn_archive.v1.Head object>, ...]
-            or a dictionary containing the head metadata.
+            List of all head objects of the model: [<depthai.nn_archive.v1.Head object>, ...] or a dictionary containing the head configuration.
         head_name : str
-            The name of the head to use. If multiple heads are available in the archive, the name must be specified.
+            The name of the head to use. If multiple heads are available, the name must be specified.
 
         Returns
         -------
@@ -34,39 +46,40 @@ class Parser(dai.node.ThreadedHostNode):
         if isinstance(heads, list):
             if len(heads) == 0:
                 raise ValueError("No heads available in the nn_archive.")
-
-            head = heads[0]
-
-            if len(heads) > 1 and head_name == "":
-                current_parser = self.__class__.__name__
-                parser_names_in_archive = [head.parser for head in heads]
-                num_matches = parser_names_in_archive.count(current_parser)
-                if num_matches == 0:
-                    raise ValueError(
-                        f"No heads available for {current_parser} in the nn_archive."
-                    )
-                elif num_matches == 1:
-                    head = [head for head in heads if head.parser == current_parser][0]
+            elif len(heads) == 1:
+                head = heads[0]
+            else:
+                if head_name:
+                    head_candidates = [
+                        head
+                        for head in heads
+                        if head.metadata.extraParams["name"] == head_name
+                    ]
+                    if len(head_candidates) == 0:
+                        raise ValueError(
+                            f"No head with name {head_name} specified in nn_archive."
+                        )
+                    if len(head_candidates) > 1:
+                        raise ValueError(
+                            f"Multiple heads with name {head_name} found in nn_archive, please specify a unique name."
+                        )
+                    head = head_candidates[0]
                 else:
-                    raise ValueError(
-                        f"Multiple heads with parser= {current_parser} detected, please specify a head name."
-                    )
-
-            if head_name != "":
-                head_candidates = [
-                    head
-                    for head in heads
-                    if head.metadata.extraParams["name"] == head_name
-                ]
-                if len(head_candidates) == 0:
-                    raise ValueError(
-                        f"No head with name {head_name} specified in nn_archive."
-                    )
-                if len(head_candidates) > 1:
-                    raise ValueError(
-                        f"Multiple heads with name {head_name} found in nn_archive, please specify a unique name."
-                    )
-                head = head_candidates[0]
+                    current_parser = self.__class__.__name__
+                    parser_names_in_archive = [head.parser for head in heads]
+                    num_matches = parser_names_in_archive.count(current_parser)
+                    if num_matches == 0:
+                        raise ValueError(
+                            f"No heads available for {current_parser} in the nn_archive."
+                        )
+                    elif num_matches == 1:
+                        head = [
+                            head for head in heads if head.parser == current_parser
+                        ][0]
+                    else:
+                        raise ValueError(
+                            f"Multiple heads with parser= {current_parser} detected, please specify a head name."
+                        )
 
             parser_name = head.parser
             metadata = head.metadata
@@ -84,7 +97,28 @@ class Parser(dai.node.ThreadedHostNode):
                 head_dictionary.update(metadata.extraParams)
             self.head_config = head_dictionary
 
-        else:
+        elif isinstance(heads, dict):
             self.head_config = heads
 
+        else:
+            raise ValueError(
+                f"Provided heads must be of type Dict or List[Dict] not {type(heads)}."
+            )
+
         return self
+
+    def run(self, **kwargs):
+        """Parses the output from the neural network head.
+
+        This method should be overridden by subclasses to implement the specific parsing logic.
+        It accepts arbitrary keyword arguments for flexibility.
+
+        Args:
+            **kwargs: Arbitrary keyword arguments for the parsing process.
+
+        Returns:
+            The parsed output message, as defined by the logic in the subclass.
+        """
+        raise NotImplementedError(
+            "Missing the parsing logic. Implement the run method."
+        )

--- a/depthai_nodes/ml/parsers/parser_generator.py
+++ b/depthai_nodes/ml/parsers/parser_generator.py
@@ -7,9 +7,11 @@ from .base_parser import BaseParser
 from .utils import decode_head
 
 
-class Parser(dai.node.ThreadedHostNode):
-    """General interface for instantiating parsers based on the provided model
-    archive."""
+class ParserGenerator(dai.node.ThreadedHostNode):
+    """General interface for instantiating parsers based on the provided model archive.
+
+    The `build` method creates parsers based on the head information stored in the NN Archive. The method then returns a dictionary of these parsers.
+    """
 
     def __init__(self):
         super().__init__()
@@ -28,8 +30,8 @@ class Parser(dai.node.ThreadedHostNode):
 
         Returns
         -------
-        parsers: List[BaseParser]
-            List of instantiated parsers.
+        parsers: Dict[int : BaseParser]
+            A dictionary of instantiated parsers.
         """
         heads = nn_archive.getConfig().getConfigV1().model.heads
         indexes = range(len(heads))

--- a/depthai_nodes/ml/parsers/ppocr.py
+++ b/depthai_nodes/ml/parsers/ppocr.py
@@ -4,10 +4,9 @@ import depthai as dai
 import numpy as np
 
 from ..messages.creators import create_classification_sequence_message
-from .classification import Parser
 
 
-class PaddleOCRParser(Parser):
+class PaddleOCRParser(dai.node.ThreadedHostNode):
     """Postprocessing logic for PaddleOCR text recognition model.
 
     Attributes

--- a/depthai_nodes/ml/parsers/utils/__init__.py
+++ b/depthai_nodes/ml/parsers/utils/__init__.py
@@ -1,4 +1,5 @@
 from .decode_detections import decode_detections
+from .decode_head import decode_head
 from .denormalize import unnormalize_image
 from .medipipe import generate_anchors_and_decode
 from .ppdet import corners2xyxy, parse_paddle_detection_outputs
@@ -9,4 +10,5 @@ __all__ = [
     "generate_anchors_and_decode",
     "parse_paddle_detection_outputs",
     "corners2xyxy",
+    "decode_head",
 ]

--- a/depthai_nodes/ml/parsers/utils/decode_head.py
+++ b/depthai_nodes/ml/parsers/utils/decode_head.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict
+
+
+def decode_head(head) -> Dict[str, Any]:
+    """Decode head object into a dictionary containing configuration details.
+
+    @param head: The head object to decode.
+    @type head: dai.nn_archive.v1.Head
+    @return: A dictionary containing configuration details relevant to the head.
+    @rtype: Dict[str, Any]
+    """
+    head_config = {}
+    head_config["parser"] = head.parser
+    head_config["outputs"] = head.outputs
+    if head.metadata:
+        head_config.update(head.metadata.extraParams)
+
+    return head_config


### PR DESCRIPTION
Adding a small refactor PR for the base parser. Expanding docstrings and fixing the type checking (the issue described [here](https://github.com/luxonis/depthai-nodes/pull/74#discussion_r1773055805)).

Moreover, I'm wondering if:

- the base parser should rather store `head` (depthai object) instead of `head_config` (dict). The functionality would stay the same but this would, in my opinion, make things more clear and readable. It would also simplify the code. I'm assuming the `head_config` is introduced to enable manual parser building (so that one could write a custom dict instead of providing a NN Archive). However, I think that the build method should be used only for building from a NN Archive and we use the parser-specific setter methods for manual building;
- based on the same logic as the previous point, could the `heads` parameter in the build() method be changed from type Union[List, Dict] to type List[depthai.nn_archive.v1.Head]? The Dict option is not necessary if we only allow building from a NN Archive;
- the build() method should have a return statement or can it be omitted? It doesn't really need to return anything;
- we should re-name `Parser` to `BaseParser` and make it an abstract class?