### PR TITLE
Increase test timeout.

### DIFF
--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -73,14 +73,14 @@ def test_pipelines(IP: str, ip_platform: str, nn_archive_path, slug):
                 f"python manual.py -s {slug} -ip {IP}",
                 shell=True,
                 check=True,
-                timeout=30,
+                timeout=90,
             )
         else:
             subprocess.run(
                 f"python manual.py -nn {nn_archive_path} -ip {IP}",
                 shell=True,
                 check=True,
-                timeout=30,
+                timeout=90,
             )
     except subprocess.CalledProcessError as e:
         if e.returncode == 5:


### PR DESCRIPTION
Simple timeout for subprocess increase. It turns out that sometimes 30s is not enough for the test to finish - so increasing in to 90s.