### PR TITLE
feat: adjust ParsingNeuralNetwork to DAI v3 alpha6

### DIFF
--- a/depthai_nodes/parsing_neural_network.py
+++ b/depthai_nodes/parsing_neural_network.py
@@ -39,22 +39,10 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         self._nn = self._pipeline.create(dai.node.NeuralNetwork)
         self._parsers: Dict[int, BaseParser] = {}
 
-    @overload
-    def build(
-        self, input: dai.Node.Output, nn_source: dai.NNModelDescription, fps: int
-    ) -> "ParsingNeuralNetwork":
-        ...
-
-    @overload
-    def build(
-        self, input: dai.Node.Output, nn_source: dai.NNArchive, fps: int
-    ) -> "ParsingNeuralNetwork":
-        ...
-
     def build(
         self,
         input: dai.Node.Output,
-        nn_source: Union[dai.NNModelDescription, dai.NNArchive],
+        slug: str,
         fps: int = None,
     ) -> "ParsingNeuralNetwork":
         """Builds the underlying NeuralNetwork node and creates parser nodes for each
@@ -63,9 +51,8 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         @param input: Node's input. It is a linking point to which the NeuralNetwork is
             linked. It accepts the output of a Camera node.
         @type input: Node.Input
-        @param nn_source: NNModelDescription object containing the HubAI model
-            descriptors, or NNArchive object of the model.
-        @type nn_source: Union[dai.NNModelDescription, dai.NNArchive]
+        @param slug: HubAI model slug.
+        @type slug: str
         @param fps: FPS limit for the model runtime.
         @type fps: int
         @return: Returns the ParsingNeuralNetwork object.
@@ -74,21 +61,23 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
             object.
         """
 
-        if isinstance(nn_source, dai.NNModelDescription):
-            if not nn_source.platform:
-                nn_source.platform = (
-                    self.getParentPipeline().getDefaultDevice().getPlatformAsString()
-                )
-            self._nn_archive = dai.NNArchive(dai.getModelFromZoo(nn_source))
-        elif isinstance(nn_source, dai.NNArchive):
-            self._nn_archive = nn_source
-        else:
-            raise ValueError(
-                "nn_source must be either a NNModelDescription or NNArchive"
+        if isinstance(slug, str):
+            if ":" not in slug:
+                raise ValueError("Slug must be in the format <model_slug>:<model_version_slug>.")
+            model_slug, model_version_slug = slug.split(":")
+            model_description = dai.NNModelDescription(
+                modelSlug=model_slug,
+                modelVersionSlug=model_version_slug,
             )
+            model_description.platform = (
+                self.getParentPipeline().getDefaultDevice().getPlatformAsString()
+            )
+            self._nn_archive = dai.NNArchive(dai.getModelFromZoo(model_description))
+        else:
+            raise ValueError("Slug must be a string.")
 
         kwargs = {"fps": fps} if fps else {}
-        self._nn.build(input, nn_source, **kwargs)
+        self._nn.build(input, self._nn_archive, **kwargs)
 
         self._updateParsers(self._nn_archive)
         return self


### PR DESCRIPTION
Adding an update to ParsingNeuralNetwork build() method to match the recent changes in DAI (v3alpha6) that allow models to be built directly from slug. 

Previous functionality: `pipeline.create(ParsingNeuralNetwork).build(<CameraNode>, <dai.NNModelDescription OR dai.NNArchive>)`

The updated functionality:
`pipeline.create(ParsingNeuralNetwork).build(<CameraNode>, <Slug>)`