### PR TITLE
Parsers-V2: Refactor FastSAM & YOLO fixes.

### DIFF
--- a/depthai_nodes/ml/messages/creators/detection.py
+++ b/depthai_nodes/ml/messages/creators/detection.py
@@ -32,11 +32,13 @@ def create_detection_message(
     @type angles: Optional[np.ndarray]
     @param labels: Labels of detected objects of shape (N,).
     @type labels: Optional[np.ndarray]
-    @param keypoints: Keypoints of detected objects of shape (N,2) or (N,3).
+    @param keypoints: Keypoints of detected objects of shape (N, n_keypoints, dim) where
+        dim is 2 or 3.
     @type keypoints: Optional[np.array]
     @param masks: Masks of detected objects of shape (N, H, W).
     @type masks: Optional[np.ndarray]
-    @param keypoints_scores: Confidence scores of detected keypoints of shape (N,).
+    @param keypoints_scores: Confidence scores of detected keypoints of shape (N,
+        n_keypoints, 1).
     @type keypoints_scores: Optional[np.ndarray]
     @return: Message containing the bounding boxes, labels, confidence scores, and
         keypoints of detected objects.

--- a/depthai_nodes/ml/messages/creators/detection.py
+++ b/depthai_nodes/ml/messages/creators/detection.py
@@ -17,6 +17,7 @@ def create_detection_message(
     labels: np.ndarray = None,
     keypoints: np.ndarray = None,
     masks: np.ndarray = None,
+    keypoints_scores: np.ndarray = None,
 ) -> ImgDetectionsExtended:
     """Create a DepthAI message for object detection. The message contains the bounding
     boxes in X_center, Y_center, Width, Height format with optional angles, labels and
@@ -35,6 +36,8 @@ def create_detection_message(
     @type keypoints: Optional[np.array]
     @param masks: Masks of detected objects of shape (N, H, W).
     @type masks: Optional[np.ndarray]
+    @param keypoints_scores: Confidence scores of detected keypoints of shape (N,).
+    @type keypoints_scores: Optional[np.ndarray]
     @return: Message containing the bounding boxes, labels, confidence scores, and
         keypoints of detected objects.
     @rtype: ImgDetectionsExtended
@@ -51,6 +54,11 @@ def create_detection_message(
     @raise ValueError: If the masks are not a 3D numpy array of shape (img_height,
         img_width, N) or (N, img_height, img_width).
     @raise ValueError: If the masks are not in the range [0, 1].
+    @raise ValueError: If the keypoints scores are not a numpy array.
+    @raise ValueError: If the keypoints scores are not of shape [n_detections,
+        n_keypoints, 1].
+    @raise ValueError: If the keypoints scores do not have the same length as keypoints.
+    @raise ValueError: If the keypoints scores are not between 0 and 1.
     """
 
     if not isinstance(bboxes, np.ndarray):
@@ -118,6 +126,30 @@ def create_detection_message(
                 f"Keypoints should be of dimension 2 or 3 e.g. [x, y] or [x, y, z], got {dim} dimensions."
             )
 
+    if keypoints_scores is not None:
+        if keypoints is None:
+            raise ValueError(
+                "Keypoints scores should be provided only if keypoints are provided."
+            )
+        if not isinstance(keypoints_scores, np.ndarray):
+            raise ValueError(
+                f"Keypoints scores should be a numpy array, got {type(keypoints_scores)}."
+            )
+
+        n_detections, n_keypoints, _ = keypoints.shape
+        if keypoints_scores.shape[0] != n_detections:
+            raise ValueError(
+                f"Keypoints scores should have same length as keypoints, got {len(keypoints_scores)} and {n_detections}."
+            )
+
+        if keypoints_scores.shape[1] != n_keypoints:
+            raise ValueError(
+                f"Number of keypoints scores per detection should be the same as number of keypoints per detection, got {keypoints_scores.shape[1]} and {n_keypoints}."
+            )
+
+        if not all(0 <= score <= 1 for score in keypoints_scores.flatten()):
+            raise ValueError("Keypoints scores should be between 0 and 1.")
+
     detections = []
     for detection_idx in range(n_bboxes):
         detection = ImgDetectionExtended()
@@ -133,7 +165,12 @@ def create_detection_message(
         if labels is not None:
             detection.label = labels[detection_idx].item()
         if keypoints is not None:
-            detection.keypoints = transform_to_keypoints(keypoints[detection_idx])
+            if keypoints_scores is not None:
+                detection.keypoints = transform_to_keypoints(
+                    keypoints[detection_idx], keypoints_scores[detection_idx]
+                )
+            else:
+                detection.keypoints = transform_to_keypoints(keypoints[detection_idx])
 
         detections.append(detection)
 

--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -298,7 +298,7 @@ class ImgDetectionsExtended(dai.Buffer):
         if not isinstance(masks, np.ndarray):
             raise TypeError("Mask must be a numpy array")
 
-        if not np.all(masks >= 0 or masks <= 1):
-            raise ValueError(f"Masks should be in range [0, 1], got {masks}.")
+        # if not np.all(masks >= 0 or masks <= 1):
+        # raise ValueError(f"Masks should be in range [0, 1], got {masks}.")
 
         self._masks = masks

--- a/depthai_nodes/ml/parsers/fastsam.py
+++ b/depthai_nodes/ml/parsers/fastsam.py
@@ -66,12 +66,8 @@ class FastSAMParser(BaseParser):
         points: Optional[Tuple[int, int]] = None,
         point_label: Optional[int] = None,
         bbox: Optional[Tuple[int, int, int, int]] = None,
-        yolo_outputs: List[str] = (
-            "output1_yolov8",
-            "output2_yolov8",
-            "output3_yolov8",
-        ),
-        mask_outputs: List[str] = ("output1_masks", "output2_masks", "output3_masks"),
+        yolo_outputs: List[str] = None,
+        mask_outputs: List[str] = None,
         protos_output: str = "protos_output",
     ) -> None:
         """Initialize the FastSAMParser node.
@@ -108,8 +104,16 @@ class FastSAMParser(BaseParser):
         self.points = points
         self.point_label = point_label
         self.bbox = bbox
-        self.yolo_outputs = yolo_outputs
-        self.mask_outputs = mask_outputs
+        self.yolo_outputs = (
+            ["output1_yolov8", "output2_yolov8", "output3_yolov8"]
+            if yolo_outputs is None
+            else yolo_outputs
+        )
+        self.mask_outputs = (
+            ["output1_masks", "output2_masks", "output3_masks"]
+            if mask_outputs is None
+            else mask_outputs
+        )
         self.protos_output = protos_output
 
     def build(self, head_config: Dict[str, Any]) -> "FastSAMParser":

--- a/depthai_nodes/ml/parsers/fastsam.py
+++ b/depthai_nodes/ml/parsers/fastsam.py
@@ -11,7 +11,7 @@ from .utils.fastsam import (
     point_prompt,
     process_single_mask,
 )
-from .utils.yolo import get_segmentation_outputs, reshape_seg_outputs
+from .utils.masks_utils import get_segmentation_outputs, reshape_seg_outputs
 
 
 class FastSAMParser(BaseParser):

--- a/depthai_nodes/ml/parsers/fastsam.py
+++ b/depthai_nodes/ml/parsers/fastsam.py
@@ -149,9 +149,9 @@ class FastSAMParser(BaseParser):
         return self
 
     def setConfidenceThreshold(self, threshold: float) -> None:
-        """Sets the confidence score threshold for detected faces.
+        """Sets the confidence score threshold.
 
-        @param threshold: Confidence score threshold for detected faces.
+        @param threshold: Confidence score threshold.
         @type threshold: float
         """
         if not isinstance(threshold, float):

--- a/depthai_nodes/ml/parsers/utils/fastsam.py
+++ b/depthai_nodes/ml/parsers/utils/fastsam.py
@@ -245,7 +245,9 @@ def decode_fastsam_output(
     @return: NMS output
     @rtype: np.ndarray
     """
-    output = parse_yolo_outputs(outputs, strides, anchors, kpts=None)
+    output = parse_yolo_outputs(
+        outputs=outputs, strides=strides, num_outputs=6, anchors=anchors, kpts=None
+    )
     output_nms = non_max_suppression(
         output,
         conf_thres=conf_thres,

--- a/depthai_nodes/ml/parsers/utils/keypoints.py
+++ b/depthai_nodes/ml/parsers/utils/keypoints.py
@@ -89,7 +89,7 @@ def transform_to_keypoints(
 
         if dim == 3:
             kp.z = keypoint[2]
-        if confidences:
+        if confidences is not None:
             kp.confidence = confidences[i]
 
         keypoints_list.append(kp)

--- a/depthai_nodes/ml/parsers/utils/masks_utils.py
+++ b/depthai_nodes/ml/parsers/utils/masks_utils.py
@@ -1,3 +1,6 @@
+from typing import List, Optional, Tuple
+
+import depthai as dai
 import numpy as np
 
 
@@ -61,3 +64,34 @@ def process_single_mask(
     mask = sigmoid(np.sum(protos * mask_coeff[..., np.newaxis, np.newaxis], axis=0))
     mask = crop_mask(mask, scaled_bbox)
     return (mask > mask_conf).astype(np.uint8)
+
+
+def get_segmentation_outputs(
+    output: dai.NNData,
+    mask_output_layer_names: Optional[List[str]] = None,
+    protos_output_layer_name: Optional[str] = None,
+) -> Tuple[List[np.ndarray], np.ndarray, int]:
+    """Get the segmentation outputs from the Neural Network data."""
+    # Get all the layer names
+    layer_names = mask_output_layer_names or output.getAllLayerNames()
+    mask_outputs = sorted([name for name in layer_names if "mask" in name])
+    masks_outputs_values = [
+        output.getTensor(o, dequantize=True).astype(np.float32) for o in mask_outputs
+    ]
+    protos_output = output.getTensor(
+        protos_output_layer_name or "protos_output", dequantize=True
+    ).astype(np.float32)
+    protos_len = protos_output.shape[1]
+    return masks_outputs_values, protos_output, protos_len
+
+
+def reshape_seg_outputs(
+    protos_output: np.ndarray,
+    protos_len: int,
+    masks_outputs_values: List[np.ndarray],
+) -> Tuple[np.ndarray, int, List[np.ndarray]]:
+    """Reshape the segmentation outputs."""
+    protos_output = protos_output.transpose((0, 3, 1, 2))
+    protos_len = protos_output.shape[1]
+    masks_outputs_values = [o.transpose((0, 3, 1, 2)) for o in masks_outputs_values]
+    return protos_output, protos_len, masks_outputs_values

--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -2,7 +2,6 @@ import time
 from enum import Enum
 from typing import List, Optional, Tuple
 
-import depthai as dai
 import numpy as np
 
 from .bbox_format_converters import xywh_to_xyxy
@@ -422,34 +421,3 @@ def decode_yolo_output(
     )[0]
 
     return output_nms
-
-
-def get_segmentation_outputs(
-    output: dai.NNData,
-    mask_output_layer_names: Optional[List[str]] = None,
-    protos_output_layer_name: Optional[str] = None,
-) -> Tuple[List[np.ndarray], np.ndarray, int]:
-    """Get the segmentation outputs from the Neural Network data."""
-    # Get all the layer names
-    layer_names = mask_output_layer_names or output.getAllLayerNames()
-    mask_outputs = sorted([name for name in layer_names if "mask" in name])
-    masks_outputs_values = [
-        output.getTensor(o, dequantize=True).astype(np.float32) for o in mask_outputs
-    ]
-    protos_output = output.getTensor(
-        protos_output_layer_name or "protos_output", dequantize=True
-    ).astype(np.float32)
-    protos_len = protos_output.shape[1]
-    return masks_outputs_values, protos_output, protos_len
-
-
-def reshape_seg_outputs(
-    protos_output: np.ndarray,
-    protos_len: int,
-    masks_outputs_values: List[np.ndarray],
-) -> Tuple[np.ndarray, int, List[np.ndarray]]:
-    """Reshape the segmentation outputs."""
-    protos_output = protos_output.transpose((0, 3, 1, 2))
-    protos_len = protos_output.shape[1]
-    masks_outputs_values = [o.transpose((0, 3, 1, 2)) for o in masks_outputs_values]
-    return protos_output, protos_len, masks_outputs_values

--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -425,18 +425,20 @@ def decode_yolo_output(
 
 
 def get_segmentation_outputs(
-    output: dai.NNData, output_layer_names: Optional[List[str]] = None
+    output: dai.NNData,
+    mask_output_layer_names: Optional[List[str]] = None,
+    protos_output_layer_name: Optional[str] = None,
 ) -> Tuple[List[np.ndarray], np.ndarray, int]:
     """Get the segmentation outputs from the Neural Network data."""
     # Get all the layer names
-    layer_names = output_layer_names or output.getAllLayerNames()
-    mask_outputs = sorted([name for name in layer_names if "_masks" in name])
+    layer_names = mask_output_layer_names or output.getAllLayerNames()
+    mask_outputs = sorted([name for name in layer_names if "mask" in name])
     masks_outputs_values = [
         output.getTensor(o, dequantize=True).astype(np.float32) for o in mask_outputs
     ]
-    protos_output = output.getTensor("protos_output", dequantize=True).astype(
-        np.float32
-    )
+    protos_output = output.getTensor(
+        protos_output_layer_name or "protos_output", dequantize=True
+    ).astype(np.float32)
     protos_len = protos_output.shape[1]
     return masks_outputs_values, protos_output, protos_len
 

--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -2,6 +2,7 @@ import time
 from enum import Enum
 from typing import List, Optional, Tuple
 
+import depthai as dai
 import numpy as np
 
 from .bbox_format_converters import xywh_to_xyxy
@@ -421,3 +422,32 @@ def decode_yolo_output(
     )[0]
 
     return output_nms
+
+
+def get_segmentation_outputs(
+    output: dai.NNData, output_layer_names: Optional[List[str]] = None
+) -> Tuple[List[np.ndarray], np.ndarray, int]:
+    """Get the segmentation outputs from the Neural Network data."""
+    # Get all the layer names
+    layer_names = output_layer_names or output.getAllLayerNames()
+    mask_outputs = sorted([name for name in layer_names if "_masks" in name])
+    masks_outputs_values = [
+        output.getTensor(o, dequantize=True).astype(np.float32) for o in mask_outputs
+    ]
+    protos_output = output.getTensor("protos_output", dequantize=True).astype(
+        np.float32
+    )
+    protos_len = protos_output.shape[1]
+    return masks_outputs_values, protos_output, protos_len
+
+
+def reshape_seg_outputs(
+    protos_output: np.ndarray,
+    protos_len: int,
+    masks_outputs_values: List[np.ndarray],
+) -> Tuple[np.ndarray, int, List[np.ndarray]]:
+    """Reshape the segmentation outputs."""
+    protos_output = protos_output.transpose((0, 3, 1, 2))
+    protos_len = protos_output.shape[1]
+    masks_outputs_values = [o.transpose((0, 3, 1, 2)) for o in masks_outputs_values]
+    return protos_output, protos_len, masks_outputs_values

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -7,13 +7,15 @@ import numpy as np
 from ..messages.creators import create_detection_message
 from .base_parser import BaseParser
 from .utils.bbox_format_converters import normalize_bboxes, xyxy_to_xywh
-from .utils.masks_utils import process_single_mask
+from .utils.masks_utils import (
+    get_segmentation_outputs,
+    process_single_mask,
+    reshape_seg_outputs,
+)
 from .utils.yolo import (
     YOLOVersion,
     decode_yolo_output,
-    get_segmentation_outputs,
     parse_kpts,
-    reshape_seg_outputs,
 )
 
 

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -207,7 +207,7 @@ class YOLOExtendedParser(BaseParser):
             self.subtype = YOLOSubtype(subtype.lower())
         except ValueError as err:
             raise ValueError(
-                f"Invalid YOLO version {subtype}. Supported YOLO versions are {[e.value for e in YOLOSubtype][:-1]}."
+                f"Invalid YOLO subtype {subtype}. Supported YOLO subtypes are {[e.value for e in YOLOSubtype][:-1]}."
             ) from err
 
     def setOutputLayerNames(self, output_layer_names: List[str]) -> None:

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -198,7 +198,7 @@ class YOLOExtendedParser(BaseParser):
         self.anchors = anchors
 
     def setSubtype(self, subtype: str) -> None:
-        """Sets the version of the YOLO model.
+        """Sets the subtype of the YOLO model.
 
         @param subtype: The version of the YOLO model.
         @type subtype: YOLOSubtype

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -131,22 +131,35 @@ class YOLOExtendedParser(BaseParser):
 
         self.output_layer_names = bbox_layer_names + kps_layer_names + masks_layer_names
 
-        metadata = head_config["metadata"]
-        self.conf_threshold = metadata["conf_threshold"]
-        self.n_classes = metadata["n_classes"]
-        self.iou_threshold = metadata["iou_threshold"]
-        self.anchors = metadata["anchors"]
-        if "mask_conf" in metadata:
-            self.mask_conf = metadata["mask_conf"]
-        if "n_keypoints" in metadata:
-            self.n_keypoints = metadata["n_keypoints"]
-        if "yolo_version" in metadata:
-            try:
-                self.yolo_version = YOLOVersion(metadata["yolo_version"].lower())
-            except ValueError as err:
-                raise ValueError(
-                    f"Invalid YOLO version {metadata['yolo_version']}. Supported YOLO versions are {[e.value for e in YOLOVersion][:-1]}."
-                ) from err
+        # metadata = head_config["metadata"]
+        self.conf_threshold = head_config.get("conf_threshold", self.conf_threshold)
+        self.n_classes = head_config.get("n_classes", self.n_classes)
+        self.iou_threshold = head_config.get("iou_threshold", self.iou_threshold)
+        self.mask_conf = head_config.get("mask_conf", self.mask_conf)
+        self.anchors = head_config.get("anchors", self.anchors)
+        self.n_keypoints = head_config.get("n_keypoints", self.n_keypoints)
+        yolo_version = head_config.get("yolo_version", self.yolo_version)
+        try:
+            self.yolo_version = YOLOVersion(yolo_version.lower())
+        except ValueError as err:
+            raise ValueError(
+                f"Invalid YOLO version {yolo_version}. Supported YOLO versions are {[e.value for e in YOLOVersion][:-1]}."
+            ) from err
+        # self.conf_threshold = metadata["conf_threshold"]
+        # self.n_classes = metadata["n_classes"]
+        # self.iou_threshold = metadata["iou_threshold"]
+        # self.anchors = metadata["anchors"]
+        # if "mask_conf" in metadata:
+        #     self.mask_conf = metadata["mask_conf"]
+        # if "n_keypoints" in metadata:
+        #     self.n_keypoints = metadata["n_keypoints"]
+        # if "yolo_version" in metadata:
+        #     try:
+        #         self.yolo_version = YOLOVersion(metadata["yolo_version"].lower())
+        #     except ValueError as err:
+        #         raise ValueError(
+        #             f"Invalid YOLO version {metadata['yolo_version']}. Supported YOLO versions are {[e.value for e in YOLOVersion][:-1]}."
+        #         ) from err
         return self
 
     def setConfidenceThreshold(self, threshold: float) -> None:

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -133,7 +133,6 @@ class YOLOExtendedParser(BaseParser):
 
         self.output_layer_names = bbox_layer_names + kps_layer_names + masks_layer_names
 
-        # metadata = head_config["metadata"]
         self.conf_threshold = head_config.get("conf_threshold", self.conf_threshold)
         self.n_classes = head_config.get("n_classes", self.n_classes)
         self.iou_threshold = head_config.get("iou_threshold", self.iou_threshold)
@@ -147,21 +146,7 @@ class YOLOExtendedParser(BaseParser):
             raise ValueError(
                 f"Invalid YOLO version {yolo_version}. Supported YOLO versions are {[e.value for e in YOLOVersion][:-1]}."
             ) from err
-        # self.conf_threshold = metadata["conf_threshold"]
-        # self.n_classes = metadata["n_classes"]
-        # self.iou_threshold = metadata["iou_threshold"]
-        # self.anchors = metadata["anchors"]
-        # if "mask_conf" in metadata:
-        #     self.mask_conf = metadata["mask_conf"]
-        # if "n_keypoints" in metadata:
-        #     self.n_keypoints = metadata["n_keypoints"]
-        # if "yolo_version" in metadata:
-        #     try:
-        #         self.yolo_version = YOLOVersion(metadata["yolo_version"].lower())
-        #     except ValueError as err:
-        #         raise ValueError(
-        #             f"Invalid YOLO version {metadata['yolo_version']}. Supported YOLO versions are {[e.value for e in YOLOVersion][:-1]}."
-        #         ) from err
+
         return self
 
     def setConfidenceThreshold(self, threshold: float) -> None:

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -138,7 +138,7 @@ class YOLOExtendedParser(BaseParser):
         self.mask_conf = head_config.get("mask_conf", self.mask_conf)
         self.anchors = head_config.get("anchors", self.anchors)
         self.n_keypoints = head_config.get("n_keypoints", self.n_keypoints)
-        yolo_version = head_config.get("yolo_version", self.yolo_version)
+        yolo_version = head_config.get("subtype", self.yolo_version)
         try:
             self.yolo_version = YOLOVersion(yolo_version.lower())
         except ValueError as err:

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -200,7 +200,7 @@ class YOLOExtendedParser(BaseParser):
     def setSubtype(self, subtype: str) -> None:
         """Sets the subtype of the YOLO model.
 
-        @param subtype: The version of the YOLO model.
+        @param subtype: The subtype of the YOLO model.
         @type subtype: YOLOSubtype
         """
         try:

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -144,7 +144,7 @@ class YOLOExtendedParser(BaseParser):
             self.subtype = YOLOSubtype(subtype.lower())
         except ValueError as err:
             raise ValueError(
-                f"Invalid YOLO version {subtype}. Supported YOLO versions are {[e.value for e in YOLOSubtype][:-1]}."
+                f"Invalid YOLO subtype {subtype}. Supported YOLO subtypes are {[e.value for e in YOLOSubtype][:-1]}."
             ) from err
 
         return self

--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -23,7 +23,7 @@ class ParserGenerator(dai.node.ThreadedHostNode):
         ----------
         nn_archive: dai.NNArchive
             NN Archive of the model.
-        head__index: int
+        head_index: int
             Index of the head to be used for parsing. If not provided, each head will instantiate a separate parser.
 
         Returns


### PR DESCRIPTION
This PR refactors the last remaining parser FastSAM - because previously it was dependent on the YOLOExtended parser. Now its parent class is BaseParser. We dont need to pass input size anymore as it is calculated automatically from the output tensor shape by multiplying it with the stride.

I also moved two functions `_get_segmentation_outputs` and `reshape_seg_outputs` away from YOLO class into YOLO utils because the two functions are also used in FastSAM.

Validation logic in `ImgDetectionsExtended` for `masks` was not right for current masks in YOLOExtended. I just commented it because when we add new masks representetation we would probably need it.

`ImgDetectionsExtended` was not having option to add a confidence to the keypoint (YOLO Pose outputs also `visibility` for each keypoint - confidence in our case). So, this is also added.

YOLOExtedend parser was slightly modified. `build` method now correctly takes parameters from head config. Previously it was taking `metadata` from `head_config` but the `head_config` itself is acctually a `metadata`. And when using `KPTS_MODE` we extract also keypoint scores, previously they were given as `z` coordinate. @ptoupas can you check if this is correct because I didnt check with all YOLOs but I think this only affects YOLO Pose and we only have one, right?