### PR TITLE
Minor release preparation.

### DIFF
--- a/depthai_nodes/ml/messages/creators/classification.py
+++ b/depthai_nodes/ml/messages/creators/classification.py
@@ -66,7 +66,7 @@ def create_classification_message(
             f"Scores list must contain probabilities between 0 and 1, instead got {scores}."
         )
 
-    if not np.isclose(np.sum(scores), 1.0, atol=1e-2):
+    if not np.isclose(np.sum(scores), 1.0, atol=1e-1):
         raise ValueError(f"Scores should sum to 1, got {np.sum(scores)}.")
 
     if len(scores) != len(classes):

--- a/depthai_nodes/ml/parsers/classification.py
+++ b/depthai_nodes/ml/parsers/classification.py
@@ -123,8 +123,8 @@ class MultiClassificationParser(dai.node.ThreadedHostNode):
 
     def __init__(
         self,
-        classification_attributes: List[str],
-        classification_labels: List[List[str]],
+        classification_attributes: List[str] = None,
+        classification_labels: List[List[str]] = None,
     ):
         """Initializes the MultipleClassificationParser node."""
         dai.node.ThreadedHostNode.__init__(self)
@@ -133,7 +133,28 @@ class MultiClassificationParser(dai.node.ThreadedHostNode):
         self.classification_attributes: List[str] = classification_attributes
         self.classification_labels: List[List[str]] = classification_labels
 
+    def setClassificationAttributes(self, classification_attributes: List[str]):
+        """Sets the classification attributes for the multiple classification model.
+
+        @param classification_attributes: List of attributes to be classified.
+        @type classification_attributes: List[str]
+        """
+        self.classification_attributes = classification_attributes
+
+    def setClassificationLabels(self, classification_labels: List[List[str]]):
+        """Sets the classification labels for the multiple classification model.
+
+        @param classification_labels: List of class labels for each attribute.
+        @type classification_labels: List[List[str]]
+        """
+        self.classification_labels = classification_labels
+
     def run(self):
+        if not self.classification_attributes:
+            raise ValueError("Classification attributes must be provided.")
+        if not self.classification_labels:
+            raise ValueError("Classification labels must be provided.")
+
         while self.isRunning():
             try:
                 output: dai.NNData = self.input.get()

--- a/depthai_nodes/ml/parsers/keypoints.py
+++ b/depthai_nodes/ml/parsers/keypoints.py
@@ -53,6 +53,7 @@ class KeypointParser(dai.node.ThreadedHostNode):
 
         self.scale_factor = scale_factor
         self.n_keypoints = n_keypoints
+        self._warned = False
 
     def setScaleFactor(self, scale_factor):
         """Sets the scale factor to divide the keypoints by.
@@ -82,10 +83,11 @@ class KeypointParser(dai.node.ThreadedHostNode):
 
             output_layer_names = output.getAllLayerNames()
 
-            if len(output_layer_names) != 1:
-                raise ValueError(
-                    f"Expected 1 output layer, got {len(output_layer_names)}."
+            if len(output_layer_names) != 1 and not self._warned:
+                print(
+                    f"Expected 1 output layer, got {len(output_layer_names)}, will take the first one."
                 )
+                self._warned = True
 
             keypoints = output.getTensor(output_layer_names[0], dequantize=True).astype(
                 np.float32

--- a/depthai_nodes/ml/parsers/segmentation.py
+++ b/depthai_nodes/ml/parsers/segmentation.py
@@ -39,6 +39,7 @@ class SegmentationParser(dai.node.ThreadedHostNode):
         self.input = self.createInput()
         self.out = self.createOutput()
         self.background_class = background_class
+        self._warned = False
 
     def setBackgroundClass(self, background_class):
         """Sets the background class.
@@ -57,10 +58,11 @@ class SegmentationParser(dai.node.ThreadedHostNode):
 
             output_layer_names = output.getAllLayerNames()
 
-            if len(output_layer_names) != 1:
+            if len(output_layer_names) != 1 and not self._warned:
                 print(
                     f"Expected 1 output layer, got {len(output_layer_names)}. Will take the first one."
                 )
