### PR TITLE
fix: input size setting

### DIFF
--- a/depthai_nodes/ml/parsers/base_parser.py
+++ b/depthai_nodes/ml/parsers/base_parser.py
@@ -57,6 +57,8 @@ class BaseParser(dai.node.ThreadedHostNode, metaclass=BaseMeta):
         @param head_config: A dictionary containing configuration details relevant to
             the parser, including parameters and settings required for output parsing.
         @type head_config: Dict[str, Any]
+        @return: The parser object with the head configuration set.
+        @rtype: BaseParser
         """
         pass
 

--- a/depthai_nodes/ml/parsers/lane_detection.py
+++ b/depthai_nodes/ml/parsers/lane_detection.py
@@ -126,23 +126,15 @@ class LaneDetectionParser(BaseParser):
     def build(
         self,
         head_config: Dict[str, Any],
-        inputs_size: List[List[int]],
     ) -> "LaneDetectionParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
         @type head_config: Dict[str, Any]
-        @param inputs_size: Model inputs size.
-        @type inputs_size: List[List[int]]
         @return: The parser object with the head configuration set.
         @rtype: LaneDetectionParser
         """
 
-        if len(inputs_size) != 1:
-            raise ValueError(
-                f"Only one input supported for LaneDetectionParser, got {len(inputs_size)} inputs."
-            )
-        self.input_size = inputs_size[0]
         output_layers = head_config.get("outputs", [])
         if len(output_layers) != 1:
             raise ValueError(
@@ -154,6 +146,20 @@ class LaneDetectionParser(BaseParser):
         self.cls_num_per_lane = head_config.get(
             "cls_num_per_lane", self.cls_num_per_lane
         )
+
+        inputs = head_config["model"]["inputs"]
+        if len(inputs) != 1:
+            raise ValueError(
+                f"Only one input supported for LaneDetectionParser, got {len(inputs)} inputs."
+            )
+        self.input_shape = inputs[0].get("shape")
+        self.layout = inputs[0].get("layout")
+        if self.layout == "NHWC":
+            self.input_size = [self.input_shape[2], self.input_shape[1]]
+        elif self.layout == "NCHW":
+            self.input_size = [self.input_shape[3], self.input_shape[2]]
+        else:
+            raise ValueError(f"Input layout {self.layout} not supported for input_size extraction.")
 
         return self
 

--- a/depthai_nodes/ml/parsers/lane_detection.py
+++ b/depthai_nodes/ml/parsers/lane_detection.py
@@ -147,7 +147,7 @@ class LaneDetectionParser(BaseParser):
             "cls_num_per_lane", self.cls_num_per_lane
         )
 
-        inputs = head_config["model"]["inputs"]
+        inputs = head_config["model_inputs"]
         if len(inputs) != 1:
             raise ValueError(
                 f"Only one input supported for LaneDetectionParser, got {len(inputs)} inputs."

--- a/depthai_nodes/ml/parsers/lane_detection.py
+++ b/depthai_nodes/ml/parsers/lane_detection.py
@@ -24,7 +24,7 @@ class LaneDetectionParser(BaseParser):
     cls_num_per_lane : int
         Number of points per lane.
     input_shape : Tuple[int, int]
-        Input shape.
+        Input shape (height,width).
 
     Output Message/s
     ----------------
@@ -44,7 +44,7 @@ class LaneDetectionParser(BaseParser):
         row_anchors: List[int] = None,
         griding_num: int = None,
         cls_num_per_lane: int = None,
-        input_shape: Tuple[int, int] = (288, 800),
+        input_shape: Tuple[int, int] = None,
     ) -> None:
         """Initializes the lane detection parser node.
 
@@ -56,7 +56,7 @@ class LaneDetectionParser(BaseParser):
         @type griding_num: int
         @param cls_num_per_lane: Number of points per lane.
         @type cls_num_per_lane: int
-        @param input_shape: Input shape.
+        @param input_shape: Input shape (height,width).
         @type input_shape: Tuple[int, int]
         """
         super().__init__()
@@ -112,7 +112,7 @@ class LaneDetectionParser(BaseParser):
     def setInputShape(self, input_shape: Tuple[int, int]) -> None:
         """Set the input shape for the lane detection model.
 
-        @param input_shape: Input shape.
+        @param input_shape: Input shape (height,width).
         @type input_shape: Tuple[int, int]
         """
         if not isinstance(input_shape, tuple):

