### PR TITLE
Parsers-V2: Refactor YuNet Parser

### DIFF
--- a/depthai_nodes/ml/messages/creators/regression.py
+++ b/depthai_nodes/ml/messages/creators/regression.py
@@ -22,13 +22,13 @@ def create_regression_message(predictions: List[float]) -> Predictions:
             raise ValueError(
                 f"Each predictions should be a float, got {type(prediction)} instead."
             )
-        
+
     prediction_objects_list = []
     for prediction in predictions:
         prediction_object = Prediction()
         prediction_object.prediction = prediction
         prediction_objects_list.append((prediction_object))
-        
+
     predictions_message = Predictions()
     predictions_message.predictions = prediction_objects_list
 

--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union
+from typing import List
 
 import depthai as dai
 import numpy as np
@@ -11,68 +11,46 @@ class ImgDetectionExtended(dai.ImgDetection):
 
     Attributes
     ----------
-    keypoints: Union[List[Tuple[float, float]], List[Tuple[float, float, float]]]
-        Keypoints of the image detection.
+    keypoints: Keypoints
+        Keypoints of the detection.
     masks: np.ndarray
-        Mask of the image segmentation.
+        Segmentation Mask of the detection.
+    angle: float
+        Angle of the detection.
     """
 
     def __init__(self):
         """Initializes the ImgDetectionExtended object."""
-        dai.ImgDetection.__init__(self)  # TODO: change to super().__init__()?
-        self._keypoints: Union[
-            List[Tuple[float, float]], List[Tuple[float, float, float]]
-        ] = []
+        super().__init__()
+        self._keypoints: Keypoints = []
         self._mask: np.ndarray = np.array([])
+        self._angle: float = 0.0
 
     @property
     def keypoints(
         self,
-    ) -> Union[List[Tuple[float, float]], List[Tuple[float, float, float]]]:
+    ) -> Keypoints:
         """Returns the keypoints.
 
         @return: List of keypoints.
-        @rtype: Union[List[Tuple[float, float]], List[Tuple[float, float, float]]]
+        @rtype: Keypoints
         """
         return self._keypoints
 
     @keypoints.setter
     def keypoints(
         self,
-        value: Union[
-            List[Tuple[Union[int, float], Union[int, float]]],
-            List[Tuple[Union[int, float], Union[int, float], Union[int, float]]],
-        ],
+        value: Keypoints,
     ):
         """Sets the keypoints.
 
         @param value: List of keypoints.
-        @type value: Union[List[Tuple[Union[int, float], Union[int, float]]],
-            List[Tuple[Union[int, float], Union[int, float], Union[int, float]]]]
-        @raise TypeError: If the keypoints are not a list.
-        @raise TypeError: If each keypoint is not a tuple of two or three floats or
-            integers.
+        @type value: Keypoints
+        @raise TypeError: If the keypoints are not a Keypoints object.
         """
-        if not isinstance(value, list):
-            raise TypeError("Keypoints must be a list")
-        dim = len(value[0]) if value else 0
-        for item in value:
-            if (
-                not (isinstance(item, tuple) or isinstance(item, list))
-                or (len(item) != 2 and len(item) != 3)
-                or not all(isinstance(i, (int, float)) for i in item)
-            ):
-                raise TypeError(
-                    "Each keypoint must be a tuple of two or three floats or integers."
-                )
-            if len(item) != dim:
-                raise ValueError(
-                    "All keypoints must be of the same dimension e.g. [x, y] or [x, y, z], got mixed inner dimensions."
-                )
-        keypoints = []
-        for items in value:
-            keypoints.append(tuple(float(v) for v in items))
-        self._keypoints = keypoints
+        if not isinstance(value, Keypoints):
+            raise TypeError("Keypoints must be a Keypoints object")
+        self._keypoints = value
 
     @property
     def mask(self) -> np.ndarray:
@@ -99,7 +77,7 @@ class ImgDetectionExtended(dai.ImgDetection):
         self._mask = value
 
 
-class ImgDetectionsExtended(dai.Buffer):
+class ImgDetectionsExtended(dai.ImgDetections):
     """ImgDetectionsExtended class for storing image detections with keypoints.
 
     Attributes
@@ -110,7 +88,7 @@ class ImgDetectionsExtended(dai.Buffer):
 
     def __init__(self):
         """Initializes the ImgDetectionsExtended object."""
-        dai.Buffer.__init__(self)  # TODO: change to super().__init__()?
+        super().__init__()
         self._detections: List[ImgDetectionExtended] = []
 
     @property

--- a/depthai_nodes/ml/parsers/__init__.py
+++ b/depthai_nodes/ml/parsers/__init__.py
@@ -12,7 +12,6 @@ from .mediapipe_palm_detection import MPPalmDetectionParser
 from .mlsd import MLSDParser
 from .parser_generator import ParserGenerator
 from .ppdet import PPTextDetectionParser
-from .classification_sequence import ClassificationSequenceParser
 from .regression import RegressionParser
 from .scrfd import SCRFDParser
 from .segmentation import SegmentationParser

--- a/depthai_nodes/ml/parsers/regression.py
+++ b/depthai_nodes/ml/parsers/regression.py
@@ -1,13 +1,15 @@
+from typing import Any, Dict
+
 import depthai as dai
 import numpy as np
