### PR TITLE
Fix: ParsingNeuralNetwork and ParserGenerator

### DIFF
--- a/depthai_nodes/ml/parsers/__init__.py
+++ b/depthai_nodes/ml/parsers/__init__.py
@@ -10,7 +10,6 @@ from .lane_detection import LaneDetectionParser
 from .map_output import MapOutputParser
 from .mediapipe_palm_detection import MPPalmDetectionParser
 from .mlsd import MLSDParser
-from .parser_generator import ParserGenerator
 from .ppdet import PPTextDetectionParser
 from .regression import RegressionParser
 from .scrfd import SCRFDParser
@@ -40,7 +39,6 @@ __all__ = [
     "MapOutputParser",
     "ClassificationSequenceParser",
     "LaneDetectionParser",
-    "ParserGenerator",
     "BaseParser",
     "DetectionParser",
 ]

--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -44,8 +44,6 @@ class ParserGenerator(dai.node.ThreadedHostNode):
         parsers = {}
         pipeline = self.getParentPipeline()
 
-        
-
         for index, head in zip(indexes, heads):
             parser_name = head.parser
             parser = globals().get(parser_name)

--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -2,9 +2,9 @@ from typing import Dict
 
 import depthai as dai
 
-from . import *
-from .base_parser import BaseParser
-from .utils import decode_head
+from .ml.parsers import *
+from .ml.parsers.base_parser import BaseParser
+from .ml.parsers.utils import decode_head
 
 
 class ParserGenerator(dai.node.ThreadedHostNode):
@@ -31,7 +31,7 @@ class ParserGenerator(dai.node.ThreadedHostNode):
         parsers: Dict[int : BaseParser]
             A dictionary of instantiated parsers.
         """
-        heads = nn_archive.getConfig().getConfigV1().model.heads
+        heads = nn_archive.getConfig().model.heads
         indexes = range(len(heads))
 
         if len(heads) == 0:
@@ -43,6 +43,8 @@ class ParserGenerator(dai.node.ThreadedHostNode):
 
         parsers = {}
         pipeline = self.getParentPipeline()
+
+        
 
         for index, head in zip(indexes, heads):
             parser_name = head.parser

--- a/depthai_nodes/parsing_neural_network.py
+++ b/depthai_nodes/parsing_neural_network.py
@@ -40,10 +40,16 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         self._parsers: dict[int, BaseParser] = {}
 
     @overload
-    def method(self, input: dai.Node.Output, nn_source: dai.NNModelDescription, fps: int) -> "ParsingNeuralNetwork": ...
-    
+    def method(
+        self, input: dai.Node.Output, nn_source: dai.NNModelDescription, fps: int
+    ) -> "ParsingNeuralNetwork":
+        ...
+
     @overload
-    def method(self, input: dai.Node.Output, nn_source: dai.NNArchive, fps: int) -> "ParsingNeuralNetwork": ...
+    def method(
+        self, input: dai.Node.Output, nn_source: dai.NNArchive, fps: int
+    ) -> "ParsingNeuralNetwork":
+        ...
 
     def build(
         self,

--- a/depthai_nodes/parsing_neural_network.py
+++ b/depthai_nodes/parsing_neural_network.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Union
+from typing import overload
 
 import depthai as dai
 
@@ -39,10 +39,16 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         self._nn = self._pipeline.create(dai.node.NeuralNetwork)
         self._parsers: dict[int, BaseParser] = {}
 
+    @overload
+    def method(self, input: dai.Node.Output, nn_source: dai.NNModelDescription, fps: int) -> "ParsingNeuralNetwork": ...
+    
+    @overload
+    def method(self, input: dai.Node.Output, nn_source: dai.NNArchive, fps: int) -> "ParsingNeuralNetwork": ...
+
     def build(
         self,
         input: dai.Node.Output,
-        nn_source: Union[dai.NNModelDescription, dai.NNArchive],
+        nn_source,
         fps: int = None,
     ) -> "ParsingNeuralNetwork":
         """Builds the underlying NeuralNetwork node and creates parser nodes for each


### PR DESCRIPTION
Adding a small change to the `ParsingNeuralNetwork` build method which now also accepts `dai.NNModelDescription` (next to `dai.NNArchive`). This is done to allow abstracted pipeline creation as shown in the DAI example [HERE](https://github.com/luxonis/depthai-core/blob/v3_develop/examples/python/NeuralNetwork/neural_network.py).

Moreover, ParserGenerator is moved one level higher to prevent errors with getting parser classes from the globals (`globals().get(parser_name)`).