### PR TITLE
Feat: ImgDetectionsExtended masks should be set if specified in the function call

### DIFF
--- a/depthai_nodes/ml/messages/creators/detection.py
+++ b/depthai_nodes/ml/messages/creators/detection.py
@@ -67,7 +67,9 @@ def create_detection_message(
         raise ValueError(f"Bounding boxes should be a numpy array, got {type(bboxes)}.")
 
     if len(bboxes) == 0:
-        return ImgDetectionsExtended()
+        img_detections = ImgDetectionsExtended()
+        img_detections.masks = masks
+        return img_detections
 
     if len(bboxes.shape) != 2:
         raise ValueError(

--- a/depthai_nodes/ml/messages/creators/detection.py
+++ b/depthai_nodes/ml/messages/creators/detection.py
@@ -68,7 +68,8 @@ def create_detection_message(
 
     if len(bboxes) == 0:
         img_detections = ImgDetectionsExtended()
-        img_detections.masks = masks
+        if masks is not None:
+            img_detections.masks = masks
         return img_detections
 
     if len(bboxes.shape) != 2:

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -284,7 +284,7 @@ class YOLOExtendedParser(BaseParser):
             )
 
             bboxes, labels, scores, additional_output = [], [], [], []
-            final_mask = np.full(input_shape, -1, dtype=float)
+            final_mask = np.full(input_shape, -1, dtype=np.int16)
             for i in range(results.shape[0]):
                 bbox, conf, label, other = (
                     results[i, :4],

--- a/tests/unittests/test_creators/test_detections.py
+++ b/tests/unittests/test_creators/test_detections.py
@@ -297,5 +297,41 @@ def test_bboxes_scores_keypoints():
             assert keypoint.y == keypoints[i][ii][1]
 
 
+def test_bboxes_masks():
+    bboxes = np.array(
+        [[0.2, 0.2, 0.4, 0.4], [0.5, 0.5, 0.1, 0.1], [0.1, 0.1, 0.2, 0.2]]
+    )
+
+    scores = np.array([0.1, 0.2, 0.3])
+    mask = np.array([[-1, -1, -1], [-1, 0, -1], [-1, -1, -1]], dtype=np.int16)
+
+    message = create_detection_message(bboxes=bboxes, scores=scores, masks=mask)
+
+    assert isinstance(message, ImgDetectionsExtended)
+    assert np.array_equal(message.masks, mask)
+
+
+def test_no_bboxes_masks():
+    bboxes = np.array([])
+    scores = np.array([])
+    mask = np.array([[-1, -1, -1], [-1, 0, -1], [-1, -1, -1]], dtype=np.int16)
+
+    message = create_detection_message(bboxes=bboxes, scores=scores, masks=mask)
+
+    assert isinstance(message, ImgDetectionsExtended)
+    assert np.array_equal(message.masks, mask)
+
+
+def test_no_masks_no_bboxes():
+    bboxes = np.array([])
+    scores = np.array([])
+    mask = np.array([[]], dtype=np.int16)
+
+    message = create_detection_message(bboxes=bboxes, scores=scores, masks=mask)
+
+    assert isinstance(message, ImgDetectionsExtended)
+    assert np.array_equal(message.masks, mask)
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
When a segmentation + detection model like YOLO-P has no detections, the `create_detection_message` should set the `masks` parameter to the output shape of the model with -1 as values. This kind of mask is already created in `yolo.py` parser but not properly processed when no detections are found.  