-
-from typing import Any, Dict
 
 from ..messages.creators import create_regression_message
 from .base_parser import BaseParser
 
+
 class RegressionParser(BaseParser):
-    """Parser class for parsing the output of a model with regression output (e.g. Age-Gender).
+    """Parser class for parsing the output of a model with regression output (e.g. Age-
+    Gender).
 
     Attributes
     ----------
@@ -17,7 +19,7 @@ class RegressionParser(BaseParser):
         Parser sends the processed network results to this output in a form of DepthAI message. It is a linking point from which the processed network results are retrieved.
     output_layer_name : str
         Name of the output layer relevant to the parser.
-        
+
     Output Message/s
     ----------------
     **Type**: Predictions
@@ -27,7 +29,8 @@ class RegressionParser(BaseParser):
 
     def __init__(
         self,
-        output_layer_name: str = "",):
+        output_layer_name: str = "",
+    ):
         """Initializes the RegressionParser node.
 
         @param output_layer_name: Name of the output layer relevant to the parser.
@@ -82,9 +85,11 @@ class RegressionParser(BaseParser):
                     f"Expected 1 output layer, got {len(layers)} layers. Please provide the output_layer_name."
                 )
 
-            predictions = output.getTensor(self.output_layer_name, dequantize=True).squeeze()
+            predictions = output.getTensor(
+                self.output_layer_name, dequantize=True
+            ).squeeze()
             predictions = np.atleast_1d(predictions).tolist()
-            
+
             regression_message = create_regression_message(predictions=predictions)
             regression_message.setTimestamp(output.getTimestamp())
 

--- a/depthai_nodes/ml/parsers/utils/bbox.py
+++ b/depthai_nodes/ml/parsers/utils/bbox.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 
-def xywh2xyxy(bboxes):
-    """ 
-    Convert bounding box coordinates from (x, y, width, height) to (x_min, y_min, x_max, y_max).
+def xywh2xyxy(bboxes: np.ndarray):
+    """Convert bounding box coordinates from (x, y, width, height) to (x_min, y_min,
+    x_max, y_max).
 
     @param bboxes: A numpy array of shape (N, 4) containing the bounding boxes in (x, y, width, height) format.
     @type np.ndarray
@@ -12,18 +12,18 @@ def xywh2xyxy(bboxes):
     """
 
     xyxy_bboxes = np.zeros_like(bboxes)
-    xyxy_bboxes[:, 0] = bboxes[:, 0] # x_min = x
-    xyxy_bboxes[:, 1] = bboxes[:, 1] # y_min = y
-    xyxy_bboxes[:, 2] = bboxes[:, 0] + bboxes[:, 2] # x_max = x + w
-    xyxy_bboxes[:, 3] = bboxes[:, 1] + bboxes[:, 3] # y_max = y + h
+    xyxy_bboxes[:, 0] = bboxes[:, 0]  # x_min = x
+    xyxy_bboxes[:, 1] = bboxes[:, 1]  # y_min = y
+    xyxy_bboxes[:, 2] = bboxes[:, 0] + bboxes[:, 2]  # x_max = x + w
+    xyxy_bboxes[:, 3] = bboxes[:, 1] + bboxes[:, 3]  # y_max = y + h
     return xyxy_bboxes
 
-def normalize_bbox(bbox, height, width):
-    """
-    Normalize bounding box coordinates to (0, 1).
 
-    @param bbox: A tuple or list with 4 elements (x_min, y_min, w, h).
-    @type bbox: tuple or list
+def normalize_bbox(bbox: np.ndarray, height: int, width: int):
+    """Normalize bounding box coordinates to (0, 1).
+
+    @param bbox: A numpy array with 4 elements (x_min, y_min, w, h).
+    @type bbox: np.ndarray
     @param height: The height of the image.
     @type height: int
     @param width: The width of the image.
@@ -35,9 +35,9 @@ def normalize_bbox(bbox, height, width):
     xmin, ymin, w, h = bbox
     return [xmin / width, ymin / height, w / width, h / height]
 
-def normalize_bboxes(bboxes, height, width):
-    """
-    Normalize bounding box coordinates to (0, 1).
+
+def normalize_bboxes(bboxes: np.ndarray, height: int, width: int):
+    """Normalize bounding box coordinates to (0, 1).
 
     @param bboxes: A numpy array of shape (N, 4) containing the bounding boxes.
     @type np.ndarray

