### PR TITLE
Add support for YOLO and SSD in ParserGenerator.

### DIFF
--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -43,6 +43,13 @@ class ParserGenerator(dai.node.ThreadedHostNode):
 
         for index, head in zip(indexes, heads):
             parser_name = head.parser
+
+            if parser_name == "YOLO" or parser_name == "SSD":
+                parser = pipeline.create(dai.node.DetectionParser)
+                parser.setNNArchive(nn_archive)
+                parsers[index] = parser
+                continue
+
             parser = globals().get(parser_name)
 
             if parser is None:


### PR DESCRIPTION
This PR adds support for YOLO and SSD models in `ParserGenerator`. It uses dai's `DetectionParser` to parse the outputs. We can now instatiate `ParsingNeuralNetwork` node with yolo's or ssd's archives.