+                self._warned = True
 
             segmentation_mask = output.getTensor(output_layer_names[0], dequantize=True)
             if len(segmentation_mask.shape) == 4:

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,3 +35,7 @@ python main.py -s yolov6-nano:coco-416x416 -fps 28
 Some models have small input sizes and requesting small image size from `Camera` is problematic so we request 4x bigger frame and resize it back down. During visualization image frame is resized back so some image quality is lost - only for visualization.
 
 The parser is obtained from NN archive along with other important parameters for the parser. So, make sure your NN archive is well-defined.
+
+### XFeat
+
+If you want to run xfeat demo you have two options available - to run it in `Stereo` mode or `Mono` mode depending on the nn archive you provided. If the NN archive requires `XFeatMonoParser` then the mono mode will be used, otherwise the stereo mode will be used (`XFeatStereoParser`). For the stereo mode you need OAK camera which has left and right cameras, if not the error will be raised. If you use mono mode you can set the reference frame to which all the other frames will be compared to. The reference frame is set by triggering - pressing `S` key.

--- a/examples/main.py
+++ b/examples/main.py
@@ -2,6 +2,7 @@ import depthai as dai
 from utils.arguments import initialize_argparser, parse_fps_limit, parse_model_slug
 from utils.model import get_input_shape, get_model_from_hub, get_parser
 from utils.parser import setup_parser
+from utils.xfeat import xfeat_mono, xfeat_stereo
 from visualization.visualize import visualize
 
 # Initialize the argument parser
@@ -18,8 +19,12 @@ nn_archive = get_model_from_hub(model_slug, model_version_slug)
 parser_class, parser_name = get_parser(nn_archive)
 input_shape = get_input_shape(nn_archive)
 
-if parser_name == "XFeatParser":
-    raise NotImplementedError("XFeatParser is not supported in this script yet.")
+if parser_name == "XFeatMonoParser":
+    xfeat_mono(nn_archive, input_shape, fps_limit)
+    exit(0)
+elif parser_name == "XFeatStereoParser":
+    xfeat_stereo(nn_archive, input_shape, fps_limit)
+    exit(0)
 
 # Create the pipeline
 with dai.Pipeline() as pipeline:

--- a/examples/utils/parser.py
+++ b/examples/utils/parser.py
@@ -7,9 +7,10 @@ from depthai_nodes.ml.parsers import (
     LaneDetectionParser,
     MapOutputParser,
     MPPalmDetectionParser,
+    MultiClassificationParser,
+    PaddleOCRParser,
     SCRFDParser,
     SegmentationParser,
-    XFeatParser,
     YOLOExtendedParser,
 )
 
@@ -76,18 +77,6 @@ def setup_map_output_parser(parser: MapOutputParser, params: dict):
         )
 
 
-def setup_xfeat_parser(parser: XFeatParser, params: dict):
-    """Setup the XFeat parser with the required metadata."""
-    try:
-        input_size = params["input_size"]
-        parser.setInputSize(input_size)
-        parser.setOriginalSize(input_size)
-    except Exception:
-        print(
-            "This NN archive does not have required metadata for XFeatParser. Skipping setup..."
-        )
-
-
 def setup_yolo_extended_parser(parser: YOLOExtendedParser, params: dict):
     """Setup the YOLO parser with the required metadata."""
     try:
@@ -142,6 +131,30 @@ def setup_fastsam_parser(parser: FastSAMParser, params: dict):
         )
 
 
+def setup_paddleocr_parser(parser: PaddleOCRParser, params: dict):
+    """Setup the PaddleOCR parser with the required metadata."""
+    try:
+        classes = params["classes"]
+        parser.setClasses(classes)
+    except Exception:
+        print(
+            "This NN archive does not have required metadata for PaddleOCRParser. Skipping setup..."
+        )
+
+
+def setup_multi_classification_parser(parser: MultiClassificationParser, params: dict):
+    """Setup the Multi Classification parser with the required metadata."""
+    try:
+        classification_attributes = params["classification_attributes"]
+        classification_labels = params["classification_labels"]
+        parser.setClassificationAttributes(classification_attributes)
+        parser.setClassificationLabels(classification_labels)
+    except Exception:
+        print(
+            "This NN archive does not have required metadata for MultiClassificationParser. Skipping setup..."
+        )
+
+
 def setup_parser(parser: dai.ThreadedNode, nn_archive: dai.NNArchive, parser_name: str):
     """Setup the parser with the NN archive."""
 