--- a/depthai_nodes/ml/parsers/utils/bbox.py
+++ b/depthai_nodes/ml/parsers/utils/bbox.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+
+def xywh2xyxy(bboxes):
+    """ 
+    Convert bounding box coordinates from (x, y, width, height) to (x_min, y_min, x_max, y_max).
+
+    @param bboxes: A numpy array of shape (N, 4) containing the bounding boxes in (x, y, width, height) format.
+    @type np.ndarray
+    @return: A numpy array of shape (N, 4) containing the bounding boxes in (x_min, y_min, x_max, y_max) format.
+    @type np.ndarray
+    """
+
+    xyxy_bboxes = np.zeros_like(bboxes)
+    xyxy_bboxes[:, 0] = bboxes[:, 0] # x_min = x
+    xyxy_bboxes[:, 1] = bboxes[:, 1] # y_min = y
+    xyxy_bboxes[:, 2] = bboxes[:, 0] + bboxes[:, 2] # x_max = x + w
+    xyxy_bboxes[:, 3] = bboxes[:, 1] + bboxes[:, 3] # y_max = y + h
+    return xyxy_bboxes
+
+def normalize_bbox(bbox, height, width):
+    """
+    Normalize bounding box coordinates to (0, 1).
+
+    @param bbox: A tuple or list with 4 elements (x_min, y_min, w, h).
+    @type bbox: tuple or list
+    @param height: The height of the image.
+    @type height: int
+    @param width: The width of the image.
+    @type width: int
+    @return: A list with 4 elements [x_min, y_min, w, h].
+    @type list
+    """
+
+    xmin, ymin, w, h = bbox
+    return [xmin / width, ymin / height, w / width, h / height]
+
+def normalize_bboxes(bboxes, height, width):
+    """
+    Normalize bounding box coordinates to (0, 1).
+
+    @param bboxes: A numpy array of shape (N, 4) containing the bounding boxes.
+    @type np.ndarray
+    @param height: The height of the image.
+    @type height: int
+    @param width: The width of the image.
+    @type width: int
+    @return: A numpy array of shape (N, 4) containing the normalized bounding boxes.
+    @type np.ndarray
+    """
+
+    return np.array([normalize_bbox(bbox, height, width) for bbox in bboxes])

--- a/depthai_nodes/ml/parsers/utils/keypoints.py
+++ b/depthai_nodes/ml/parsers/utils/keypoints.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+
+def normalize_keypoint(keypoint, height, width):
+    """
+    Normalize keypoint coordinates to (0, 1).
+
+    Parameters:
+    keypoint (tuple or list): A tuple or list with 2 elements (x, y).
+    height (int): The height of the image.
+    width (int): The width of the image.
+
+    Returns:
+    tuple: A list with 2 elements [x, y].
+    """
+
+    if len(keypoint) != 2:
+        raise ValueError(
+            "Keypoint must be a tuple or list of length 2. Other options are currently not supported."
+        )
+
+    x, y = keypoint
+    return [x / width, y / height]
+
+
+def normalize_keypoints(keypoints, height, width):
+    """
+    Normalize keypoint coordinates to (0, 1).
+
+    Parameters:
+    keypoints (np.ndarray): A numpy array of shape (N, 2) or (N, K, 2) where N is the number of keypoint sets and K is the number of keypoint in each set.
+    height (int): The height of the image.
+    width (int): The width of the image.
+
+    Returns:
+    np.ndarray: A numpy array of shape (N, 2) containing the normalized keypoints.
+    """
+
+    # TODO: expect keypoints to be either of shape (N,2) - one keypoint set or (batch,N,2) - multiple keypoint sets
+
+    if not isinstance(keypoints, np.ndarray):
+        raise TypeError("Keypoints must be a numpy array.")
+
+    return np.array(
+        [
+            [normalize_keypoint(keypoint, height, width) for keypoint in keypoint_set]
+            for keypoint_set in keypoints.tolist()
+        ]
+    )

--- a/depthai_nodes/ml/parsers/utils/keypoints.py
+++ b/depthai_nodes/ml/parsers/utils/keypoints.py
@@ -1,14 +1,16 @@
 import numpy as np
 
 
-def normalize_keypoint(keypoint, height, width):
-    """
-    Normalize keypoint coordinates to (0, 1).
+def normalize_keypoint(keypoint: np.ndarray, height: int, width: int):
+    """Normalize keypoint coordinates to (0, 1).
 
     Parameters:
-    keypoint (tuple or list): A tuple or list with 2 elements (x, y).
-    height (int): The height of the image.
-    width (int): The width of the image.
+    @param keypoint: A tuple or list with 2 elements (x, y).
+    @type np.ndarray
+    @param height: The height of the image.
+    @type height: int
+    @param width: The width of the image.
+    @type width: int
 
     Returns:
     tuple: A list with 2 elements [x, y].
@@ -23,14 +25,16 @@ def normalize_keypoint(keypoint, height, width):
     return [x / width, y / height]
 
 
-def normalize_keypoints(keypoints, height, width):
-    """
-    Normalize keypoint coordinates to (0, 1).
+def normalize_keypoints(keypoints: np.ndarray, height: int, width: int):
+    """Normalize keypoint coordinates to (0, 1).
 
     Parameters:
-    keypoints (np.ndarray): A numpy array of shape (N, 2) or (N, K, 2) where N is the number of keypoint sets and K is the number of keypoint in each set.
-    height (int): The height of the image.
-    width (int): The width of the image.
+    @param keypoints: A numpy array of shape (N, 2) or (N, K, 2) where N is the number of keypoint sets and K is the number of keypoint in each set.
+    @type np.ndarray
+    @param height: The height of the image.
+    @type height: int
+    @param width: The width of the image.
+    @type width: int
 
     Returns:
     np.ndarray: A numpy array of shape (N, 2) containing the normalized keypoints.