--- a/depthai_nodes/ml/parsers/lane_detection.py
+++ b/depthai_nodes/ml/parsers/lane_detection.py
@@ -155,11 +155,13 @@ class LaneDetectionParser(BaseParser):
         self.input_shape = inputs[0].get("shape")
         self.layout = inputs[0].get("layout")
         if self.layout == "NHWC":
-            self.input_size = [self.input_shape[2], self.input_shape[1]]
+            self.input_size = (self.input_shape[2], self.input_shape[1])
         elif self.layout == "NCHW":
-            self.input_size = [self.input_shape[3], self.input_shape[2]]
+            self.input_size = (self.input_shape[3], self.input_shape[2])
         else:
-            raise ValueError(f"Input layout {self.layout} not supported for input_size extraction.")
+            raise ValueError(
+                f"Input layout {self.layout} not supported for input_size extraction."
+            )
 
         return self
 

--- a/depthai_nodes/ml/parsers/lane_detection.py
+++ b/depthai_nodes/ml/parsers/lane_detection.py
@@ -24,7 +24,7 @@ class LaneDetectionParser(BaseParser):
     cls_num_per_lane : int
         Number of points per lane.
     input_shape : Tuple[int, int]
-        Input shape (height,width).
+        Input shape (width,height).
 
     Output Message/s
     ----------------
@@ -56,7 +56,7 @@ class LaneDetectionParser(BaseParser):
         @type griding_num: int
         @param cls_num_per_lane: Number of points per lane.
         @type cls_num_per_lane: int
-        @param input_shape: Input shape (height,width).
+        @param input_shape: Input shape (width,height).
         @type input_shape: Tuple[int, int]
         """
         super().__init__()
@@ -112,7 +112,7 @@ class LaneDetectionParser(BaseParser):
     def setInputShape(self, input_shape: Tuple[int, int]) -> None:
         """Set the input shape for the lane detection model.
 
-        @param input_shape: Input shape (height,width).
+        @param input_shape: Input shape (width,height).
         @type input_shape: Tuple[int, int]
         """
         if not isinstance(input_shape, tuple):
@@ -126,15 +126,23 @@ class LaneDetectionParser(BaseParser):
     def build(
         self,
         head_config: Dict[str, Any],
+        inputs_size: List[List[int]],
     ) -> "LaneDetectionParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
         @type head_config: Dict[str, Any]
+        @param inputs_size: Model inputs size.
+        @type inputs_size: List[List[int]]
         @return: The parser object with the head configuration set.
         @rtype: LaneDetectionParser
         """
 
+        if len(inputs_size) != 1:
+            raise ValueError(
+                f"Only one input supported for LaneDetectionParser, got {len(inputs_size)} inputs."
+            )
+        self.input_shape = inputs_size[0]
         output_layers = head_config.get("outputs", [])
         if len(output_layers) != 1:
             raise ValueError(
@@ -180,8 +188,8 @@ class LaneDetectionParser(BaseParser):
                 anchors=self.row_anchors,
                 griding_num=self.griding_num,
                 cls_num_per_lane=self.cls_num_per_lane,
-                input_width=self.input_shape[1],
-                input_height=self.input_shape[0],
+                input_width=self.input_shape[0],
+                input_height=self.input_shape[1],
                 y=y,
             )
 

--- a/depthai_nodes/ml/parsers/lane_detection.py
+++ b/depthai_nodes/ml/parsers/lane_detection.py
@@ -23,8 +23,8 @@ class LaneDetectionParser(BaseParser):
         Griding number.
     cls_num_per_lane : int
         Number of points per lane.
-    input_shape : Tuple[int, int]
-        Input shape (width,height).
+    input_size : Tuple[int, int]
+        Input size (width,height).
 
     Output Message/s
     ----------------
@@ -44,7 +44,7 @@ class LaneDetectionParser(BaseParser):
         row_anchors: List[int] = None,
         griding_num: int = None,
         cls_num_per_lane: int = None,
-        input_shape: Tuple[int, int] = None,
+        input_size: Tuple[int, int] = None,
     ) -> None:
         """Initializes the lane detection parser node.
 
@@ -56,8 +56,8 @@ class LaneDetectionParser(BaseParser):
         @type griding_num: int
         @param cls_num_per_lane: Number of points per lane.
         @type cls_num_per_lane: int
-        @param input_shape: Input shape (width,height).
-        @type input_shape: Tuple[int, int]
+        @param input_size: Input size (width,height).
+        @type input_size: Tuple[int, int]
         """
         super().__init__()
         self.output_layer_name = output_layer_name
