### PR TITLE
Message improvements (properties and methods).

### DIFF
--- a/depthai_nodes/ml/messages/classification.py
+++ b/depthai_nodes/ml/messages/classification.py
@@ -72,3 +72,21 @@ class Classifications(dai.Buffer):
         if value.size > 0 and value.dtype != np.float32:
             raise ValueError("Scores must be a np.ndarray of floats.")
         self._scores = value
+
+    @property
+    def top_class(self) -> str:
+        """Returns the most probable class.
+
+        @return: The top class.
+        @rtype: str
+        """
+        return self._classes[0]
+
+    @property
+    def top_score(self) -> float:
+        """Returns the probability of the most probable class.
+
+        @return: The top score.
+        @rtype: float
+        """
+        return self._scores[0]

--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -241,7 +241,8 @@ class ImgDetectionExtended(dai.Buffer):
         self._keypoints = value
 
     def get_xyxy_bbox_points(self) -> NDArray[np.float32]:
-        """Returns the [x1, y1, x2, y2] bounding box points.
+        """Returns the axis-aligned [x1, y1, x2, y2] bounding box points. It does not
+        take into account the angle of the bounding box.
 
         @return: Bounding box points.
         @rtype: NDArray[np.float32]

--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -240,6 +240,44 @@ class ImgDetectionExtended(dai.Buffer):
             raise ValueError("Keypoints must be a list of Keypoint objects.")
         self._keypoints = value
 
+    def get_xyxy_bbox_points(self) -> NDArray[np.float32]:
+        """Returns the [x1, y1, x2, y2] bounding box points.
+
+        @return: Bounding box points.
+        @rtype: NDArray[np.float32]
+        """
+        x1 = self.x_center - self.width / 2
+        y1 = self.y_center - self.height / 2
+        x2 = self.x_center + self.width / 2
+        y2 = self.y_center + self.height / 2
+        return np.array([x1, y1, x2, y2], dtype=np.float32)
+
+    def get_bbox_points(self) -> NDArray[np.float32]:
+        """Returns the bounding box points in the format [[x1,y1], [x2,y2], [x3,y3],
+        [x4,y4]]. Starting from the top-left corner and going clockwise. This is useful
+        for drawing rotated bounding boxes.
+
+        @return: Rotated bounding box points.
+        @rtype: NDArray[np.float32]
+        """
+
+        angle = np.radians(self.angle)
+        x_center, y_center, w, h = self.x_center, self.y_center, self.width, self.height
+
+        w_half, h_half = w / 2, h / 2
+
+        corners = np.array(
+            [[-w_half, -h_half], [w_half, -h_half], [w_half, h_half], [-w_half, h_half]]
+        )
+
+        cos_a, sin_a = np.cos(angle), np.sin(angle)
+        rotation_matrix = np.array([[cos_a, -sin_a], [sin_a, cos_a]])
+        rotated_corners = np.dot(corners, rotation_matrix) + np.array(
+            [x_center, y_center]
+        )
+
+        return rotated_corners
+
 
 class ImgDetectionsExtended(dai.Buffer):
     """ImgDetectionsExtended class for storing image detections with keypoints.

--- a/depthai_nodes/ml/messages/prediction.py
+++ b/depthai_nodes/ml/messages/prediction.py
@@ -80,3 +80,12 @@ class Predictions(dai.Buffer):
         if not all(isinstance(item, Prediction) for item in value):
             raise ValueError("Predictions must be a list of Prediction objects.")
         self._predictions = value
+
+    @property
+    def prediction(self) -> float:
+        """Returns the first prediction. Useful for single predictions.
+
+        @return: The predicted value.
+        @rtype: float
+        """
+        return self._predictions[0].prediction


### PR DESCRIPTION
This PR improves 3 messages:

1. `Predictions` msg - we add a property `prediction` for retrieving first prediction value. This is useful because Regression parser many times returns one value and to get the value we must type `message.predictions[0].prediction`. Now, we will just write `message.prediction`.
2. `Classification` msg - same idea as with Predictions msg. to get the most probable class and score we add two properties: `top_class` and `top_score`. 
3. `ImgDetectionExtended` msg - two methods are added for easy conversion to [x1,y1,x2,y2] bbox and for [[x1,y1], [x2,y2],[x3,y3],[x4,y4]] rotated bbox (going from the top-left and clockwise)