### PR TITLE
 Fix YuNet parser data types

### DIFF
--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -99,7 +99,7 @@ class ImgDetectionExtended(dai.ImgDetection):
         self._mask = value
 
 
-class ImgDetectionsExtended(dai.Buffer):
+class ImgDetectionsExtended(dai.ImgDetections):
     """ImgDetectionsExtended class for storing image detections with keypoints.
 
     Attributes
@@ -110,7 +110,7 @@ class ImgDetectionsExtended(dai.Buffer):
 
     def __init__(self):
         """Initializes the ImgDetectionsExtended object."""
-        dai.Buffer.__init__(self)  # TODO: change to super().__init__()?
+        dai.ImgDetections.__init__(self)  # TODO: change to super().__init__()?
         self._detections: List[ImgDetectionExtended] = []
 
     @property

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -48,7 +48,11 @@ class YuNetParser(dai.node.ThreadedHostNode):
         """
         dai.node.ThreadedHostNode.__init__(self)
         self.input = self.createInput()
-        self.out = self.createOutput()
+        self.out = self.createOutput(
+            possibleDatatypes=[
+                dai.Node.DatatypeHierarchy(dai.DatatypeEnum.ImgDetections, True)
+            ]
+        )
 
         self.conf_threshold = conf_threshold
         self.iou_threshold = iou_threshold


### PR DESCRIPTION
This PR fixes the issue with the `YuNet` parser not being able to connect its output to the detection parser's input.

Previously, the output could not be connected to the input because of the way `depthai-core` checks data types send around throughout the pipeline.

Additionally, this PR changes the parent type of the `ImgDetectionsExtended`, allowing `depthai-core` to dynamically cast it to `ImgDetections`. With the parent class being just `dai.Buffer`, `depthai-core` could not cast it and as a result would log an error message.

For more context, refer to [this](https://luxonis.slack.com/archives/C065PDYKNAK/p1727215341703719) conversation.

I removed the last PR as it was rather short and did not want to deal with re-basing.