### PR TITLE
Integration tests for parsers.

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -42,8 +42,8 @@ jobs:
       - name: Setup HIL Tools
         run: |
           cd hil_framework
-          sudo chmod +x setup_hil_tools.sh 
-          ./setup_hil_tools.sh -ga
+          sudo chmod +x ./setup/setup_hil_tools.sh 
+          ./setup/setup_hil_tools.sh -ga
           
       - name: Add HIL Tools to Path
         run: |

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,0 +1,64 @@
+name: Integration tests for parsers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      additional-parameter:
+        description: 'Additional parameter: -all or -p <parser_name>. Default: -all. If -p is used: -p <parser_name>'
+        required: true
+        default: '-all'
+      branch:
+        description: 'Branch to run the tests on. Default: main'
+        required: true
+        default: 'main'
+      testbed:
+        description: 'Testbed to run the tests on. Default: oak4-s'
+        required: true
+        default: 'oak4-s'
+
+jobs:
+  Integration-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.12]
+
+    steps:
+      - name: Setup WireGuard
+        run: |
+          sudo apt install wireguard
+          echo "${{ secrets.WIREGUARD_PRIVATE_KEY }}" > privatekey
+          sudo ip link add dev wg0 type wireguard
+          sudo ip address add dev wg0 10.12.99.26 peer 10.12.99.1
+          sudo wg set wg0 listen-port 48123 private-key privatekey peer ${{ secrets.WIREGUARD_PUBLIC_KEY }} allowed-ips 10.12.99.1/32,10.12.99.26/32,10.12.0.0/16 endpoint "${{ secrets.WIREGUARD_PUBLIC_ENDPOINT }}"
+          sudo ip link set up dev wg0
+          sudo ip route add 10.12.0.0/16 dev wg0
+
+      - name: Clone HIL Framework
+        run: |
+          git clone https://oauth2:${{secrets.GITLAB_TOKEN}}@gitlab.luxonis.com/luxonis/hil_lab/hil_framework.git --recursive
+      
+      - name: Setup HIL Tools
+        run: |
+          cd hil_framework
+          sudo chmod +x setup_hil_tools.sh 
+          ./setup_hil_tools.sh -ga
+          
+      - name: Add HIL Tools to Path
+        run: |
+          cd hil_framework
+          echo "$(pwd)/lib_testbed/tools" >> $GITHUB_PATH
+          echo "PYTHONPATH="$PYTHONPATH:$(pwd)"" >> $GITHUB_ENV
+          echo "HIL_FRAMEWORK_PATH="$(pwd)"" >> $GITHUB_ENV
+          
+      - name: Run Test
+        run: |
+          CMD="hil --testbed ${{ github.event.inputs.testbed }} --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          eval $CMD
+
+      - name: Stop WireGuard
+        if: always()
+        run: |
+          sudo ip link set down dev wg0
+          sudo ip link delete dev wg0

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -6,7 +6,7 @@ on:
       additional-parameter:
         description: 'Additional parameter: -all or -p <parser_name>. Default: -all. If -p is used: -p <parser_name>'
         required: true
-        default: '-all'
+        default: '-all --download'
       branch:
         description: 'Branch to run the tests on. Default: main'
         required: true
@@ -42,8 +42,8 @@ jobs:
       - name: Setup HIL Tools
         run: |
           cd hil_framework
-          sudo chmod +x setup_hil_tools.sh 
-          ./setup_hil_tools.sh -ga
+          sudo chmod +x ./setup/setup_hil_tools.sh 
+          ./setup/setup_hil_tools.sh -ga
           
       - name: Add HIL Tools to Path
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ cython_debug/
 
 #VS Code
 .vscode/
+
+/tests/integration_tests/nn_datas

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-cov>=4.1.0
 pytest-subtests>=0.12.1
 pytest-md>=0.2.0
 coverage-badge>=1.1.0
+b2==3.16.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,7 @@ def pytest_addoption(parser):
         default="",
         help="RVC platform to run the tests on.",
     )
+    parser.addoption(
+        "--models", action="store", default="", help="Model slug from the ZOO."
+    )
+    parser.addoption("--parsers", action="store", default="", help="Parsers to test.")

--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -1,0 +1,63 @@
+# Integration tests for Parsers in Depthai-nodes
+
+## Overview
+
+This directory contains integration tests for parsers in DepthAI-nodes. These tests are designed to simulate a neural network output and send it to the parser node. The parser node will parse the output and return the message. The tests check if the parser outputs the expected message. Since we know what `NNData` we are sending to the parser, we can check if the outputed message is correct.
+
+The testing pipeline is as follows:
+
+1. Load the neural network archive.
+1. Load the parser node with `ParserGenerator` based on the NN archive.
+1. Read and load the `NNData` from pickle file. It contains the output of the neural network.
+1. Send the `NNData` to the parser node.
+1. Read and load the expected message from the pickle file.
+1. Check if the parser node outputs the expected message.
+
+We are storing tests in the B2 bucket. In the beginning, we download the tests from the bucket and store them in the `nn_datas` directory. The tests are stored in the following structure:
+
+```
+nn_datas
+├── <parser_name>
+│   ├── <model-slug.pkl> # Contains the NNData
+│   └── <model-slug_output.pkl> # Contains the expected message
+│   └── <model-slug.png> # Contains the input image
+```
+
+for example:
+
+```
+nn_datas
+├── ClassificationParser
+│   ├── efficientnet-lite.pkl
+│   └── efficientnet-lite_output.pkl
+│   └── efficientnet-lite.png
+├── FastSAMParser
+│   ├── fastsam-s.pkl
+│   └── fastsam-s_output.pkl
+│   └── fastsam-s.png
+```
+
+## Test generation
+
+To generate a new test for the parser, you can use `extract_nn_data.py` script. The script will extract the `NNData` from the neural network output and store it in the pickle file. The script requires the following arguments: `-m` for the model slug, `-img` for the input image, and optional `-ip` for the device IP or mxid.
+
+The script does not generate the expected message because each parser has its own message format and DAI messages can not be dumped in the pickle file.
+
+One example for generating the expected message for the `ClassificationParser`:
+
+```python
+expected_output = {
+    'model': 'luxonis/efficientnet-lite:lite0-224x224',
+    'parser': 'ClassificationParser',
+    'classes': ['wolf', 'dog', 'cat'],
+    'scores': [0.7, 0.2, 0.1]
+}
+
+with open('nn_datas/ClassificationParser/efficientnet-lite_output.pkl', 'wb') as f:
+    pickle.dump(expected_output, f)
+```
+
+## Running the tests
+
+To run the tests, you can use the `main.py` script. You can use `--all` flag to test all parsers or test a specific parser with `-p` flag.
+You would need the B2 credentials to download the tests from the bucket and set it in the ENV variables `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY`.