@@ -159,8 +172,6 @@ def setup_parser(parser: dai.ThreadedNode, nn_archive: dai.NNArchive, parser_nam
         setup_classification_parser(parser, extraParams)
     elif parser_name == "MapOutputParser":
         setup_map_output_parser(parser, extraParams)
-    elif parser_name == "XFeatParser":
-        setup_xfeat_parser(parser, extraParams)
     elif parser_name == "YOLOExtendedParser":
         setup_yolo_extended_parser(parser, extraParams)
     elif parser_name == "MPPalmDetectionParser":
@@ -169,3 +180,7 @@ def setup_parser(parser: dai.ThreadedNode, nn_archive: dai.NNArchive, parser_nam
         setup_land_detection_parser(parser, extraParams)
     elif parser_name == "FastSAMParser":
         setup_fastsam_parser(parser, extraParams)
+    elif parser_name == "PaddleOCRParser":
+        setup_paddleocr_parser(parser, extraParams)
+    elif parser_name == "MultiClassificationParser":
+        setup_multi_classification_parser(parser, extraParams)

--- a/examples/utils/xfeat.py
+++ b/examples/utils/xfeat.py
@@ -107,7 +107,7 @@ def xfeat_stereo(nn_archive: dai.NNArchive, input_shape: List[int], fps_limit: i
         parser = pipeline.create(XFeatStereoParser)
         parser.setOriginalSize(input_shape)
         parser.setInputSize(input_shape)
-        parser.setMaxKeypoints(4096)
+        parser.setMaxKeypoints(512)
 
         left_network.out.link(parser.reference_input)
         right_network.out.link(parser.target_input)
@@ -124,7 +124,9 @@ def xfeat_stereo(nn_archive: dai.NNArchive, input_shape: List[int], fps_limit: i
             features: dai.TrackedFeatures = parser_queue.get()
             features = features.trackedFeatures
 
-            resulting_frame = xfeat_visualizer(left_frame, right_frame, features)
+            resulting_frame = xfeat_visualizer(
+                left_frame, right_frame, features, draw_warp_corners=False
+            )
             number_of_matches = len(features) // 2
             cv2.putText(
                 resulting_frame,

--- a/examples/utils/xfeat.py
+++ b/examples/utils/xfeat.py
@@ -1,0 +1,143 @@
+from typing import List
+
+import cv2
+import depthai as dai
+from visualization.visualizers import xfeat_visualizer
+
+from depthai_nodes.ml.parsers import XFeatMonoParser, XFeatStereoParser
+
+
+def xfeat_mono(nn_archive: dai.NNArchive, input_shape: List[int], fps_limit: int):
+    """Run the XFeatMonoParser on a single camera.
+
+    It lets you set the reference frame by pressing S-key.
+    """
+    previous_frame = None
+    with dai.Pipeline() as pipeline:
+        # Set up camera
+        cam = pipeline.create(dai.node.Camera).build()
+
+        # Set up the neural network
+        network = pipeline.create(dai.node.NeuralNetwork).build(
+            cam.requestOutput(
+                input_shape, type=dai.ImgFrame.Type.BGR888p, fps=fps_limit
+            ),
+            nn_archive,
+        )
+
+        # Set up parser
+        parser = XFeatMonoParser()
+        parser.setOriginalSize(input_shape)
+        parser.setInputSize(input_shape)
+        parser.setMaxKeypoints(2048)
+
+        # Linking
+        network.out.link(parser.input)
+
+        # Set up queue
+        camera_queue = network.passthrough.createOutputQueue()
+        parser_queue = parser.out.createOutputQueue()
+
+        pipeline.start()
+
+        while pipeline.isRunning():
+            frame: dai.ImgFrame = camera_queue.get().getCvFrame()
+            message: dai.TrackedFeatures = (
+                parser_queue.get()
+            )  # get message from the queue
+            features = message.trackedFeatures
+            if previous_frame is not None:
+                resulting_frame = xfeat_visualizer(previous_frame, frame, features)
+            else:
+                resulting_frame = frame
+            number_of_matches = len(features) // 2
+            cv2.putText(
+                resulting_frame,
+                f"Number of matches: {number_of_matches}",
+                (10, 30),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (255, 255, 255),
+                1,
+            )
+            cv2.imshow("XFeat", resulting_frame)
+
+            key_pressed = cv2.waitKey(1)
+            if key_pressed == ord("s"):
+                parser.setTrigger()  # trigger to set the reference frame
+                previous_frame = frame
+            if key_pressed == ord("q"):
+                cv2.destroyAllWindows()
+                pipeline.stop()
+                break
+
+
+def xfeat_stereo(nn_archive: dai.NNArchive, input_shape: List[int], fps_limit: int):
+    """Run the XFeatStereoParser on stereo cameras - left and right - and match the features."""
+    with dai.Pipeline() as pipeline:
+        device: dai.Device = pipeline.getDefaultDevice()
+        available_cameras = [
+            camera.name for camera in device.getConnectedCameraFeatures()
+        ]
+
+        if "left" not in available_cameras or "right" not in available_cameras:
+            raise RuntimeError(
+                f"Stereo cameras are not available! Available cameras: {available_cameras}"
+            )
+
+        left_cam = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_B)
+        right_cam = pipeline.create(dai.node.Camera).build(dai.CameraBoardSocket.CAM_C)
+
+        left_network = pipeline.create(dai.node.NeuralNetwork).build(
+            left_cam.requestOutput(
+                input_shape, type=dai.ImgFrame.Type.RGB888p, fps=fps_limit
+            ),
+            nn_archive,
+        )
+        left_network.setNumInferenceThreads(2)
+
+        right_network = pipeline.create(dai.node.NeuralNetwork).build(
+            right_cam.requestOutput(
+                input_shape, type=dai.ImgFrame.Type.RGB888p, fps=fps_limit
+            ),
+            nn_archive,
+        )
+        right_network.setNumInferenceThreads(2)
+
+        parser = pipeline.create(XFeatStereoParser)
+        parser.setOriginalSize(input_shape)
+        parser.setInputSize(input_shape)
+        parser.setMaxKeypoints(4096)
+
+        left_network.out.link(parser.reference_input)
+        right_network.out.link(parser.target_input)
+
+        left_cam_queue = left_network.passthrough.createOutputQueue()
+        right_cam_queue = right_network.passthrough.createOutputQueue()
+        parser_queue = parser.out.createOutputQueue()
+
+        pipeline.start()
+
+        while pipeline.isRunning():
+            left_frame: dai.ImgFrame = left_cam_queue.get().getCvFrame()
+            right_frame: dai.ImgFrame = right_cam_queue.get().getCvFrame()
+            features: dai.TrackedFeatures = parser_queue.get()
+            features = features.trackedFeatures
+
+            resulting_frame = xfeat_visualizer(left_frame, right_frame, features)
+            number_of_matches = len(features) // 2
+            cv2.putText(
+                resulting_frame,
+                f"Number of matches: {number_of_matches}",
+                (10, 30),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (255, 255, 255),
+                1,
+            )
+            cv2.imshow("XFeat Stereo", resulting_frame)
+
+            if cv2.waitKey(1) == ord("q"):
+                cv2.destroyAllWindows()
+                pipeline.stop()
+                break

--- a/examples/visualization/visualize.py
+++ b/examples/visualization/visualize.py
@@ -10,7 +10,10 @@ from .visualizers import (
     visualize_lane_detections,
     visualize_line_detections,
     visualize_map,
+    visualize_multi_classification,
     visualize_segmentation,
+    visualize_text_detection,
+    visualize_text_recognition,
     visualize_yolo_extended,
 )
 
@@ -33,6 +36,9 @@ visualizers_dict = {
     "YOLOExtendedParser": visualize_yolo_extended,
     "LaneDetectionParser": visualize_lane_detections,
     "FastSAMParser": visualize_fastsam,
+    "PPTextDetectionParser": visualize_text_detection,
+    "PaddleOCRParser": visualize_text_recognition,
+    "MultiClassificationParser": visualize_multi_classification,
 }
 
 

--- a/examples/visualization/visualizers/__init__.py
+++ b/examples/visualization/visualizers/__init__.py
@@ -15,6 +15,7 @@ from .image import visualize_image
 from .keypoints import visualize_keypoints
 from .map import visualize_map
 from .segmentation import visualize_fastsam, visualize_segmentation
+from .xfeat import xfeat_visualizer
 
 __all__ = [
     "visualize_image",
@@ -31,4 +32,5 @@ __all__ = [
     "visualize_text_detection",
     "visualize_text_recognition",
     "visualize_multi_classification",
+    "xfeat_visualizer",
 ]

--- a/examples/visualization/visualizers/__init__.py
+++ b/examples/visualization/visualizers/__init__.py
@@ -1,8 +1,14 @@
-from .classification import visualize_age_gender, visualize_classification
+from .classification import (
+    visualize_age_gender,
+    visualize_classification,
+    visualize_multi_classification,
+    visualize_text_recognition,
+)
 from .detection import (
     visualize_detections,
     visualize_lane_detections,
     visualize_line_detections,
+    visualize_text_detection,
     visualize_yolo_extended,
 )
 from .image import visualize_image
@@ -22,4 +28,7 @@ __all__ = [
     "visualize_line_detections",
     "visualize_lane_detections",
     "visualize_fastsam",
+    "visualize_text_detection",
+    "visualize_text_recognition",
+    "visualize_multi_classification",
 ]

--- a/examples/visualization/visualizers/classification.py
+++ b/examples/visualization/visualizers/classification.py
@@ -1,10 +1,12 @@
 import cv2
 import depthai as dai
+import numpy as np
 
 from depthai_nodes.ml.messages import Classifications, CompositeMessage
 
 from .utils.message_parsers import (
     parse_classification_message,
+    parse_multi_classification_message,
     parser_age_gender_message,
 )
 
@@ -36,6 +38,35 @@ def visualize_classification(
     return False
 
 
+def visualize_multi_classification(
+    frame: dai.ImgFrame, message: Classifications, extraParams: dict
+):
+    """Visualizes the multi classification on the frame."""
+    parsed_message = parse_multi_classification_message(message)
+    if frame.shape[0] < 128:
+        frame = cv2.resize(frame, (frame.shape[1] * 2, frame.shape[0] * 2))
+
+    for i, atribute in enumerate(parsed_message.keys()):
+        classes = parsed_message[atribute]["classes"]
+        scores = parsed_message[atribute]["scores"]
+        predicted_class = classes[np.argmax(scores)]
+        cv2.putText(
+            frame,
+            f"{atribute}: {predicted_class}",
+            (10, 20 + 20 * i),
+            cv2.FONT_HERSHEY_TRIPLEX,
+            0.3,
+            255,
+        )
+
+    cv2.imshow("Multi Classification", frame)
+    if cv2.waitKey(1) == ord("q"):
+        cv2.destroyAllWindows()
+        return True
+
+    return False
+
+
 def visualize_age_gender(
     frame: dai.ImgFrame, message: CompositeMessage, extraParams: dict
 ):
@@ -55,6 +86,26 @@ def visualize_age_gender(
         )
 
     cv2.imshow("Age-gender", frame)
+    if cv2.waitKey(1) == ord("q"):
+        cv2.destroyAllWindows()
+        return True
+
+    return False
+
+
+def visualize_text_recognition(
+    frame: dai.ImgFrame, message: CompositeMessage, extraParams: dict
+):
+    """Visualizes the text recognition on the frame."""
+
+    if frame.shape[0] < 128:
+        frame = cv2.resize(frame, (frame.shape[1] * 2, frame.shape[0] * 2))
+
+    classes, scores = parse_classification_message(message)
+    text = "".join(classes)
+    cv2.putText(frame, text, (10, 20), cv2.FONT_HERSHEY_TRIPLEX, 0.5, 255)
+
+    cv2.imshow("Text recognition", frame)
     if cv2.waitKey(1) == ord("q"):
         cv2.destroyAllWindows()
         return True

--- a/examples/visualization/visualizers/detection.py
+++ b/examples/visualization/visualizers/detection.py
@@ -2,11 +2,17 @@ import cv2
 import depthai as dai
 import numpy as np
 
-from depthai_nodes.ml.messages import Clusters, ImgDetectionsExtended, Lines
+from depthai_nodes.ml.messages import (
+    Clusters,
+    CornerDetections,
+    ImgDetectionsExtended,
+    Lines,
+)
 
 from .utils.colors import get_yolo_colors
 from .utils.message_parsers import (
     parse_cluster_message,
+    parse_corner_detection_message,
     parse_detection_message,
     parse_line_detection_message,
     parse_yolo_kpts_message,
@@ -202,6 +208,44 @@ def visualize_lane_detections(
             )
 
     cv2.imshow("Lane Detection", frame)
+    if cv2.waitKey(1) == ord("q"):
+        cv2.destroyAllWindows()
+        return True
+
+    return False
+
+
+def visualize_text_detection(
+    frame: dai.ImgFrame, message: CornerDetections, extraParams: dict
+):
+    detections = parse_corner_detection_message(message)
+    for detection in detections:
+        for i in range(len(detection.keypoints)):
+            cv2.circle(
+                frame,
+                (int(detection.keypoints[i].x), int(detection.keypoints[i].y)),
+                3,
+                (0, 255, 0),
+                -1,
+            )
+            if i == len(detection.keypoints) - 1:
+                cv2.line(
+                    frame,
+                    (int(detection.keypoints[i].x), int(detection.keypoints[i].y)),
+                    (int(detection.keypoints[0].x), int(detection.keypoints[0].y)),
+                    (0, 255, 0),
+                    2,
+                )
+                break
+            cv2.line(
+                frame,
+                (int(detection.keypoints[i].x), int(detection.keypoints[i].y)),
+                (int(detection.keypoints[i + 1].x), int(detection.keypoints[i + 1].y)),
+                (0, 255, 0),
+                2,
+            )
+
+    cv2.imshow("Text Detection", frame)
     if cv2.waitKey(1) == ord("q"):
         cv2.destroyAllWindows()
         return True

--- a/examples/visualization/visualizers/utils/message_parsers.py
+++ b/examples/visualization/visualizers/utils/message_parsers.py
@@ -4,6 +4,7 @@ from depthai_nodes.ml.messages import (
     Classifications,
     Clusters,
     CompositeMessage,
+    CornerDetections,
     ImgDetectionsExtended,
     Keypoints,
     Lines,
@@ -42,6 +43,17 @@ def parse_classification_message(message: Classifications):
     classes = message.classes
     scores = message.scores
     return classes, scores
+
+
+def parse_multi_classification_message(message: CompositeMessage):
+    """Parses the multi classification message and returns the classification."""
+    message = message.getData()
+    result = {}
+    for key in message:
+        classes = message[key].classes
+        scores = message[key].scores
+        result[key] = {"classes": classes, "scores": scores}
+    return result
 
 
 def parse_image_message(message: dai.ImgFrame):
@@ -83,3 +95,9 @@ def parse_map_message(message: Map2D):
     """Parses the map message and returns the map."""
     map = message.map
     return map
+
+
+def parse_corner_detection_message(message: CornerDetections):
+    """Parses the corner detection message and returns the corners."""
+    detections = message.detections
+    return detections

--- a/examples/visualization/visualizers/xfeat.py
+++ b/examples/visualization/visualizers/xfeat.py
@@ -1,0 +1,72 @@
+import cv2
+import numpy as np
+
+
+def calc_warp_corners_and_matches(
+    ref_points: np.ndarray,
+    dst_points: np.ndarray,
+    image1: np.ndarray,
+):
+    H, mask = cv2.findHomography(
+        ref_points,
+        dst_points,
+        cv2.USAC_MAGSAC,
+        13.5,
+        maxIters=1_000,
+        confidence=0.8,
+    )
+    mask = mask.flatten()
+
+    h, w = image1.shape[:2]
+    corners_image1 = np.array(
+        [[0, 0], [w - 1, 0], [w - 1, h - 1], [0, h - 1]], dtype=np.float32
+    ).reshape(-1, 1, 2)
+
+    warped_corners = cv2.perspectiveTransform(corners_image1, H)
+
+    keypoints1 = [cv2.KeyPoint(p[0], p[1], 5) for p in ref_points]
+    keypoints2 = [cv2.KeyPoint(p[0], p[1], 5) for p in dst_points]
+    matches = [cv2.DMatch(i, i, 0) for i in range(len(mask)) if mask[i]]
+
+    return warped_corners, [keypoints1, keypoints2, matches]
+
+
+def xfeat_visualizer(image1, image2, features):
+    n = len(features)
+    if n < 50:
+        return image2
+
+    ref_feats = features[0:n:2]
+    tgt_feats = features[1:n:2]
+    mkpts0 = np.array([[x.position.x, x.position.y] for x in ref_feats])
+    mkpts1 = np.array([[x.position.x, x.position.y] for x in tgt_feats])
+
+    result = calc_warp_corners_and_matches(
+        mkpts0,
+        mkpts1,
+        image1,
+    )
+
+    warped_corners = result[0]
+    keypoints1 = result[1][0]
+    keypoints2 = result[1][1]
+    matches = result[1][2]
+
+    image2_with_corners = image2.copy()
+    for i in range(len(warped_corners)):
+        start_point = tuple(warped_corners[i - 1][0].astype(int))
+        end_point = tuple(warped_corners[i][0].astype(int))
+        cv2.line(image2_with_corners, start_point, end_point, (0, 255, 0), 4)
+
+    debug_image = cv2.drawMatches(
+        image1,
+        keypoints1,
+        image2_with_corners,
+        keypoints2,
+        matches,
+        None,
+        matchColor=(0, 255, 0),
+        flags=2,
+    )
+
+    return debug_image

--- a/examples/visualization/visualizers/xfeat.py
+++ b/examples/visualization/visualizers/xfeat.py
@@ -31,7 +31,7 @@ def calc_warp_corners_and_matches(
     return warped_corners, [keypoints1, keypoints2, matches]
 
 
-def xfeat_visualizer(image1, image2, features):
+def xfeat_visualizer(image1, image2, features, draw_warp_corners=True):
     n = len(features)
     if n < 50:
         return image2
@@ -53,10 +53,11 @@ def xfeat_visualizer(image1, image2, features):
     matches = result[1][2]
 
     image2_with_corners = image2.copy()
-    for i in range(len(warped_corners)):
-        start_point = tuple(warped_corners[i - 1][0].astype(int))
-        end_point = tuple(warped_corners[i][0].astype(int))
-        cv2.line(image2_with_corners, start_point, end_point, (0, 255, 0), 4)
+    if draw_warp_corners:
+        for i in range(len(warped_corners)):
+            start_point = tuple(warped_corners[i - 1][0].astype(int))
+            end_point = tuple(warped_corners[i][0].astype(int))
+            cv2.line(image2_with_corners, start_point, end_point, (0, 255, 0), 4)
 
     debug_image = cv2.drawMatches(
         image1,

--- a/tests/unittests/test_creators/test_classification.py
+++ b/tests/unittests/test_creators/test_classification.py
@@ -58,7 +58,7 @@ def test_mixed_scores():
 
 def test_non_probability_scores():
     with pytest.raises(ValueError):
-        create_classification_message(["cat", "dog", "bird"], [0.2, 0.3, 0.4])
+        create_classification_message(["cat", "dog", "bird"], [0.2, 0.3, 0.1])
 
 
 def test_non_probability_scores_2():
@@ -66,22 +66,22 @@ def test_non_probability_scores_2():
         create_classification_message(["cat", "dog", "bird"], [0.5, 0.5, 0.5])
 
 
-def test_sum_above_upper_thr():  # upper thr is 1.01001001
+def test_sum_above_upper_thr():
     with pytest.raises(ValueError):
-        create_classification_message(["cat", "dog", "bird"], [0.5, 0.11001001, 0.4])
+        create_classification_message(["cat", "dog", "bird"], [0.5, 0.21, 0.4])
 
 
 def test_sum_below_upper_thr():
     create_classification_message(["cat", "dog", "bird"], [0.5, 0.11001000, 0.4])
 
 
-def test_sum_above_lower_thr():  # lower thr is 0.98999001
-    create_classification_message(["cat", "dog", "bird"], [0.5, 0.18999001, 0.3])
+def test_sum_above_lower_thr():
+    create_classification_message(["cat", "dog", "bird"], [0.5, 0.2, 0.3])
 
 
 def test_sum_below_bottom_thr():
     with pytest.raises(ValueError):
-        create_classification_message(["cat", "dog", "bird"], [0.5, 0.18999, 0.3])
+        create_classification_message(["cat", "dog", "bird"], [0.5, 0.9, 0.3])
 
 
 def test_mismatch_lengths():


### PR DESCRIPTION
In this PR we add support in examples for unsupported parsers including:
- MultiClassificationParser
- PaddleOCRParser
- PPTextDetectionParser
- XFeat Mono and Stereo parsers

XFeat example is a bit different so it is not implemented in the general example flow but its rather in its own function.

Next, I extended the MultiClassificationParser because it didnt have set methods. I also increased the tolerance in probability scores validation - if the scores sum to 1. The problem was with efficientnet-lite becuase it predicts 1000 classes so sometimes it didnt meet the criteria (maybe rounding errors or something?).

I adjusted Segmentation and Keypoint parsers so the warning (`Expected 1 output layer, got .... Taking the first one`) is not spammed in real time but rather only printed once.