### PR TITLE
Fix on YOLOExtendedParser anchors

### DIFF
--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -49,7 +49,7 @@ def non_max_suppression(
     prediction: np.ndarray,
     conf_thres: float = 0.5,
     iou_thres: float = 0.45,
-    classes: List = None,
+    classes: Optional[List] = None,
     num_classes: int = 1,
     agnostic: bool = False,
     multi_label: bool = False,
@@ -69,7 +69,7 @@ def non_max_suppression(
     @param iou_thres: Intersection over union threshold.
     @type iou_thres: float
     @param classes: For filtering by classes.
-    @type classes: List
+    @type classes: Optional[List]
     @param num_classes: Number of classes.
     @type num_classes: int
     @param agnostic: Runs NMS on all boxes together rather than per class if True.
@@ -190,7 +190,7 @@ def parse_yolo_outputs(
     outputs: List[np.ndarray],
     strides: List[int],
     num_outputs: int,
-    anchors: Optional[List[np.ndarray]] = None,
+    anchors: Optional[np.ndarray] = None,
     kpts: Optional[List[np.ndarray]] = None,
     det_mode: bool = False,
     subtype: YOLOSubtype = YOLOSubtype.DEFAULT,
@@ -203,8 +203,8 @@ def parse_yolo_outputs(
     @type strides: List[int]
     @param num_outputs: Number of outputs of the model.
     @type num_outputs: int
-    @param anchors: An optional list of anchors.
-    @type anchors: Optional[List[np.ndarray]]
+    @param anchors: An optional array of anchors.
+    @type anchors: Optional[np.ndarray]
     @param kpts: An optional list of keypoints for each output.
     @type kpts: Optional[List[np.ndarray]]
     @param det_mode: Detection only mode.
@@ -218,7 +218,7 @@ def parse_yolo_outputs(
 
     for i, (out_head, stride) in enumerate(zip(outputs, strides)):
         kpt = kpts[i] if kpts else None
-        anchors_head = anchors[i] if anchors else None
+        anchors_head = anchors[i] if anchors is not None else None
         out = parse_yolo_output(
             out_head,
             stride,
@@ -265,7 +265,9 @@ def parse_yolo_output(
     @return: Parsed output.
     @rtype: np.ndarray
     """
-    na = len(anchors) // 2 if anchors else 1  # number of anchors per head
+    na = (
+        anchors.shape[0] // 2 if anchors is not None else 1
+    )  # number of anchors per head
     bs, _, ny, nx = out.shape  # bs - batch size, ny|nx - y and x of grid cells
 
     if subtype in [
@@ -375,7 +377,7 @@ def parse_kpts(
 def decode_yolo_output(
     yolo_outputs: List[np.ndarray],
     strides: List[int],
-    anchors: Optional[List[np.ndarray]] = None,
+    anchors: Optional[np.ndarray] = None,
     kpts: Optional[List[np.ndarray]] = None,
     conf_thres: float = 0.5,
     iou_thres: float = 0.45,
@@ -389,8 +391,8 @@ def decode_yolo_output(
     @type yolo_outputs: List[np.ndarray]
     @param strides: List of strides.
     @type strides: List[int]
-    @param anchors: An optional list of anchors.
-    @type anchors: Optional[List[np.ndarray]]
+    @param anchors: An optional array of anchors.
+    @type anchors: Optional[np.ndarray]
     @param kpts: An optional list of keypoints.
     @type kpts: Optional[List[np.ndarray]]
     @param conf_thres: Confidence threshold.

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -35,7 +35,7 @@ class YOLOExtendedParser(BaseParser):
         Mask confidence threshold.
     n_keypoints : int
         Number of keypoints in the model.
-    anchors : Optional[List[np.ndarray]]
+    anchors : Optional[List[List[List[float]]]]
         Anchors for the YOLO model (optional).
     subtype : str
         Version of the YOLO model.
@@ -59,7 +59,7 @@ class YOLOExtendedParser(BaseParser):
         iou_threshold: float = 0.5,
         mask_conf: float = 0.5,
         n_keypoints: int = 17,
-        anchors: Optional[List[np.ndarray]] = None,
+        anchors: Optional[List[List[List[float]]]] = None,
         subtype: str = "",
     ):
         """Initialize the parser node.
@@ -75,7 +75,7 @@ class YOLOExtendedParser(BaseParser):
         @param n_keypoints: The number of keypoints in the model
         @type n_keypoints: int
         @param anchors: The anchors for the YOLO model
-        @type anchors: Optional[List[np.ndarray]]
+        @type anchors: Optional[List[List[List[float]]]]
         @param subtype: The version of the YOLO model
         @type subtype: str
         """
@@ -143,11 +143,11 @@ class YOLOExtendedParser(BaseParser):
         """
         self.n_keypoints = n_keypoints
 
-    def setAnchors(self, anchors: List[np.ndarray]) -> None:
+    def setAnchors(self, anchors: List[List[List[float]]]) -> None:
         """Sets the anchors for the YOLO model.
 
         @param anchors: The anchors for the YOLO model.
-        @type anchors: List[np.ndarray]
+        @type anchors: List[List[List[float]]]
         """
         self.anchors = anchors
 
@@ -279,6 +279,10 @@ class YOLOExtendedParser(BaseParser):
             input_shape = tuple(
                 dim * strides[0] for dim in outputs_values[0].shape[2:4]
             )
+
+            # Reshape the anchors based on the model's output heads
+            if self.anchors is not None:
+                self.anchors = np.array(self.anchors).reshape(len(strides), -1)
 
             # Decode the outputs
             results = decode_yolo_output(


### PR DESCRIPTION
Fix the type and format of anchors in YOLOExtendedParser to be compatible with the format needed in the [NN Archive](https://github.com/luxonis/luxonis-ml/blob/41c0b6b61d71fcf5f96ba0d7cf9e04c307bfbd59/luxonis_ml/nn_archive/config_building_blocks/base_models/head_metadata.py#L58-L61).