### PR TITLE
Update config usage in examples to latest DAIv3 version

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -83,7 +83,7 @@ with dai.Pipeline() as pipeline:
         message = parser_queue.get()
 
         extraParams = (
-            nn_archive.getConfig().getConfigV1().model.heads[0].metadata.extraParams
+            nn_archive.getConfig().model.heads[0].metadata.extraParams
         )
         if visualize(frame, message, parser_name, extraParams):
             pipeline.stop()

--- a/examples/utils/model.py
+++ b/examples/utils/model.py
@@ -23,7 +23,7 @@ def get_model_from_hub(model_slug: str, model_version_slug: str) -> dai.NNArchiv
 def get_parser_from_archive(nn_archive: dai.NNArchive) -> str:
     """Get the required parser from the NN archive."""
     try:
-        required_parser = nn_archive.getConfig().getConfigV1().model.heads[0].parser
+        required_parser = nn_archive.getConfig().model.heads[0].parser
     except AttributeError:
         print(
             "This NN archive does not have a parser. Please use NN archives that have parsers."
@@ -55,7 +55,7 @@ def get_parser(nn_archive: dai.NNArchive) -> Tuple[dai.ThreadedNode, str]:
 def get_inputs_from_archive(nn_archive: dai.NNArchive) -> List:
     """Get all inputs from NN archive."""
     try:
-        inputs = nn_archive.getConfig().getConfigV1().model.inputs
+        inputs = nn_archive.getConfig().model.inputs
     except AttributeError:
         print(
             "This NN archive does not have an input shape. Please use NN archives that have input shapes."

--- a/examples/utils/parser.py
+++ b/examples/utils/parser.py
@@ -160,7 +160,7 @@ def setup_parser(parser: dai.ThreadedNode, nn_archive: dai.NNArchive, parser_nam
     """Setup the parser with the NN archive."""
 
     extraParams = (
-        nn_archive.getConfig().getConfigV1().model.heads[0].metadata.extraParams
+        nn_archive.getConfig().model.heads[0].metadata.extraParams
     )
 
     if parser_name == "SCRFDParser":


### PR DESCRIPTION
This PR updates the example and replaces:
`nn_archive.getConfig().getConfigV1()` with `nn_archive.getConfig()`
as introduced in latest DepthAI V3 alpha releases (https://github.com/luxonis/depthai-core/pull/1133)