### PR TITLE
E2E Tests: ImageManip node and better checks.

### DIFF
--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -84,15 +84,17 @@ def test_pipelines(IP: str, ip_platform: str, nn_archive_path, slug):
             )
     except subprocess.CalledProcessError as e:
         if e.returncode == 5:
-            pytest.skip(f"Model not supported on {ip_platform}.")
+            pytest.skip(f"Model {slug} not supported on {ip_platform}.")
         elif e.returncode == 6:
             pytest.skip(f"Can't connect to the device with IP/mxid: {IP}")
         elif e.returncode == 7:
             pytest.skip(f"Couldn't find model {slug} in the ZOO")
         elif e.returncode == 8:
             pytest.skip(
-                "The model is not supported in this test. (small input size, grayscale image, etc.)"
+                f"The model {slug} is not supported in this test. (small input size, grayscale image, etc.)"
             )
+        elif e.returncode == 9:
+            pytest.skip(f"Couldn't load the model {slug} from NN archive.")
         else:
             raise RuntimeError("Pipeline crashed.") from e
     except subprocess.TimeoutExpired:

--- a/tests/end_to_end/utils.py
+++ b/tests/end_to_end/utils.py
@@ -61,6 +61,13 @@ def get_input_shape(nn_archive: dai.NNArchive) -> Tuple[int, int]:
     return input_shape
 
 
+def get_num_inputs(nn_archive: dai.NNArchive) -> int:
+    """Get the number of inputs of the model from the NN archive."""
+    inputs = get_inputs_from_archive(nn_archive)
+
+    return len(inputs)
+
+
 def parse_model_slug(full_slug) -> Tuple[str, str]:
     """Parse the model slug into model_slug and model_version_slug."""
     if ":" not in full_slug:


### PR DESCRIPTION
Checks added in E2E tests:
-  Catches the error when downloading the model from ZOO
-  Catches the error when loading the NN archive
-  Checks if the model has more than one output

Every catch has a `print(e)` so we know whats wrong when running it with `manual.py`

This PR also adds `ImageManipV2` node to the pipeline if the model input size is not divisible by 2 (e.g. 513x513 in deeplab) or the input size is too small. We request 2 or 4 times bigger input size from the camera and then resize it down to model's input size with `ImageManipV2` node.

This feature now runs more models in E2E testing.