--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -57,6 +57,8 @@ with open('nn_datas/ClassificationParser/efficientnet-lite_output.pkl', 'wb') as
     pickle.dump(expected_output, f)
 ```
 
+In the end, you should have all the files in the parser-specific directory inside `nn_datas` directory. You need to upload the parser directory to the B2 bucket.
+
 ## Running the tests
 
 To run the tests, you can use the `main.py` script. You can use `--all` flag to test all parsers or test a specific parser with `-p` flag.

--- a/tests/integration_tests/check_messages.py
+++ b/tests/integration_tests/check_messages.py
@@ -33,6 +33,10 @@ def check_classification_msg(message: Classifications, expected_output: Dict[str
         "score": 0.9
     }
     """
+    assert isinstance(
+        message, Classifications
+    ), f"The message is not a Classifications. Got {type(message)}."
+
     print(
         f"Expected top class: {expected_output['class']}, predicted top class: {message.top_class}"
     )
@@ -53,6 +57,10 @@ def check_classification_sequence_msg(
         "parser": "ClassificationSequenceParser",
         "class": ['HELLO']
     """
+    assert isinstance(
+        message, Classifications
+    ), f"The message is not a Classifications. Got {type(message)}."
+
     print(
         f"Expected top class: {expected_output['class']}, predicted top class: {message.classes}"
     )
@@ -74,6 +82,10 @@ def check_embeddings_msg(message: dai.NNData, expected_output: Dict[str, Any]):
         "embeddings": array([[-9.47265625e-02, -1.23901367e-01,...]])
     }
     """
+    assert isinstance(
+        message, dai.NNData
+    ), f"The message is not a dai.NNData. Got {type(message)}."
+
     outputs = message.getAllLayerNames()
     assert len(outputs) == 1, "The number of outputs must be 1."
     embeddings = message.getTensor(outputs[0])
@@ -98,6 +110,10 @@ def check_segmentation_msg(
         "mask": np.array([[0, 0, 0, ..., 0, 0, 0]])
     }
     """
+    assert isinstance(
+        message, SegmentationMask
+    ), f"The message is not a SegmentationMask. Got {type(message)}."
+
     mask = message.mask
 
     expected_mask = expected_output["mask"]
@@ -132,6 +148,10 @@ def check_keypoints_msg(
         "parser": "KeypointParser",
         "keypoints": [[0.1, 0.2], ...]
     """
+    assert isinstance(
+        message, Keypoints
+    ), f"The message is not a Keypoints. Got {type(message)}."
+
     keypoints = [[kp.x, kp.y] for kp in message.keypoints]
     keypoints = np.array(keypoints)
     expected_keypoints = np.array(expected_output["keypoints"])
@@ -164,6 +184,10 @@ def check_image_msg(message: dai.ImgFrame, expected_output: Dict[str, Any]):
         "output": np.array([[0, 0, 0, ..., 0, 0, 0]])
     }
     """
+    assert isinstance(
+        message, dai.ImgFrame
+    ), f"The message is not a dai.ImgFrame. Got {type(message)}."
+
     image = message.getCvFrame()
     expected_image = expected_output["output"]
     print(
@@ -183,6 +207,10 @@ def check_cluster_msg(message: Clusters, expected_output: Dict[str, Any]):
         "parser": "LaneDetectionParser",
         "clusters": [[[0.1, 0.2], ...]]
     """
+    assert isinstance(
+        message, Clusters
+    ), f"The message is not a Clusters. Got {type(message)}."
+
     clusters = message.clusters
     expected_clusters = expected_output["clusters"]
     clusters_list = []
@@ -212,6 +240,10 @@ def check_map_msg(message: Map2D, expected_output: Dict[str, Any]):
         "map": np.array([[0, 0, 0, ..., 0, 0, 0]])
     }
     """
+    assert isinstance(
+        message, Map2D
+    ), f"The message is not a Map2D. Got {type(message)}."
+
     map_tensor = message.map
     expected_map = expected_output["map"]
     print(
@@ -247,6 +279,10 @@ def check_detection_msg(
         ]
     }
     """
+    assert isinstance(
+        message, ImgDetectionsExtended
+    ), f"The message is not a ImgDetectionsExtended. Got {type(message)}."
+
     predicted_detections = []
     expected_detections: List[Dict[str, Any]] = expected_output["detections"]
 
@@ -332,6 +368,10 @@ def check_line_msg(message: Lines, expected_output: Dict[str, Any]):
         ]
     }
     """
+    assert isinstance(
+        message, Lines
+    ), f"The message is not a Lines. Got {type(message)}."
+
     expected_lines: List[Dict[str, Any]] = expected_output["lines"]
     predicted_lines = []
     for line in message.lines:
@@ -371,6 +411,10 @@ def check_regression_msg(message: Predictions, expected_output: Dict[str, Any]):
         "value": [0.4, 0.2, 0.1]
     }
     """
+    assert isinstance(
+        message, Predictions
+    ), f"The message is not a Predictions. Got {type(message)}."
+
     predictions = message.predictions
     predictions = np.array([pred.prediction for pred in predictions])
     expected_predictions = np.array(expected_output["value"])

--- a/tests/integration_tests/check_messages.py
+++ b/tests/integration_tests/check_messages.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 import depthai as dai
 import numpy as np
+from utils import extract_main_slug
 
 from depthai_nodes.ml.messages import (
     Classifications,
@@ -13,10 +14,6 @@ from depthai_nodes.ml.messages import (
     Map2D,
     SegmentationMask,
 )
-
-
-def extract_main_slug(model_slug: str) -> str:
-    return model_slug.split("/")[1].split(":")[0]
 
 
 def load_expected_output(model: str, parser: str) -> Dict[str, Any]:

--- a/tests/integration_tests/check_messages.py
+++ b/tests/integration_tests/check_messages.py
@@ -139,7 +139,6 @@ def check_segmentation_msg(
 def check_keypoints_msg(
     message: Keypoints,
     expected_output: Dict[str, Any],
-    distance_threshold: float = 0.001,
 ):
     """
     Expected output format:
@@ -164,15 +163,7 @@ def check_keypoints_msg(
         keypoints.shape == expected_keypoints.shape
     ), f"The shape of the keypoints is different. Expects {expected_keypoints.shape}, got {keypoints.shape}"
 
-    for gt_kpt in expected_keypoints:
-        min_dist = float("inf")
-        for pred_kpt in keypoints:
-            dist = (gt_kpt[0] - pred_kpt[0]) ** 2 + (gt_kpt[1] - pred_kpt[1]) ** 2
-            if dist < min_dist:
-                min_dist = dist
-        assert (
-            min_dist < distance_threshold
-        ), f"Expected min distance < {distance_threshold}, got {min_dist}"
+    np.testing.assert_allclose(keypoints, expected_keypoints, rtol=1e-2)
 
 
 def check_image_msg(message: dai.ImgFrame, expected_output: Dict[str, Any]):

--- a/tests/integration_tests/check_messages.py
+++ b/tests/integration_tests/check_messages.py
@@ -24,6 +24,15 @@ def load_expected_output(model: str, parser: str) -> Dict[str, Any]:
 
 
 def check_classification_msg(message: Classifications, expected_output: Dict[str, Any]):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/efficientnet-lite:lite0-224x224",
+        "parser": "ClassificationParser",
+        "class": "car",
+        "score": 0.9
+    }
+    """
     print(
         f"Expected top class: {expected_output['class']}, predicted top class: {message.top_class}"
     )
@@ -37,6 +46,13 @@ def check_classification_msg(message: Classifications, expected_output: Dict[str
 def check_classification_sequence_msg(
     message: Classifications, expected_output: Dict[str, Any]
 ):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/efficientnet-lite:lite0-224x224",
+        "parser": "ClassificationSequenceParser",
+        "class": ['HELLO']
+    """
     print(
         f"Expected top class: {expected_output['class']}, predicted top class: {message.classes}"
     )
@@ -50,6 +66,14 @@ def check_classification_sequence_msg(
 
 
 def check_embeddings_msg(message: dai.NNData, expected_output: Dict[str, Any]):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/arcface:lfw-112x112",
+        "parser": "EmbeddingsParser",
+        "embeddings": array([[-9.47265625e-02, -1.23901367e-01,...]])
+    }
+    """
     outputs = message.getAllLayerNames()
     assert len(outputs) == 1, "The number of outputs must be 1."
     embeddings = message.getTensor(outputs[0])
@@ -66,6 +90,14 @@ def check_embeddings_msg(message: dai.NNData, expected_output: Dict[str, Any]):
 def check_fastsam_msg(
     message: SegmentationMask, expected_output: Dict[str, Any], threshold: float = 0.9
 ):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/fastsam-s:512x288",
+        "parser": "FastSAMParser",
+        "mask": np.array([[0, 0, 0, ..., 0, 0, 0]])
+    }
+    """
     mask = message.mask
 
     expected_mask = expected_output["mask"]
@@ -93,6 +125,13 @@ def check_keypoints_msg(
     expected_output: Dict[str, Any],
     distance_threshold: float = 0.001,
 ):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/mediapipe-face-landmarker:192x192",
+        "parser": "KeypointParser",
+        "keypoints": [[0.1, 0.2], ...]
+    """
     keypoints = [[kp.x, kp.y] for kp in message.keypoints]
     keypoints = np.array(keypoints)
     expected_keypoints = np.array(expected_output["keypoints"])
@@ -117,6 +156,14 @@ def check_keypoints_msg(
 
 
 def check_image_msg(message: dai.ImgFrame, expected_output: Dict[str, Any]):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/dncnn3:240x320",
+        "parser": "ImageOutputParser",
+        "output": np.array([[0, 0, 0, ..., 0, 0, 0]])
+    }
+    """
     image = message.getCvFrame()
     expected_image = expected_output["output"]
     print(
@@ -129,6 +176,13 @@ def check_image_msg(message: dai.ImgFrame, expected_output: Dict[str, Any]):
 
 
 def check_cluster_msg(message: Clusters, expected_output: Dict[str, Any]):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/ultra-fast-lane-detection:culane-800x288",
+        "parser": "LaneDetectionParser",
+        "clusters": [[[0.1, 0.2], ...]]
+    """
     clusters = message.clusters
     expected_clusters = expected_output["clusters"]
     clusters_list = []
@@ -150,6 +204,14 @@ def check_cluster_msg(message: Clusters, expected_output: Dict[str, Any]):
 
 
 def check_map_msg(message: Map2D, expected_output: Dict[str, Any]):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/dm-count:sha-144x256",
+        "parser": "MapOutputParser",
+        "map": np.array([[0, 0, 0, ..., 0, 0, 0]])
+    }
+    """
     map_tensor = message.map
     expected_map = expected_output["map"]
     print(
@@ -164,6 +226,27 @@ def check_map_msg(message: Map2D, expected_output: Dict[str, Any]):
 def check_detection_msg(
     message: ImgDetectionsExtended, expected_output: Dict[str, Any]
 ):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/scrfd-face-detection:10g-640x640",
+        "parser": "SCRFDParser",
+        "detections": [
+            {
+                "confidence": 0.9,
+                "label": "person",
+                "x_center": 0.1,
+                "y_center": 0.2,
+                "width": 0.3,
+                "height": 0.4,
+                "angle": 0.5,
+                "keypoints": [[0.1, 0.2, 0.3], ...],
+                "mask": np.array([[0, 0, 0, ..., 0, 0, 0]])
+            },
+            ...
+        ]
+    }
+    """
     predicted_detections = []
     expected_detections: List[Dict[str, Any]] = expected_output["detections"]
 

--- a/tests/integration_tests/check_messages.py
+++ b/tests/integration_tests/check_messages.py
@@ -1,0 +1,320 @@
+import pickle
+from typing import Any, Dict, List
+
+import depthai as dai
+import numpy as np
+
+from depthai_nodes.ml.messages import (
+    Classifications,
+    Clusters,
+    ImgDetectionsExtended,
+    Keypoints,
+    Lines,
+    Map2D,
+    SegmentationMask,
+)
+
+
+def extract_main_slug(model_slug: str) -> str:
+    return model_slug.split("/")[1].split(":")[0]
+
+
+def load_expected_output(model: str, parser: str) -> Dict[str, Any]:
+    model = extract_main_slug(model)
+    with open(f"nn_datas/{parser}/{model}_output.pkl", "rb") as f:
+        return pickle.load(f)
+
+
+def check_classification_msg(message: Classifications, expected_output: Dict[str, Any]):
+    print(
+        f"Expected top class: {expected_output['class']}, predicted top class: {message.top_class}"
+    )
+    print(
+        f"Expected top score: {expected_output['score']}, predicted top score: {message.top_score}"
+    )
+    assert message.top_class == expected_output["class"]
+    np.testing.assert_allclose(message.top_score, expected_output["score"], rtol=1e-2)
+
+
+def check_classification_sequence_msg(
+    message: Classifications, expected_output: Dict[str, Any]
+):
+    print(
+        f"Expected top class: {expected_output['class']}, predicted top class: {message.classes}"
+    )
+    assert len(message.classes) == len(
+        expected_output["class"]
+    ), "The number of classes is different."
+    for i in range(len(message.classes)):
+        assert (
+            message.classes[i] == expected_output["class"][i]
+        ), f"Class {i} is different."
+
+
+def check_embeddings_msg(message: dai.NNData, expected_output: Dict[str, Any]):
+    outputs = message.getAllLayerNames()
+    assert len(outputs) == 1, "The number of outputs must be 1."
+    embeddings = message.getTensor(outputs[0])
+    expected_embeddings = expected_output["embeddings"]
+    print(
+        f"Expected embeddings shape: {expected_embeddings.shape}, predicted embeddings shape: {embeddings.shape}"
+    )
+    assert (
+        embeddings.shape == expected_embeddings.shape
+    ), "The shape of the embeddings is different."
+    np.testing.assert_allclose(embeddings, expected_embeddings, rtol=1e-2)
+
+
+def check_fastsam_msg(
+    message: SegmentationMask, expected_output: Dict[str, Any], threshold: float = 0.9
+):
+    mask = message.mask
+
+    expected_mask = expected_output["mask"]
+    print(
+        f"Expected mask shape: {expected_mask.shape}, predicted mask shape: {mask.shape}"
+    )
+    assert (
+        mask.shape == expected_mask.shape
+    ), f"The shape of the mask is different. Expects {expected_mask.shape}, got {mask.shape}"
+    assert (
+        mask.dtype == expected_mask.dtype
+    ), f"The dtype of the mask is different. Expects {expected_mask.dtype}, got {mask.dtype}"
+
+    correct = (mask == expected_mask).sum()
+    total = expected_mask.size
+    acc = correct / total
+    print(f"Accuracy: {acc}")
+    assert (
+        acc > threshold
+    ), f"The accuracy {acc} is lower than the threshold {threshold}"
+
+
+def check_keypoints_msg(
+    message: Keypoints,
+    expected_output: Dict[str, Any],
+    distance_threshold: float = 0.001,
+):
+    keypoints = [[kp.x, kp.y] for kp in message.keypoints]
+    keypoints = np.array(keypoints)
+    expected_keypoints = np.array(expected_output["keypoints"])
+    if expected_keypoints.shape[1] == 3:
+        expected_keypoints = expected_keypoints[:, :2]  # we dont need the confidences
+    print(
+        f"Expected keypoints shape: {expected_keypoints.shape}, predicted keypoints shape: {keypoints.shape}"
+    )
+    assert (
+        keypoints.shape == expected_keypoints.shape
+    ), f"The shape of the keypoints is different. Expects {expected_keypoints.shape}, got {keypoints.shape}"
+
+    for gt_kpt in expected_keypoints:
+        min_dist = float("inf")
+        for pred_kpt in keypoints:
+            dist = (gt_kpt[0] - pred_kpt[0]) ** 2 + (gt_kpt[1] - pred_kpt[1]) ** 2
+            if dist < min_dist:
+                min_dist = dist
+        assert (
+            min_dist < distance_threshold
+        ), f"Expected min distance < {distance_threshold}, got {min_dist}"
+
+
+def check_image_msg(message: dai.ImgFrame, expected_output: Dict[str, Any]):
+    image = message.getCvFrame()
+    expected_image = expected_output["output"]
+    print(
+        f"Expected image shape: {expected_image.shape}, predicted image shape: {image.shape}"
+    )
+    assert (
+        image.shape == expected_image.shape
+    ), f"The shape of the image is different. Expects {expected_image.shape}, got {image.shape}"
+    assert np.allclose(image, expected_image, atol=1), "The image is different."
+
+
+def check_cluster_msg(message: Clusters, expected_output: Dict[str, Any]):
+    clusters = message.clusters
+    expected_clusters = expected_output["clusters"]
+    clusters_list = []
+    for cluster in clusters:
+        c = []
+        for point in cluster.points:
+            c.append([point.x, point.y])
+        clusters_list.append(c)
+
+    # check if all points are in the expected clusters
+    for i, cluster in enumerate(expected_clusters):
+        for gt_point in cluster:
+            found = False
+            for pred_point in clusters_list[i]:
+                if np.allclose(gt_point, pred_point, atol=0.001):
+                    found = True
+                    break
+            assert found, f"Expected point {gt_point} not found in the cluster."
+
+
+def check_map_msg(message: Map2D, expected_output: Dict[str, Any]):
+    map_tensor = message.map
+    expected_map = expected_output["map"]
+    print(
+        f"Expected map shape: {expected_map.shape}, predicted map shape: {map_tensor.shape}"
+    )
+    assert (
+        map_tensor.shape == expected_map.shape
+    ), f"The shape of the map is different. Expects {expected_map.shape}, got {map_tensor.shape}"
+    assert np.allclose(map_tensor, expected_map, atol=0.001), "The map is different."
+
+
+def check_detection_msg(
+    message: ImgDetectionsExtended, expected_output: Dict[str, Any]
+):
+    predicted_detections = []
+    expected_detections: List[Dict[str, Any]] = expected_output["detections"]
+
+    for detection in message.detections:
+        d = {
+            "confidence": detection.confidence,
+            "label": detection.label,
+            "x_center": detection.rotated_rect.center.x,
+            "y_center": detection.rotated_rect.center.y,
+            "width": detection.rotated_rect.size.width,
+            "height": detection.rotated_rect.size.height,
+            "angle": detection.rotated_rect.angle,
+            "keypoints": [[kp.x, kp.y, kp.confidence] for kp in detection.keypoints],
+            "mask": message.masks,
+        }
+        predicted_detections.append(d)
+
+    assert (
+        len(predicted_detections) == len(expected_detections)
+    ), f"The number of detections is different. Got {len(predicted_detections)}, expected {len(expected_detections)}"
+    print(
+        f"Expected number of detections: {len(expected_detections)}, predicted number of detections: {len(predicted_detections)}"
+    )
+
+    for i, expected_detection in enumerate(expected_detections):
+        predicted_detection = predicted_detections[i]
+        assert np.allclose(
+            expected_detection["confidence"],
+            predicted_detection["confidence"],
+            atol=0.01,
+        ), f"Expected confidence {expected_detection['confidence']}, got {predicted_detection['confidence']}."
+        assert (
+            expected_detection["label"] == predicted_detection["label"]
+        ), f"Expected label {expected_detection['label']}, got {predicted_detection['label']}."
+        assert np.allclose(
+            expected_detection["x_center"], predicted_detection["x_center"], atol=0.01
+        ), f"Expected x_center {expected_detection['x_center']}, got {predicted_detection['x_center']}."
+        assert np.allclose(
+            expected_detection["y_center"], predicted_detection["y_center"], atol=0.01
+        ), f"Expected y_center {expected_detection['y_center']}, got {predicted_detection['y_center']}."
+        assert np.allclose(
+            expected_detection["width"], predicted_detection["width"], atol=0.01
+        ), f"Expected width {expected_detection['width']}, got {predicted_detection['width']}."
+        assert np.allclose(
+            expected_detection["height"], predicted_detection["height"], atol=0.01
+        ), f"Expected height {expected_detection['height']}, got {predicted_detection['height']}."
+        assert np.allclose(
+            expected_detection["angle"], predicted_detection["angle"], atol=0.01
+        ), f"Expected angle {expected_detection['angle']}, got {predicted_detection['angle']}."
+
+        if "keypoints" in expected_detection.keys():
+            assert np.allclose(
+                expected_detection["keypoints"],
+                predicted_detection["keypoints"],
+                atol=0.01,
+            ), f"Expected keypoints {expected_detection['keypoints']}, got {predicted_detection['keypoints']}."
+
+        if "mask" in expected_detection.keys():
+            print(
+                f"Expected mask shape: {expected_detection['mask'].shape}, predicted mask shape: {predicted_detection['mask'].shape}"
+            )
+            assert (
+                expected_detection["mask"].shape == predicted_detection["mask"].shape
+            ), f"The shape of the mask is different. Expects {expected_detection['mask'].shape}, got {predicted_detection['mask'].shape}"
+            assert np.allclose(
+                expected_detection["mask"], predicted_detection["mask"], atol=0.01
+            ), f"Expected mask {expected_detection['mask']}, got {predicted_detection['mask']}."
+
+
+def check_line_msg(message: Lines, expected_output: Dict[str, Any]):
+    """
+    Expected output format:
+    {
+        "model": "luxonis/m-mlsd-tiny:512x512",
+        "parser": "MLSDParser",
+        "lines": [
+            {
+                "confidence": 0.9,
+                "start_point": [0.1, 0.2],
+                "end_point": [0.3, 0.4]
+            },
+            ...
+        ]
+    }
+    """
+    expected_lines: List[Dict[str, Any]] = expected_output["lines"]
+    predicted_lines = []
+    for line in message.lines:
+        line_dict = {
+            "confidence": line.confidence,
+            "start_point": [line.start_point.x, line.start_point.y],
+            "end_point": [line.end_point.x, line.end_point.y],
+        }
+        predicted_lines.append(line_dict)
+
+    print(
+        f"Expected number of lines: {len(expected_lines)}, predicted number of lines: {len(predicted_lines)}"
+    )
+    assert (
+        len(predicted_lines) == len(expected_lines)
+    ), f"The number of lines is different. Got {len(predicted_lines)}, expected {len(expected_lines)}"
+
+    for i, expected_line in enumerate(expected_lines):
+        predicted_line = predicted_lines[i]
+        assert np.allclose(
+            expected_line["confidence"], predicted_line["confidence"], atol=0.01
+        ), f"Expected confidence {expected_line['confidence']}, got {predicted_line['confidence']}."
+        assert np.allclose(
+            expected_line["start_point"], predicted_line["start_point"], atol=0.01
+        ), f"Expected start_point {expected_line['start_point']}, got {predicted_line['start_point']}."
+        assert np.allclose(
+            expected_line["end_point"], predicted_line["end_point"], atol=0.01
+        ), f"Expected end_point {expected_line['end_point']}, got {predicted_line['end_point']}."
+
+
+def test_output(message, model_slug, parser_name):
+    expected_output = load_expected_output(model_slug, parser_name)
+
+    if expected_output["parser"] == "ClassificationParser":
+        check_classification_msg(message, expected_output)
+    elif expected_output["parser"] == "ClassificationSequenceParser":
+        check_classification_sequence_msg(message, expected_output)
+    elif expected_output["parser"] == "EmbeddingsParser":
+        check_embeddings_msg(message, expected_output)
+    elif expected_output["parser"] == "FastSAMParser":
+        check_fastsam_msg(message, expected_output)
+    elif expected_output["parser"] == "HRNetParser":
+        check_keypoints_msg(message, expected_output)
+    elif expected_output["parser"] == "KeypointParser":
+        check_keypoints_msg(message, expected_output)
+    elif expected_output["parser"] == "ImageOutputParser":
+        check_image_msg(message, expected_output)
+    elif expected_output["parser"] == "LaneDetectionParser":
+        check_cluster_msg(message, expected_output)
+    elif expected_output["parser"] == "MapOutputParser":
+        check_map_msg(message, expected_output)
+    elif expected_output["parser"] == "MPPalmDetectionParser":
+        check_detection_msg(message, expected_output)
+    elif expected_output["parser"] == "MLSDParser":
+        check_line_msg(message, expected_output)
+    elif expected_output["parser"] == "PPTextDetectionParser":
+        check_detection_msg(message, expected_output)
+    elif expected_output["parser"] == "SCRFDParser":
+        check_detection_msg(message, expected_output)
+    elif expected_output["parser"] == "SegmentationParser":
+        check_fastsam_msg(message, expected_output)
+    elif expected_output["parser"] == "SuperAnimalParser":
+        check_keypoints_msg(message, expected_output)
+    elif expected_output["parser"] == "YuNetParser":
+        check_detection_msg(message, expected_output)
+    elif expected_output["parser"] == "YOLOExtendedParser":
+        check_detection_msg(message, expected_output)

--- a/tests/integration_tests/check_messages.py
+++ b/tests/integration_tests/check_messages.py
@@ -87,7 +87,7 @@ def check_embeddings_msg(message: dai.NNData, expected_output: Dict[str, Any]):
     np.testing.assert_allclose(embeddings, expected_embeddings, rtol=1e-2)
 
 
-def check_fastsam_msg(
+def check_segmentation_msg(
     message: SegmentationMask, expected_output: Dict[str, Any], threshold: float = 0.9
 ):
     """
@@ -393,7 +393,7 @@ def test_output(message, model_slug, parser_name):
     elif expected_output["parser"] == "EmbeddingsParser":
         check_embeddings_msg(message, expected_output)
     elif expected_output["parser"] == "FastSAMParser":
-        check_fastsam_msg(message, expected_output)
+        check_segmentation_msg(message, expected_output)
     elif expected_output["parser"] == "HRNetParser":
         check_keypoints_msg(message, expected_output)
     elif expected_output["parser"] == "KeypointParser":
@@ -415,7 +415,7 @@ def test_output(message, model_slug, parser_name):
     elif expected_output["parser"] == "SCRFDParser":
         check_detection_msg(message, expected_output)
     elif expected_output["parser"] == "SegmentationParser":
-        check_fastsam_msg(message, expected_output)
+        check_segmentation_msg(message, expected_output)
     elif expected_output["parser"] == "SuperAnimalParser":
         check_keypoints_msg(message, expected_output)
     elif expected_output["parser"] == "YuNetParser":

--- a/tests/integration_tests/config.py
+++ b/tests/integration_tests/config.py
@@ -1,0 +1,28 @@
+parsers_slugs = {
+    "ClassificationParser": [
+        "luxonis/efficientnet-lite:lite0-224x224",
+        "luxonis/emotion-recognition:260x260",
+    ],
+    "ClassificationSequenceParser": ["luxonis/paddle-text-recognition:320x48"],
+    "EmbeddingsParser": ["luxonis/arcface:lfw-112x112"],
+    "FastSAMParser": ["luxonis/fastsam-s:512x288"],
+    "HRNetParser": ["luxonis/lite-hrnet:18-coco-256x192"],
+    "ImageOutputParser": ["luxonis/dncnn3:240x320"],
+    "KeypointParser": ["luxonis/mediapipe-face-landmarker:192x192"],
+    "LaneDetectionParser": ["luxonis/ultra-fast-lane-detection:culane-800x288"],
+    "MapOutputParser": ["luxonis/dm-count:sha-144x256"],
+    "MPPalmDetectionParser": ["luxonis/mediapipe-palm-detection:192x192"],
+    "MLSDParser": ["luxonis/m-lsd-tiny:512x512"],
+    "PPTextDetectionParser": ["luxonis/paddle-text-detection:256x256"],
+    "SCRFDParser": ["luxonis/scrfd-face-detection:10g-640x640"],
+    "SegmentationParser": [
+        "luxonis/mediapipe-selfie-segmentation:144x256",
+        "luxonis/deeplab-v3-plus:256x256",
+    ],
+    "SuperAnimalParser": ["luxonis/superanimal-landmarker:256x256"],
+    "YOLOExtendedParser": [
+        "luxonis/yolov8-instance-segmentation-nano:coco-512x288",
+        "luxonis/yolov8-nano-pose-estimation:coco-512x288",
+    ],
+    "YuNetParser": ["luxonis/yunet:new-240x320"],
+}

--- a/tests/integration_tests/config.py
+++ b/tests/integration_tests/config.py
@@ -25,4 +25,5 @@ parsers_slugs = {
         "luxonis/yolov8-nano-pose-estimation:coco-512x288",
     ],
     "YuNetParser": ["luxonis/yunet:new-240x320"],
+    "RegressionParser": ["luxonis/gaze-estimation-adas:60x60"],
 }

--- a/tests/integration_tests/extract_nn_data.py
+++ b/tests/integration_tests/extract_nn_data.py
@@ -1,0 +1,108 @@
+import argparse
+import os
+import pickle
+
+import cv2
+import depthai as dai
+from utils import extract_main_slug, extract_parser, get_input_shape
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument("-ip", help="IP address of the device", default="")
+argparser.add_argument(
+    "-img", "--img_path", help="Path to the input image", required=True, type=str
+)
+argparser.add_argument(
+    "-m", "--model_slug", help="Slug of the model from HubAI", required=True, type=str
+)
+
+args = argparser.parse_args()
+IP_mxid = args.ip
+img_path = args.img_path
+model: str = args.model_slug
+
+device = dai.Device(dai.DeviceInfo(IP_mxid))
+device_platform = device.getPlatform().name
+
+# Get the model from the HubAI
+model_description = dai.NNModelDescription(model=model, platform=device_platform)
+archive_path = dai.getModelFromZoo(model_description)
+nn_archive = dai.NNArchive(archive_path)
+
+input_size = get_input_shape(nn_archive)
+input_width = input_size[0]
+input_height = input_size[1]
+parser = extract_parser(nn_archive)
+
+
+class HostImage(dai.node.ThreadedHostNode):
+    def __init__(self):
+        dai.node.ThreadedHostNode.__init__(self)
+        self.out = self.createOutput()
+
+    def run(self):
+        frame = cv2.imread(img_path)
+        if frame is None:
+            raise FileNotFoundError(f"Cannot read image from {img_path}")
+        else:
+            frame = cv2.resize(frame, (input_width, input_height))
+            if device_platform == "RVC2":
+                frame = frame.transpose(2, 0, 1)
+
+            imgFrame = dai.ImgFrame()
+
+            imgFrame.setFrame(frame)
+            imgFrame.setWidth(input_width)
+            imgFrame.setHeight(input_height)
+            imgFrame.setType(
+                dai.ImgFrame.Type.BGR888p
+                if device_platform == "RVC2"
+                else dai.ImgFrame.Type.BGR888i
+            )
+            print("input frame HW:", imgFrame.getHeight(), imgFrame.getWidth())
+
+            self.out.send(imgFrame)
+
+
+with dai.Pipeline(device) as pipeline:
+    image_node = pipeline.create(HostImage)
+
+    model_platforms = [platform.name for platform in nn_archive.getSupportedPlatforms()]
+
+    if device_platform not in model_platforms:
+        print(f"Model not supported on {device_platform}.")
+        device.close()
+        exit(5)
+
+    detection_nn = pipeline.create(dai.node.NeuralNetwork)
+    detection_nn.setNNArchive(nn_archive)
+    image_node.out.link(detection_nn.input)
+
+    nn_queue = detection_nn.out.createOutputQueue()
+    pass_queue = detection_nn.passthrough.createOutputQueue()
+
+    pipeline.start()
+
+    while pipeline.isRunning():
+        nn_data: dai.NNData = nn_queue.get()
+        frame: dai.ImgFrame = pass_queue.get().getCvFrame()
+        tensor_names = nn_data.getAllLayerNames()
+        tensors = {}
+        print("-------------------------------")
+        print("Tensor name | Shape | Data type")
+        print("-------------------------------")
+        for tensor_name in tensor_names:
+            tensor = nn_data.getTensor(tensor_name)
+            print(tensor_name, tensor.shape, tensor.dtype)
+            tensors[tensor_name] = tensor
+
+        if not os.path.exists("nn_datas"):
+            os.makedirs("nn_datas")
+        if not os.path.exists(f"nn_datas/{parser}"):
+            os.makedirs(f"nn_datas/{parser}")
+        with open(f"nn_datas/{parser}/{extract_main_slug(model)}.pkl", "wb") as f:
+            pickle.dump(tensors, f)
+        cv2.imwrite(f"nn_datas/{parser}/{extract_main_slug(model)}.png", frame)
+
+        pipeline.stop()
+
+device.close()

--- a/tests/integration_tests/main.py
+++ b/tests/integration_tests/main.py
@@ -21,17 +21,24 @@ def main():
     arg_parser.add_argument(
         "-p", "--parser", default="", help="Name of the specific parser to test."
     )
+    arg_parser.add_argument(
+        "-d", "--download", action="store_true", help="Download test files"
+    )
 
     args = arg_parser.parse_args()
     models = args.model
     run_all = args.all
     parser = args.parser
+    download = args.download
 
     if os.path.exists("nn_datas"):
         print()
         print("Folder `nn_datas` with test files already exists. Skipping download.")
         print()
     else:
+        download_test_files()
+
+    if download:
         download_test_files()
 
     print(f"Run all tests: {run_all}")
@@ -61,20 +68,18 @@ def main():
         if model in value
     ]
 
-    for model in models:
-        print(f"Running tests for model {model}")
-        command = [
-            "parser_test.py",
-            f"--models={models}",
-            f"--parsers={parsers}",
-            "-v",
-            "--tb=no",
-            "-r a",
-            "--log-cli-level=DEBUG",
-            "--color=yes",
-        ]
-        exitcode = pytest.main(command)
-        sys.exit(exitcode)
+    command = [
+        "parser_test.py",
+        f"--models={models}",
+        f"--parsers={parsers}",
+        "-v",
+        "--tb=no",
+        "-r a",
+        "--log-cli-level=DEBUG",
+        "--color=yes",
+    ]
+    exitcode = pytest.main(command)
+    sys.exit(exitcode)
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/main.py
+++ b/tests/integration_tests/main.py
@@ -1,0 +1,81 @@
+import argparse
+import os
+import sys
+
+import pytest
+from config import parsers_slugs
+from utils import download_test_files
+
+
+def main():
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument(
+        "-m",
+        "--model",
+        type=str,
+        nargs="+",
+        default="",
+        help="Model slug from HubAI.",
+    )
+    arg_parser.add_argument("-all", action="store_true", help="Run all tests")
+    arg_parser.add_argument(
+        "-p", "--parser", default="", help="Name of the specific parser to test."
+    )
+
+    args = arg_parser.parse_args()
+    models = args.model
+    run_all = args.all
+    parser = args.parser
+
+    if os.path.exists("nn_datas"):
+        print()
+        print("Folder `nn_datas` with test files already exists. Skipping download.")
+        print()
+    else:
+        download_test_files()
+
+    print(f"Run all tests: {run_all}")
+
+    if run_all and models:
+        raise ValueError("You can't pass both -all and --model")
+
+    if run_all:
+        models = list(parsers_slugs.values())
+        models = [model for sublist in models for model in sublist]
+
+    if parser:
+        models = parsers_slugs.get(parser, None)
+        if not models:
+            raise ValueError(f"No models found for parser {parser}")
+        else:
+            print(f"Found model slugs for parser {parser}: {models}")
+
+    if not models:
+        raise ValueError("No models provided")
+
+    # Get keys from dictionary according to values in models
+    parsers = [
+        key
+        for key, value in parsers_slugs.items()
+        for model in models
+        if model in value
+    ]
+
+    for model in models:
+        print(f"Running tests for model {model}")
+        command = [
+            "parser_test.py",
+            f"--models={models}",
+            f"--parsers={parsers}",
+            "-v",
+            "--tb=no",
+            "-r a",
+            "--log-cli-level=DEBUG",
+            "--color=yes",
+        ]
+        exitcode = pytest.main(command)
+        sys.exit(exitcode)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration_tests/manual.py
+++ b/tests/integration_tests/manual.py
@@ -1,0 +1,94 @@
+import argparse
+import pickle
+
+import depthai as dai
+from check_messages import test_output
+from utils import extract_main_slug, extract_parser
+
+from depthai_nodes.parser_generator import ParserGenerator
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument(
+    "-m",
+    "--model",
+    help="The model slug from which the parser is built",
+    required=True,
+    type=str,
+)
+argparser.add_argument("-ip", help="IP address of the device", default="")
+
+args = argparser.parse_args()
+model_slug = args.model
+IP_mxid = args.ip
+
+
+def load_tensors(model: str, parser: str) -> dai.NNData:
+    model = extract_main_slug(model)
+    nn_data = dai.NNData()
+    with open(f"nn_datas/{parser}/{model}.pkl", "rb") as f:
+        data = pickle.load(f)
+        for key, value in data.items():
+            nn_data.addTensor(str(key), value.tolist())
+        return nn_data
+
+
+try:
+    device = dai.Device(dai.DeviceInfo(IP_mxid))
+except Exception as e:
+    print(f"Error: {e}")
+    exit(6)
+
+device_platform = device.getPlatform().name
+
+# Get the model from the HubAI
+try:
+    model_description = dai.NNModelDescription(
+        model=model_slug, platform=device_platform
+    )
+    archive_path = dai.getModelFromZoo(model_description)
+except Exception as e:
+    print(f"Error: {e}")
+    exit(7)
+
+try:
+    nn_archive = dai.NNArchive(archive_path)
+except Exception as e:
+    print(f"Error: {e}")
+    exit(8)
+
+try:
+    parser_name = extract_parser(nn_archive)
+except Exception as e:
+    print(e)
+    exit(9)
+
+
+class Sender(dai.node.ThreadedHostNode):
+    def __init__(self):
+        dai.node.ThreadedHostNode.__init__(self)
+        self.out = self.createOutput()
+
+    def run(self):
+        try:
+            nnData = load_tensors(model_slug, parser_name)
+        except Exception as e:
+            nnData = dai.NNData()
+            print(e)
+            return 10
+        self.out.send(nnData)
+
+
+with dai.Pipeline(device) as pipeline:
+    parser = pipeline.create(ParserGenerator).build(nn_archive=nn_archive)[0]
+
+    sender = pipeline.create(Sender)
+
+    sender.out.link(parser.input)
+    parser_queue = parser.out.createOutputQueue()
+
+    pipeline.start()
+
+    while pipeline.isRunning():
+        message = parser_queue.get()
+        test_output(message, model_slug, parser_name)
+        pipeline.stop()

--- a/tests/integration_tests/parser_test.py
+++ b/tests/integration_tests/parser_test.py
@@ -1,0 +1,59 @@
+import ast
+import subprocess
+import time
+from typing import List
+
+import pytest
+
+
+@pytest.fixture
+def models(request):
+    return request.config.getoption("--models")
+
+
+def get_parametrized_values(models: List[str], parsers: List[str]) -> List[List[str]]:
+    test_cases = []
+
+    if models:
+        models = ast.literal_eval(models)
+        parsers = ast.literal_eval(parsers)
+        test_cases.extend([(model, parsers[i]) for i, model in enumerate(models)])
+
+    return test_cases
+
+
+def pytest_generate_tests(metafunc):
+    models = metafunc.config.getoption("models")
+    parsers = metafunc.config.getoption("parsers")
+    params = get_parametrized_values(models, parsers)
+    metafunc.parametrize("models, parsers", params)
+
+
+def test_parser(models, parsers):
+    time.sleep(5)  # device needs some time to finish previous pipeline
+    if not models:
+        raise ValueError("You have to pass models")
+
+    try:
+        if models:
+            subprocess.run(
+                f"python manual.py -m {models}",
+                shell=True,
+                check=True,
+                timeout=90,
+            )
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 6:
+            pytest.skip("Couldn't connect to the default device.")
+        elif e.returncode == 7:
+            pytest.skip(f"Couldn't find model {models} in the ZOO")
+        elif e.returncode == 8:
+            pytest.skip(f"Couldn't load the model {models} from NN archive.")
+        elif e.returncode == 9:
+            pytest.skip(f"Couldn't extract the parser from the model {models}.")
+        elif e.returncode == 10:
+            pytest.skip(f"Couldn't load the tensors for the model {models}.")
+        else:
+            raise RuntimeError("Pipeline crashed.") from e
+    except subprocess.TimeoutExpired:
+        pytest.fail("Pipeline timeout.")

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -1,0 +1,111 @@
+import os
+from typing import List, Tuple
+
+import depthai as dai
+from b2sdk.api import B2Api
+
+
+def extract_parser(nn_archive: dai.NNArchive) -> str:
+    """Extract the parser from the first head in NN archive."""
+    try:
+        parser = nn_archive.getConfig().model.heads[0].parser
+    except AttributeError:
+        print(
+            "This NN archive does not have a parser. Please use NN archives that have parsers."
+        )
+        exit(1)
+
+    return parser
+
+
+def extract_main_slug(model_slug: str) -> str:
+    """Extract the main slug from the model slug."""
+    return model_slug.split("/")[1].split(":")[0]
+
+
+def get_inputs_from_archive(nn_archive: dai.NNArchive) -> List:
+    """Get all inputs from NN archive."""
+    try:
+        inputs = nn_archive.getConfig().model.inputs
+    except AttributeError:
+        print(
+            "This NN archive does not have an input shape. Please use NN archives that have input shapes."
+        )
+        exit(1)
+
+    return inputs
+
+
+def get_input_shape(nn_archive: dai.NNArchive) -> Tuple[int, int]:
+    """Get the input shape of the model from the NN archive."""
+    inputs = get_inputs_from_archive(nn_archive)
+
+    if len(inputs) > 1:
+        raise ValueError(
+            "This model has more than one input. Currently, only models with one input are supported."
+        )
+
+    try:
+        if inputs[0].layout == "NCHW":
+            input_shape = inputs[0].shape[2:][::-1]
+        elif inputs[0].layout == "NHWC":
+            input_shape = inputs[0].shape[1:3][::-1]
+        else:
+            raise ValueError(
+                "This model has an unsupported layout. Currently, only NCHW and NHWC layouts are supported."
+            )
+    except AttributeError:
+        print(
+            "This NN archive does not have an input shape. Please use NN archives that have input shapes."
+        )
+        exit(1)
+
+    return input_shape
+
+
+def download_test_files():
+    """Download test files from Backblaze B2.
+
+    The B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY must be set in the environment
+    variables. The files are downloaded to the nn_datas folder.
+    """
+    b2_application_key_id = os.getenv("B2_APPLICATION_KEY_ID", None)
+    b2_application_key = os.getenv("B2_APPLICATION_KEY", None)
+
+    if not b2_application_key_id or not b2_application_key:
+        raise ValueError(
+            "B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY must be set in the environment variables."
+        )
+
+    api = B2Api()
+    api.authorize_account(
+        application_key_id=b2_application_key_id, application_key=b2_application_key
+    )
+
+    bucket = api.get_bucket_by_name("luxonis")
+
+    files = []
+
+    if not os.path.exists("nn_datas"):
+        os.mkdir("nn_datas")
+
+    for file_version, folder_path in bucket.ls("depthai-nodes/nn_datas"):
+        if not folder_path:
+            continue
+        if folder_path.endswith("/"):  # check if the file is a folder
+            folder_name = folder_path.split("/")[-2]
+            print(f"Downloading test files for {folder_name}.")
+            for file_version, _ in bucket.ls(folder_path):
+                if file_version.file_name.endswith(".bzEmpty"):
+                    continue
+                files.append(
+                    {"filename": file_version.file_name, "id": file_version.id_}
+                )
+                f = bucket.download_file_by_id(file_version.id_)
+                filename = file_version.file_name
+                if not os.path.exists("nn_datas/" + folder_name):
+                    os.mkdir("nn_datas/" + folder_name)
+                filename = os.path.join(
+                    "nn_datas", folder_name, filename.split("/")[-1]
+                )
+                f.save_to(filename)


### PR DESCRIPTION
This PR adds integration tests for parsers. Tests work in a similar way as end-2-end tests. We have `main.py` where we can locally run a test and we can trigger the tests in the GH actions.

These tests are designed to simulate a neural network output and send it to the parser node. The parser node will parse the output and return the message. The tests check if the parser outputs the expected message. Since we know what `NNData` we are sending to the parser, we can check if the outputted message is correct.

The testing pipeline is as follows:

1. Load the neural network archive.
2. Load the parser node with `ParserGenerator` based on the NN archive.
3. Read and load the `NNData` from pickle file. It contains the output of the neural network.
4. Send the `NNData` to the parser node.
5. Read and load the expected message from the pickle file.
6. Check if the parser node outputs the expected message.


## Test generation

To generate a new test for the parser, you can use `extract_nn_data.py` script. The script will extract the `NNData` from the neural network output and store it in the pickle file. The script requires the following arguments: `-m` for the model slug, `-img` for the input image, and optional `-ip` for the device IP or mxid.

The script does not generate the expected message because each parser has its own message format and DAI messages can not be dumped in the pickle file.

One example for generating the expected message for the `ClassificationParser`:

```python
expected_output = {
    'model': 'luxonis/efficientnet-lite:lite0-224x224',
    'parser': 'ClassificationParser',
    'classes': ['wolf', 'dog', 'cat'],
    'scores': [0.7, 0.2, 0.1]
}

with open('nn_datas/ClassificationParser/efficientnet-lite_output.pkl', 'wb') as f:
    pickle.dump(expected_output, f)
```

## Running the tests

To run the tests, you can use the `main.py` script. You can use `--all` flag to test all parsers or test a specific parser with `-p` flag.
You would need the B2 credentials to download the tests from the bucket and set it in the ENV variables `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY`.


## Whats left?
This is the inital version of integration tests. All exisiting parsers have a tests prepared except the Regression and XFeat parsers. I had some troubles with them. Will add it shortly but I want to merge this PR so we can run the tests in the CI.

## Why storing NNDatas in file?
I think this is the easiest way of doing it because the framework for loading and generating NNDatas is simple and with new parsers we only need to run `extract_nn_data.py` to save the NNData to a file and then create an expected message manually. Sadly, we can not dump the DAI classes to pickle file. If anyone has better way, please share it:)

P.S.: CI successfully finished in the private repo.