--- a/depthai_nodes/ml/parsers/utils/nms.py
+++ b/depthai_nodes/ml/parsers/utils/nms.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import cv2
 import numpy as np
 
 
@@ -41,3 +42,34 @@ def nms(dets: np.ndarray, nms_thresh: float = 0.5) -> List[int]:
         order = order[inds + 1]
 
     return keep
+
+
+def nms_cv2(
+    bboxes: np.ndarray,
+    scores: np.ndarray,
+    conf_threshold: float,
+    iou_threshold: float,
+    max_det: int,
+):
+    """Non-maximum suppression from the opencv-python library.
+
+    @param bboxes: A numpy array of shape (N, 4) containing the bounding boxes.
+    @type bboxes: np.ndarray
+    @param scores: A numpy array of shape (N,) containing the scores.
+    @type scores: np.ndarray
+    @param nms_thresh: Non-maximum suppression threshold.
+    @type nms_thresh: float
+    @return: Indices of the detections to keep.
+    @rtype: List[int]
+    """
+
+    # NMS
+    keep_indices = cv2.dnn.NMSBoxes(
+        bboxes=bboxes.tolist(),
+        scores=scores.tolist(),
+        score_threshold=conf_threshold,
+        nms_threshold=iou_threshold,
+        top_k=max_det,
+    )
+
+    return keep_indices