@@ -65,7 +65,7 @@ class LaneDetectionParser(BaseParser):
         self.row_anchors = row_anchors
         self.griding_num = griding_num
         self.cls_num_per_lane = cls_num_per_lane
-        self.input_shape = input_shape
+        self.input_size = input_size
 
     def setOutputLayerName(self, output_layer_name: str) -> None:
         """Set the output layer name for the lane detection model.
@@ -109,19 +109,19 @@ class LaneDetectionParser(BaseParser):
             raise ValueError("Number of points per lane must be an integer.")
         self.cls_num_per_lane = cls_num_per_lane
 
-    def setInputShape(self, input_shape: Tuple[int, int]) -> None:
-        """Set the input shape for the lane detection model.
+    def setInputSize(self, input_size: Tuple[int, int]) -> None:
+        """Set the input size for the lane detection model.
 
-        @param input_shape: Input shape (width,height).
-        @type input_shape: Tuple[int, int]
+        @param input_size: Input size (width,height).
+        @type input_size: Tuple[int, int]
         """
-        if not isinstance(input_shape, tuple):
-            raise ValueError("Input shape must be a tuple.")
-        if len(input_shape) != 2:
-            raise ValueError("Input shape must be a tuple of two integers.")
-        if not all(isinstance(size, int) for size in input_shape):
-            raise ValueError("Input shape must be a tuple of integers.")
-        self.input_shape = input_shape
+        if not isinstance(input_size, tuple):
+            raise ValueError("Input size must be a tuple.")
+        if len(input_size) != 2:
+            raise ValueError("Input size must be a tuple of two integers.")
+        if not all(isinstance(size, int) for size in input_size):
+            raise ValueError("Input size must be a tuple of integers.")
+        self.input_size = input_size
 
     def build(
         self,
@@ -142,7 +142,7 @@ class LaneDetectionParser(BaseParser):
             raise ValueError(
                 f"Only one input supported for LaneDetectionParser, got {len(inputs_size)} inputs."
             )
-        self.input_shape = inputs_size[0]
+        self.input_size = inputs_size[0]
         output_layers = head_config.get("outputs", [])
         if len(output_layers) != 1:
             raise ValueError(
@@ -188,8 +188,8 @@ class LaneDetectionParser(BaseParser):
                 anchors=self.row_anchors,
                 griding_num=self.griding_num,
                 cls_num_per_lane=self.cls_num_per_lane,
-                input_width=self.input_shape[0],
-                input_height=self.input_shape[1],
+                input_width=self.input_size[0],
+                input_height=self.input_size[1],
                 y=y,
             )
 

--- a/depthai_nodes/ml/parsers/utils/yunet.py
+++ b/depthai_nodes/ml/parsers/utils/yunet.py
@@ -178,7 +178,7 @@ def format_detections(
     @type np.ndarray
     @param scores: A numpy array of shape (N,) containing the scores.
     @type np.ndarray
-    @param input_size: A tuple representing the height and width of the input image.
+    @param input_size: A tuple representing the width and height of the input image.
     @type input_size: tuple
     @return: A tuple of bboxes, keypoints, and scores.
         - bboxes: NumPy array of shape (N, 4) containing the decoded bounding boxes in the format [x_min, y_min, width, height].

--- a/depthai_nodes/ml/parsers/utils/yunet.py
+++ b/depthai_nodes/ml/parsers/utils/yunet.py
@@ -20,15 +20,15 @@ def manual_product(*args):
 
 
 def generate_anchors(
-    input_shape: Tuple[int, int],
+    input_size: Tuple[int, int],
     min_sizes: List[List[int]] = None,
     strides: List[int] = None,
 ):
     """Generate a set of default bounding boxes, known as anchors.
     The code is taken from https://github.com/Kazuhito00/YuNet-ONNX-TFLite-Sample/tree/main
 
-    @param input_shape: A tuple representing the width and height of the input image.
-    @type input_shape: Tuple[int, int]
+    @param input_size: A tuple representing the width and height of the input image.
+    @type input_size: Tuple[int, int]
     @param min_sizes: A list of lists, where each inner list contains the minimum sizes of the anchors for different feature maps.
     @type min_sizes List[List[int]]
     @param strides: Strides for each feature map layer.
@@ -36,7 +36,7 @@ def generate_anchors(
     @return: Anchors.
     @rtype: np.ndarray
     """
-    w, h = input_shape
+    w, h = input_size
 
     if min_sizes is None:
         min_sizes = [[10, 16, 24], [32, 48], [64, 96], [128, 192, 256]]
@@ -70,7 +70,7 @@ def generate_anchors(
 
 
 def decode_detections(
-    input_shape: Tuple[int, int],
+    input_size: Tuple[int, int],
     loc: np.ndarray,
     conf: np.ndarray,
     iou: np.ndarray,
@@ -80,8 +80,8 @@ def decode_detections(
     Decodes the output of an object detection model by converting the model's predictions (localization, confidence, and IoU scores) into bounding boxes, keypoints, and scores.
     The code is taken from https://github.com/Kazuhito00/YuNet-ONNX-TFLite-Sample/tree/main
 
-    @param input_shape: The shape of the input image (height, width).
-    @type input_shape: tuple
+    @param input_size: The size of the input image (height, width).
+    @type input_size: tuple
     @param loc: The predicted locations (or offsets) of the bounding boxes.
     @type loc: np.ndarray
     @param conf: The predicted class confidence scores.
@@ -98,12 +98,12 @@ def decode_detections(
 
     """
 
-    w, h = input_shape
+    w, h = input_size
 
     if variance is None:
         variance = [0.1, 0.2]
 
-    anchors = generate_anchors(input_shape)
+    anchors = generate_anchors(input_size)
 
     # Get scores
     cls_scores = conf[:, 1]
@@ -168,7 +168,7 @@ def format_detections(
     bboxes: np.ndarray,
     keypoints: np.ndarray,
     scores: np.ndarray,
-    input_shape: Tuple[int, int],
+    input_size: Tuple[int, int],
 ):
     """Format detections into a list of dictionaries.
 
@@ -178,8 +178,8 @@ def format_detections(
     @type np.ndarray
     @param scores: A numpy array of shape (N,) containing the scores.
     @type np.ndarray
-    @param input_shape: A tuple representing the height and width of the input image.
-    @type input_shape: tuple
+    @param input_size: A tuple representing the height and width of the input image.
+    @type input_size: tuple
     @return: A tuple of bboxes, keypoints, and scores.
         - bboxes: NumPy array of shape (N, 4) containing the decoded bounding boxes in the format [x_min, y_min, width, height].
         - keypoints: A NumPy array of shape (N, 10) containing the decoded keypoint coordinates for each anchor.
@@ -187,7 +187,7 @@ def format_detections(
     @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
     """
 
-    w, h = input_shape
+    w, h = input_size
 
     bboxes = normalize_bboxes(bboxes, height=h, width=w)
 

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Tuple
 
 import depthai as dai
 import numpy as np
@@ -150,11 +150,13 @@ class YuNetParser(DetectionParser):
         self.input_shape = inputs[0].get("shape")
         self.layout = inputs[0].get("layout")
         if self.layout == "NHWC":
-            self.input_size = [self.input_shape[2], self.input_shape[1]]
+            self.input_size = (self.input_shape[2], self.input_shape[1])
         elif self.layout == "NCHW":
-            self.input_size = [self.input_shape[3], self.input_shape[2]]
+            self.input_size = (self.input_shape[3], self.input_shape[2])
         else:
-            raise ValueError(f"Input layout {self.layout} not supported for input_size extraction.")
+            raise ValueError(
+                f"Input layout {self.layout} not supported for input_size extraction."
+            )
 
         return self
 

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -133,13 +133,12 @@ class YuNetParser(DetectionParser):
         """
 
         super().build(head_config)
-        output_layers = head_config.get("outputs", [])
         if len(inputs_size) != 1:
             raise ValueError(
                 f"Only one input supported for YuNetParser, got {len(inputs_size)} inputs."
             )
         self.input_size = inputs_size[0]
-        print(self.input_size)
+        output_layers = head_config.get("outputs", [])
         for output_layer in output_layers:
             if "loc" in output_layer:
                 self.loc_output_layer_name = output_layer

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -136,7 +136,7 @@ class YuNetParser(DetectionParser):
         output_layers = head_config.get("outputs", [])
         if len(inputs_size) != 1:
             raise ValueError(
-                f"Only one input supported for LaneDetectionParser, got {len(inputs_size)} inputs."
+                f"Only one input supported for YuNetParser, got {len(inputs_size)} inputs."
             )
         self.input_size = inputs_size[0]
         print(self.input_size)

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, List
+from typing import Any, Dict, List, Tuple
 
 import depthai as dai
 import numpy as np

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 
 import depthai as dai
 import numpy as np
@@ -55,7 +55,7 @@ class YuNetParser(DetectionParser):
         @type iou_threshold: float
         @param max_det: Maximum number of detections to keep.
         @type max_det: int
-        @param input_size: Input shape of the model (width, height).
+        @param input_size: Input size of the model (width, height).
         @type input_size: Tuple[int, int]
         @param loc_output_layer_name: Output layer name for the location predictions.
         @type loc_output_layer_name: str
@@ -120,22 +120,26 @@ class YuNetParser(DetectionParser):
     def build(
         self,
         head_config: Dict[str, Any],
+        inputs_size: List[List[int]],
     ) -> "YuNetParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
         @type head_config: Dict[str, Any]
+        @param inputs_size: Model inputs size.
+        @type inputs_size: List[List[int]]
         @return: The parser object with the head configuration set.
         @rtype: YuNetParser
         """
 
         super().build(head_config)
         output_layers = head_config.get("outputs", [])
-        self.input_size = head_config.get("input_size", self.input_size)
-        if len(output_layers) != 3:
+        if len(inputs_size) != 1:
             raise ValueError(
-                f"YuNetParser expects exactly 3 output layers, got {output_layers} layers."
+                f"Only one input supported for LaneDetectionParser, got {len(inputs_size)} inputs."
             )
+        self.input_size = inputs_size[0]
+        print(self.input_size)
         for output_layer in output_layers:
             if "loc" in output_layer:
                 self.loc_output_layer_name = output_layer

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -120,24 +120,16 @@ class YuNetParser(DetectionParser):
     def build(
         self,
         head_config: Dict[str, Any],
-        inputs_size: List[List[int]],
     ) -> "YuNetParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
         @type head_config: Dict[str, Any]
-        @param inputs_size: Model inputs size.
-        @type inputs_size: List[List[int]]
         @return: The parser object with the head configuration set.
         @rtype: YuNetParser
         """
 
         super().build(head_config)
-        if len(inputs_size) != 1:
-            raise ValueError(
-                f"Only one input supported for YuNetParser, got {len(inputs_size)} inputs."
-            )
-        self.input_size = inputs_size[0]
         output_layers = head_config.get("outputs", [])
         for output_layer in output_layers:
             if "loc" in output_layer:
@@ -150,6 +142,19 @@ class YuNetParser(DetectionParser):
                 raise ValueError(
                     f"Unexpected output layer {output_layer}. Only loc, conf, and iou output layers are supported."
                 )
+        inputs = head_config["model"]["inputs"]
+        if len(inputs) != 1:
+            raise ValueError(
+                f"Only one input supported for YuNetParser, got {len(inputs)} inputs."
+            )
+        self.input_shape = inputs[0].get("shape")
+        self.layout = inputs[0].get("layout")
+        if self.layout == "NHWC":
+            self.input_size = [self.input_shape[2], self.input_shape[1]]
+        elif self.layout == "NCHW":
+            self.input_size = [self.input_shape[3], self.input_shape[2]]
+        else:
+            raise ValueError(f"Input layout {self.layout} not supported for input_size extraction.")
 
         return self
 

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -142,7 +142,7 @@ class YuNetParser(DetectionParser):
                 raise ValueError(
                     f"Unexpected output layer {output_layer}. Only loc, conf, and iou output layers are supported."
                 )
-        inputs = head_config["model"]["inputs"]
+        inputs = head_config["model_inputs"]
         if len(inputs) != 1:
             raise ValueError(
                 f"Only one input supported for YuNetParser, got {len(inputs)} inputs."

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -22,7 +22,7 @@ class YuNetParser(DetectionParser):
     max_det : int
         Maximum number of detections to keep.
     input_size : Tuple[int, int]
-        Input size.
+        Input size (width, height).
     loc_output_layer_name: str
         Name of the output layer containing the location predictions.
     conf_output_layer_name: str
@@ -246,7 +246,7 @@ class YuNetParser(DetectionParser):
 
             # decode detections
             bboxes, keypoints, scores = decode_detections(
-                input_shape=self.input_size,
+                input_size=self.input_size,
                 loc=loc,
                 conf=conf,
                 iou=iou,
@@ -265,7 +265,7 @@ class YuNetParser(DetectionParser):
                 bboxes=bboxes,
                 keypoints=keypoints,
                 scores=scores,
-                input_shape=self.input_size,
+                input_size=self.input_size,
             )
 
             # run nms

--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -1,4 +1,5 @@
 from typing import Dict
+import inspect
 
 import depthai as dai
 
@@ -53,7 +54,21 @@ class ParserGenerator(dai.node.ThreadedHostNode):
                 )
 
             head = decode_head(head)
-            parsers[index] = pipeline.create(parser).build(head)
+            sig = inspect.signature(parser.build) # inspect build() method
+            if 'inputs_size' in sig.parameters:
+                inputs_size = []
+                for input in nn_archive.getConfig().model.inputs:
+                    breakpoint()
+                    if input.layout == "NHWC":
+                        _, height, width, _ = input.shape
+                    elif input.layout == "NCHW":
+                        _, _, height, width = input.shape
+                    else:
+                        raise ValueError(f"Input layout {input.layout} not supported for input_size extraction.")
+                    inputs_size.append([width,height])
+                parsers[index] = pipeline.create(parser).build(head, inputs_size)
+            else:
+                parsers[index] = pipeline.create(parser).build(head)
 
         return parsers
 

--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -58,7 +58,6 @@ class ParserGenerator(dai.node.ThreadedHostNode):
             if "inputs_size" in sig.parameters:
                 inputs_size = []
                 for input in nn_archive.getConfig().model.inputs:
-                    breakpoint()
                     if input.layout == "NHWC":
                         _, height, width, _ = input.shape
                     elif input.layout == "NCHW":

--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -53,9 +53,9 @@ class ParserGenerator(dai.node.ThreadedHostNode):
                 )
 
             head_config = decode_head(head)
-            head_config["model"] = {"inputs": []}
+            head_config["model_inputs"] = []
             for input in nn_archive.getConfig().model.inputs:
-                head_config["model"]["inputs"].append(
+                head_config["model_inputs"].append(
                     {"shape": input.shape, "layout": input.layout}
                 )
             parsers[index] = pipeline.create(parser).build(head_config)

--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -1,5 +1,5 @@
-from typing import Dict
 import inspect
+from typing import Dict
 
 import depthai as dai
 
@@ -54,8 +54,8 @@ class ParserGenerator(dai.node.ThreadedHostNode):
                 )
 
             head = decode_head(head)
-            sig = inspect.signature(parser.build) # inspect build() method
-            if 'inputs_size' in sig.parameters:
+            sig = inspect.signature(parser.build)
+            if "inputs_size" in sig.parameters:
                 inputs_size = []
                 for input in nn_archive.getConfig().model.inputs:
                     breakpoint()
@@ -64,8 +64,10 @@ class ParserGenerator(dai.node.ThreadedHostNode):
                     elif input.layout == "NCHW":
                         _, _, height, width = input.shape
                     else:
-                        raise ValueError(f"Input layout {input.layout} not supported for input_size extraction.")
-                    inputs_size.append([width,height])
+                        raise ValueError(
+                            f"Input layout {input.layout} not supported for input_size extraction."
+                        )
+                    inputs_size.append([width, height])
                 parsers[index] = pipeline.create(parser).build(head, inputs_size)
             else:
                 parsers[index] = pipeline.create(parser).build(head)

--- a/depthai_nodes/parser_generator.py
+++ b/depthai_nodes/parser_generator.py
@@ -1,4 +1,3 @@
-import inspect
 from typing import Dict
 
 import depthai as dai


### PR DESCRIPTION
Adding a fix to the parsers that require model input size and cannot deduce it from the model outputs (`YuNetParser` and `LaneDetectionParser`) by extending the `build()` method to look for the the `input_shape` within the `head_config`. Additionally, `ParserGenerator` is updated to set the `input_shape` argument aromatically based on the relevant `NN Archive`.

Some additional changes:
- the default `input_size` was removed for the `LaneDetectionParser`,
- all `input_shape` variable/parameter names were changed to `input_size` because it better fits their meaning (shape resembles NCHW/NHWC whereas we only describe HW) → this is more or less a refactoring change only, but it also effects the `input_size` setters for the two parsers (`setInputShape` → `setInputSize`)

The implemented changes were tested on **YuNet** and **Ultra Fast Lane Detection** models.