### PR TITLE
fix: clip hrnet scores

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -29,5 +29,3 @@ fix:
     - 'issue/*'
     - 'bugfix/*'
     - 'patch/*'
-release:
-  - base-branch: 'main'

--- a/depthai_nodes/ml/parsers/hrnet.py
+++ b/depthai_nodes/ml/parsers/hrnet.py
@@ -59,6 +59,8 @@ class HRNetParser(dai.node.ThreadedHostNode):
             _, map_h, map_w = heatmaps.shape
 
             scores = np.array([np.max(heatmap) for heatmap in heatmaps])
+            scores = np.clip(scores, 0, 1) # TODO: check why scores are sometimes >1
+
             keypoints = np.array(
                 [
                     np.unravel_index(heatmap.argmax(), heatmap.shape)

--- a/depthai_nodes/ml/parsers/hrnet.py
+++ b/depthai_nodes/ml/parsers/hrnet.py
@@ -59,7 +59,7 @@ class HRNetParser(dai.node.ThreadedHostNode):
             _, map_h, map_w = heatmaps.shape
 
             scores = np.array([np.max(heatmap) for heatmap in heatmaps])
-            scores = np.clip(scores, 0, 1) # TODO: check why scores are sometimes >1
+            scores = np.clip(scores, 0, 1)  # TODO: check why scores are sometimes >1
 
             keypoints = np.array(
                 [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pre-commit>=3.2.1
+pre-commit>=3.2.1,<=3.8.0
 pydoctor
 pytest-dependency>=0.6.0
 pytest-cov>=4.1.0


### PR DESCRIPTION
This is a quick fix for the `HRNetParser`. Scores with calues >1 were occurring (max. observed was 1.1) and this was causing errors later in the process.