--- a/depthai_nodes/ml/parsers/utils/yunet.py
+++ b/depthai_nodes/ml/parsers/utils/yunet.py
@@ -1,0 +1,183 @@
+import numpy as np
+from itertools import product # NOTE: you can use manual_product function instead of itertools.product
+
+from .bbox import normalize_bboxes
+from .keypoints import normalize_keypoints
+
+
+def manual_product(*args):
+    """You can use this function instead of itertools.product"""
+    if not args:
+        return [()]
+    result = [[]]
+    for pool in args:
+        result = [x + [y] for x in result for y in pool]
+    return [tuple(x) for x in result]
+
+
+def generate_anchors(
+    input_shape,
+    min_sizes=[[10, 16, 24], [32, 48], [64, 96], [128, 192, 256]],
+    strides=[8, 16, 32, 64],
+):
+    """Generate a set of default bounding boxes, known as anchors.
+    The code is taken from https://github.com/Kazuhito00/YuNet-ONNX-TFLite-Sample/tree/main
+
+    @param input_shape: A tuple representing the height and width of the input image.
+    @type input_shape: tuple
+    @param min_sizes: A list of lists, where each inner list contains the minimum sizes of the anchors for different feature maps.
+    @type min_sizes List[List[int]]
+    @param strides: Strides for each feature map layer.
+    @type strides: List[int]
+    @return: Anchors.
+    @rtype: np.ndarray
+    """
+    w, h = input_shape
+
+    # Calculate sizes of different feature maps by progressively halving the dimensions of the input image.
+    feature_map_2th = [int(int((h + 1) / 2) / 2), int(int((w + 1) / 2) / 2)]
+    feature_map_3th = [int(feature_map_2th[0] / 2), int(feature_map_2th[1] / 2)]
+    feature_map_4th = [int(feature_map_3th[0] / 2), int(feature_map_3th[1] / 2)]
+    feature_map_5th = [int(feature_map_4th[0] / 2), int(feature_map_4th[1] / 2)]
+    feature_map_6th = [int(feature_map_5th[0] / 2), int(feature_map_5th[1] / 2)]
+    feature_maps = [feature_map_3th, feature_map_4th, feature_map_5th, feature_map_6th]
+
+    # Generate anchors
+    anchors = []
+    for k, f in enumerate(feature_maps):
+        min_sizes_k = min_sizes[k]
+        for i, j in product(range(f[0]), range(f[1])):
+            for min_size_k in min_sizes_k:
+                s_kx = min_size_k / w
+                s_ky = min_size_k / h
+
+                cx = (j + 0.5) * strides[k] / w
+                cy = (i + 0.5) * strides[k] / h
+
+                anchors.append([cx, cy, s_kx, s_ky])
+
+    anchors = np.array(anchors, dtype=np.float32)
+    return anchors
+
+
+def decode_detections(
+    input_shape,
+    loc,
+    conf,
+    iou,
+    variance=[0.1, 0.2],
+):
+    """
+    Decodes the output of an object detection model by converting the model's predictions (localization, confidence, and IoU scores) into bounding boxes, keypoints, and scores.
+    The code is taken from https://github.com/Kazuhito00/YuNet-ONNX-TFLite-Sample/tree/main
+    
+    @param input_shape: The shape of the input image (height, width).
+    @type input_shape: tuple
+    @param loc: The predicted locations (or offsets) of the bounding boxes.
+    @type loc: np.ndarray
+    @param conf: The predicted class confidence scores.
+    @type conf: np.ndarray
+    @param iou: The predicted IoU (Intersection over Union) scores.
+    @type iou: np.ndarray
+    @param variance: A list of variances used to decode the bounding box predictions.
+    @type variance: List[float]
+    @return: A tuple of bboxes, keypoints, and scores.
+        - bboxes: NumPy array of shape (N, 4) containing the decoded bounding boxes in the format [x_min, y_min, width, height].
+        - keypoints: A NumPy array of shape (N, 10) containing the decoded keypoint coordinates for each anchor.
+        - scores: A NumPy array of shape (N, 1) containing the combined scores for each anchor.
+    @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
+
+    """
+
+    w,h = input_shape
+
+    anchors = generate_anchors(input_shape)
+
+    # Get scores
+    cls_scores = conf[:, 1]
+    iou_scores = iou[:, 0]
+    _idx = np.where(iou_scores < 0.0)
+    iou_scores[_idx] = 0.0
+    _idx = np.where(iou_scores > 1.0)
+    iou_scores[_idx] = 1.0
+    scores = np.sqrt(cls_scores * iou_scores)
+    scores = scores[:, np.newaxis]
+
+    # Get bounding boxes
+    scale = np.array((w,h))
+    bboxes = np.hstack(
+        (
+            (anchors[:, 0:2] + loc[:, 0:2] * variance[0] * anchors[:, 2:4]) * scale,
+            (anchors[:, 2:4] * np.exp(loc[:, 2:4] * variance)) * scale,
+        )
+    )
+    bboxes[:, 0:2] -= bboxes[:, 2:4] / 2
+
+    # Get keypoints
+    keypoints = np.hstack(
+        (
+            (anchors[:, 0:2] + loc[:, 4:6] * variance[0] * anchors[:, 2:4]) * scale,
+            (anchors[:, 0:2] + loc[:, 6:8] * variance[0] * anchors[:, 2:4]) * scale,
+            (anchors[:, 0:2] + loc[:, 8:10] * variance[0] * anchors[:, 2:4]) * scale,
+            (anchors[:, 0:2] + loc[:, 10:12] * variance[0] * anchors[:, 2:4]) * scale,
+            (anchors[:, 0:2] + loc[:, 12:14] * variance[0] * anchors[:, 2:4]) * scale,
+        )
+    )
+
+    return bboxes, keypoints, scores
+
+
+def prune_detections(bboxes, keypoints, scores, conf_threshold):
+    """
+    Prune detections based on confidence threshold.
+
+    Parameters:
+    @param bboxes: A numpy array of shape (N, 4) containing the bounding boxes.
+    @type np.ndarray
+    @param keypoints: A numpy array of shape (N, 10) containing the keypoints.
+    @type np.ndarray
+    @param scores: A numpy array of shape (N,) containing the scores.
+    @type np.ndarray
+    @param conf_threshold: The confidence threshold.
+    @type float
+    @return: A tuple of bboxes, keypoints, and scores.
+        - bboxes: NumPy array of shape (N, 4) containing the decoded bounding boxes in the format [x_min, y_min, width, height].
+        - keypoints: A NumPy array of shape (N, 10) containing the decoded keypoint coordinates for each anchor.
+        - scores: A NumPy array of shape (N, 1) containing the combined scores for each anchor.
+    @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
+    """
+
+    keep_indices = np.where(scores.squeeze() > conf_threshold)
+    return bboxes[keep_indices], keypoints[keep_indices], scores[keep_indices]
+
+
+def format_detections(bboxes, keypoints, scores, input_shape):
+    """
+    Format detections into a list of dictionaries.
+
+    @param bboxes: A numpy array of shape (N, 4) containing the bounding boxes.
+    @type np.ndarray
+    @param keypoints: A numpy array of shape (N, 10) containing the keypoints.
+    @type np.ndarray
+    @param scores: A numpy array of shape (N,) containing the scores.
+    @type np.ndarray
+    @param input_shape: A tuple representing the height and width of the input image.
+    @type input_shape: tuple
+    @return: A tuple of bboxes, keypoints, and scores.
+        - bboxes: NumPy array of shape (N, 4) containing the decoded bounding boxes in the format [x_min, y_min, width, height].
+        - keypoints: A NumPy array of shape (N, 10) containing the decoded keypoint coordinates for each anchor.
+        - scores: A NumPy array of shape (N, 1) containing the combined scores for each anchor.
+    @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
+    """
+
+    w, h = input_shape
+
+    bboxes = normalize_bboxes(bboxes, height=h, width=w)
+
+    keypoints = keypoints.astype(np.int32)
+    keypoints = keypoints.reshape(-1, 5, 2) # (N,10) to (N,5,2)
+    keypoints = normalize_keypoints(keypoints, height=h, width=w)
+    
+    scores = scores.squeeze()
+    
+    return bboxes, keypoints, scores

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -1,11 +1,11 @@
-import math
+from typing import Tuple
 
-import cv2
 import depthai as dai
-import numpy as np
 
 from ..messages.creators import create_detection_message
-from .utils import decode_detections
+from .utils.bbox import xywh2xyxy
+from .utils.nms import nms_cv2
+from .utils.yunet import decode_detections, format_detections, prune_detections
 
 
 class YuNetParser(dai.node.ThreadedHostNode):
@@ -31,12 +31,7 @@ class YuNetParser(dai.node.ThreadedHostNode):
     **Description**: Message containing bounding boxes, labels, confidence scores, and keypoints of detected faces.
     """
 
-    def __init__(
-        self,
-        conf_threshold=0.6,
-        iou_threshold=0.3,
-        max_det=5000,
-    ):
+    def __init__(self):
         """Initializes the YuNetParser node.
 
         @param conf_threshold: Confidence score threshold for detected faces.
@@ -50,9 +45,15 @@ class YuNetParser(dai.node.ThreadedHostNode):
         self.input = self.createInput()
         self.out = self.createOutput()
 
-        self.conf_threshold = conf_threshold
-        self.iou_threshold = iou_threshold
-        self.max_det = max_det
+        self.conf_threshold = 0.8
+        self.iou_threshold = 0.3
+        self.max_det = 5000
+
+        self.loc_output_layer_name = None
+        self.conf_output_layer_name = None
+        self.iou_output_layer_name = None
+
+        self.input_shape: Tuple[int] = (640, 480)  # None
 
     def setConfidenceThreshold(self, threshold):
         """Sets the confidence score threshold for detected faces.
@@ -78,6 +79,32 @@ class YuNetParser(dai.node.ThreadedHostNode):
         """
         self.max_det = max_det
 
+    def setInputShape(self, width, height):
+        """Sets the input shape.
+
+        @param height: Height of the input image.
+        @type height: int
+        @param width: Width of the input image.
+        @type width: int
+        """
+        self.input_shape = (width, height)
+
+    def setOutputLayerNames(
+        self, loc_output_layer_name, conf_output_layer_name, iou_output_layer_name
+    ):
+        """Sets the output layers.
+
+        @param loc_output_layer_name: Output layer name for the location predictions.
+        @type loc_output_layer_name: str
+        @param conf_output_layer_name: Output layer name for the confidence predictions.
+        @type conf_output_layer_name: str
+        @param iou_output_layer_name: Output layer name for the IoU predictions.
+        @type iou_output_layer_name: str
+        """
+        self.loc_output_layer_name = loc_output_layer_name
+        self.conf_output_layer_name = conf_output_layer_name
+        self.iou_output_layer_name = iou_output_layer_name
+
     def run(self):
         while self.isRunning():
             try:
@@ -85,84 +112,136 @@ class YuNetParser(dai.node.ThreadedHostNode):
             except dai.MessageQueue.QueueException:
                 break  # Pipeline was stopped
 
-            # get strides
-            strides = list(
-                set(
-                    [
-                        int(layer_name.split("_")[1])
-                        for layer_name in output.getAllLayerNames()
-                        if layer_name.startswith(("cls", "obj", "bbox", "kps"))
-                    ]
-                )
+            output_layer_names = output.getAllLayerNames()
+
+            # get loc
+            if self.loc_output_layer_name:
+                try:
+                    loc = output.getTensor(self.loc_output_layer_name, dequantize=True)
+                except KeyError as err:
+                    raise ValueError(
+                        f"Layer {self.loc_output_layer_name} not found in the model output."
+                    ) from err
+            else:
+                loc_output_layer_name_candidates = [
+                    layer_name
+                    for layer_name in output_layer_names
+                    if layer_name.startswith(("loc"))
+                ]
+                if len(loc_output_layer_name_candidates) == 0:
+                    raise ValueError(
+                        "No loc layer candidates found in the model output."
+                    )
+                elif len(loc_output_layer_name_candidates) > 1:
+                    raise ValueError(
+                        "Multiple loc layer candidates found in the model output."
+                    )
+                else:
+                    self.loc_output_layer_name = loc_output_layer_name_candidates[0]
+
+            # get conf
+            if self.conf_output_layer_name:
+                try:
+                    conf = output.getTensor(
+                        self.conf_output_layer_name, dequantize=True
+                    )
+                except KeyError as err:
+                    raise ValueError(
+                        f"Layer {self.conf_output_layer_name} not found in the model output."
+                    ) from err
+            else:
+                conf_output_layer_name_candidates = [
+                    layer_name
+                    for layer_name in output_layer_names
+                    if layer_name.startswith(("conf"))
+                ]
+                if len(conf_output_layer_name_candidates) == 0:
+                    raise ValueError(
+                        "No conf layer candidates found in the model output."
+                    )
+                elif len(conf_output_layer_name_candidates) > 1:
+                    raise ValueError(
+                        "Multiple conf layer candidates found in the model output."
+                    )
+                else:
+                    self.conf_output_layer_name = conf_output_layer_name_candidates[0]
+
+            # get iou
+            if self.iou_output_layer_name:
+                try:
+                    iou = output.getTensor(self.iou_output_layer_name, dequantize=True)
+                except KeyError as err:
+                    raise ValueError(
+                        f"Layer {self.iou_output_layer_name} not found in the model output."
+                    ) from err
+            else:
+                iou_output_layer_name_candidates = [
+                    layer_name
+                    for layer_name in output_layer_names
+                    if layer_name.startswith(("iou"))
+                ]
+                if len(iou_output_layer_name_candidates) == 0:
+                    raise ValueError(
+                        "No iou layer candidates found in the model output."
+                    )
+                elif len(iou_output_layer_name_candidates) > 1:
+                    raise ValueError(
+                        "Multiple iou layer candidates found in the model output."
+                    )
+                else:
+                    self.iou_output_layer_name = iou_output_layer_name_candidates[0]
+
+            loc = output.getTensor(self.loc_output_layer_name, dequantize=True)
+            conf = output.getTensor(self.conf_output_layer_name, dequantize=True)
+            iou = output.getTensor(self.iou_output_layer_name, dequantize=True)
+
+            # decode detections
+            bboxes, keypoints, scores = decode_detections(
+                input_shape=self.input_shape,
+                loc=loc,
+                conf=conf,
+                iou=iou,
             )
 
-            # get input_size
-            stride0 = strides[0]
-            cls_stride0_shape = output.getTensor(
-                f"cls_{stride0}", dequantize=True
-            ).shape
-            if len(cls_stride0_shape) == 3:
-                _, spatial_positions0, _ = cls_stride0_shape
-            elif len(cls_stride0_shape) == 2:
-                spatial_positions0, _ = cls_stride0_shape
-            input_width = input_height = int(
-                math.sqrt(spatial_positions0) * stride0
-            )  # TODO: We assume a square input size. How to get input size when height and width are not equal?
-            input_size = (input_width, input_height)
-
-            detections = []
-            for stride in strides:
-                cls = output.getTensor(f"cls_{stride}", dequantize=True)
-                cls = cls.astype(np.float32)
-                cls = cls.squeeze(0) if cls.shape[0] == 1 else cls
-
-                obj = output.getTensor(f"obj_{stride}", dequantize=True).flatten()
-                obj = obj.astype(np.float32)
-
-                bbox = output.getTensor(f"bbox_{stride}", dequantize=True)
-                bbox = bbox.astype(np.float32)
-                bbox = bbox.squeeze(0) if bbox.shape[0] == 1 else bbox
-
-                kps = output.getTensor(f"kps_{stride}", dequantize=True)
-                kps = kps.astype(np.float32)
-                kps = kps.squeeze(0) if kps.shape[0] == 1 else kps
-
-                detections += decode_detections(
-                    input_size,
-                    stride,
-                    self.conf_threshold,
-                    cls,
-                    obj,
-                    bbox,
-                    kps,
-                )
-
-            # non-maximum suppression
-            detection_boxes = [detection["bbox"] for detection in detections]
-            detection_scores = [detection["score"] for detection in detections]
-            indices = cv2.dnn.NMSBoxes(
-                detection_boxes,
-                detection_scores,
-                self.conf_threshold,
-                self.iou_threshold,
-                top_k=self.max_det,
+            # prune detections
+            bboxes, keypoints, scores = prune_detections(
+                bboxes=bboxes,
+                keypoints=keypoints,
+                scores=scores,
+                conf_threshold=self.conf_threshold,
             )
-            detections = np.array(detections)[indices]
 
-            bboxes = []
-            for detection in detections:
-                xmin, ymin, width, height = detection["bbox"]
-                bboxes.append([xmin, ymin, xmin + width, ymin + height])
-            scores = [detection["score"] for detection in detections]
-            labels = [detection["label"] for detection in detections]
-            keypoints = [detection["keypoints"] for detection in detections]
+            # format detections
+            bboxes, keypoints, scores = format_detections(
+                bboxes=bboxes,
+                keypoints=keypoints,
+                scores=scores,
+                input_shape=self.input_shape,
+            )
+
+            # run nms
+            keep_indices = nms_cv2(
+                bboxes=bboxes,
+                scores=scores,
+                conf_threshold=self.conf_threshold,
+                iou_threshold=self.iou_threshold,
+                max_det=self.max_det,
+            )
+
+            bboxes = bboxes[keep_indices]
+            keypoints = keypoints[keep_indices]
+            scores = scores[keep_indices]
+
+            bboxes = xywh2xyxy(bboxes)
+            keypoints = [
+                [tuple(keypoint) for keypoint in keypoint_set]
+                for keypoint_set in keypoints.tolist()
+            ]
 
             detections_message = create_detection_message(
-                np.array(bboxes),
-                np.array(scores),
-                labels,
-                keypoints,
+                bboxes=bboxes, scores=scores, keypoints=keypoints
             )
+
             detections_message.setTimestamp(output.getTimestamp())
 
             self.out.send(detections_message)

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -50,9 +50,12 @@ class YuNetParser(BaseParser):
         @param input_shape: Input shape of the model (width, height).
         @type input_shape: Tuple[int, int]
         """
-        dai.node.ThreadedHostNode.__init__(self)
-        self.input = self.createInput()
-        self.out = self.createOutput()
+        super().__init__()
+        self._out = self.createOutput(
+            possibleDatatypes=[
+                dai.Node.DatatypeHierarchy(dai.DatatypeEnum.ImgDetections, True)
+            ]
+        )
 
         self.conf_threshold = conf_threshold
         self.iou_threshold = iou_threshold
@@ -270,14 +273,9 @@ class YuNetParser(BaseParser):
             )
 
             bboxes = bboxes[keep_indices]
+            bboxes = xywh2xyxy(bboxes)
             keypoints = keypoints[keep_indices]
             scores = scores[keep_indices]
-
-            bboxes = xywh2xyxy(bboxes)
-            keypoints = [
-                [tuple(keypoint) for keypoint in keypoint_set]
-                for keypoint_set in keypoints.tolist()
-            ]
 
             detections_message = create_detection_message(
                 bboxes=bboxes, scores=scores, keypoints=keypoints

--- a/tests/unittests/test_creators/test_detections.py
+++ b/tests/unittests/test_creators/test_detections.py
@@ -81,7 +81,9 @@ def test_scores_length():
 
 
 def test_labels_list():
-    with pytest.raises(ValueError, match="Labels should be numpy array, got <class 'int'>."):
+    with pytest.raises(
+        ValueError, match="Labels should be numpy array, got <class 'int'>."
+    ):
         create_detection_message(
             np.array([[1.0, 2.0, 3.0, 4.0]]), np.array([0.1]), 1, None
         )

--- a/tests/unittests/test_creators/test_detections.py
+++ b/tests/unittests/test_creators/test_detections.py
@@ -60,7 +60,7 @@ def test_scores_not_numpy_array():
 def test_scores_shape():
     with pytest.raises(
         ValueError,
-        match=re.escape("Scores should be of shape (N,) meaning, got (1, 1)."),
+        match=re.escape("Scores should be of shape (N,), got (1, 1)."),
     ):
         create_detection_message(
             np.array([[1.0, 2.0, 3.0, 4.0]]), np.array([[0.1]]), None, None
@@ -70,7 +70,7 @@ def test_scores_shape():
 def test_scores_length():
     with pytest.raises(
         ValueError,
-        match=re.escape("Scores should have same length as bboxes, got 1 and 2."),
+        match=re.escape("Scores should have length N. Got 1 expected 2."),
     ):
         create_detection_message(
             np.array([[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]]),
@@ -81,7 +81,7 @@ def test_scores_length():
 
 
 def test_labels_list():
-    with pytest.raises(ValueError, match="Labels should be list, got <class 'int'>."):
+    with pytest.raises(ValueError, match="Labels should be numpy array, got <class 'int'>."):
         create_detection_message(
             np.array([[1.0, 2.0, 3.0, 4.0]]), np.array([0.1]), 1, None
         )
@@ -89,28 +89,19 @@ def test_labels_list():
 
 def test_labels_bbox_lengths():
     with pytest.raises(
-        ValueError, match="Labels should have same length as bboxes, got 1 and 2."
+        ValueError, match="Labels should have length N. Got 1 expected 2."
     ):
         create_detection_message(
             np.array([[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]]),
             np.array([0.1, 0.3]),
-            [1],
+            np.array([1]),
             None,
-        )
-
-
-def test_in_label_elements():
-    with pytest.raises(
-        ValueError, match="Labels should be list of integers, got <class 'str'>."
-    ):
-        create_detection_message(
-            np.array([[1.0, 2.0, 3.0, 4.0]]), np.array([0.1]), ["1"], None
         )
 
 
 def test_keypoints_list():
     with pytest.raises(
-        ValueError, match="Keypoints should be list, got <class 'int'>."
+        ValueError, match="Keypoints should be numpy array, got <class 'int'>."
     ):
         create_detection_message(
             np.array([[1.0, 2.0, 3.0, 4.0]]), np.array([0.1]), None, 1
@@ -119,13 +110,13 @@ def test_keypoints_list():
 
 def test_keypoints_bbox_lengths():
     with pytest.raises(
-        ValueError, match="Keypoints should have same length as bboxes, got 1 and 2."
+        ValueError, match="Keypoints should have length N. Got 1 expected 2."
     ):
         create_detection_message(
             np.array([[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]]),
             np.array([0.1, 0.3]),
             None,
-            [[(0, 0), (1, 1)]],
+            np.array([[(0, 0), (1, 1)]]),
         )
 
 
@@ -155,7 +146,7 @@ def test_bboxes_scores_labels():
         [[20.0, 20.0, 40.0, 40.0], [50.0, 50.0, 100.0, 100.0], [10.0, 10.0, 20.0, 20.0]]
     )
     scores = np.array([0.1, 0.2, 0.3])
-    labels = [1, 2, 3]
+    labels = np.array([1, 2, 3])
 
     message = create_detection_message(bboxes, scores, labels, None)
 
@@ -168,7 +159,7 @@ def test_bboxes_scores_keypoints():
         [[20.0, 20.0, 40.0, 40.0], [50.0, 50.0, 100.0, 100.0], [10.0, 10.0, 20.0, 20.0]]
     )
     scores = np.array([0.1, 0.2, 0.3])
-    keypoints = [[(0, 0), (1, 1)], [], [(4, 4), (5, 5), (6, 6)]]
+    keypoints = np.array([[(0, 0), (1, 1)], [(2, 2), (3, 3)], [(4, 4), (5, 5)]])
 
     message = create_detection_message(bboxes, scores, None, keypoints)
 


### PR DESCRIPTION
This PR adds a parsers-v2 refactor for `YuNetParser`, and adjusts `ImgDetectionExtended` message to accept the newly added `Keypoints` object and is also up-to-date with the newly planned changes that will get written in DAI. Detection message creator (`create_detection_message`) is also adjusted and now accepts only numpy arrays (this change also affects `MPPalmDetectionParser`, `SCRFDParser`, and `YOLOExtendedParser` which are not fixed in this PR).

NOTE: The PR also includes some pre-commit format fixing for the Regression parser and message.
