### PR TITLE
[FIX] dai.ImgTransformations is None for RVC2 device

### DIFF
--- a/depthai_nodes/ml/messages/classification.py
+++ b/depthai_nodes/ml/messages/classification.py
@@ -112,8 +112,10 @@ class Classifications(dai.Buffer):
         @type value: dai.ImgTransformation
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
-        if not isinstance(value, dai.ImgTransformation):
-            raise TypeError(
-                f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
-            )
+
+        if value is not None:
+            if not isinstance(value, dai.ImgTransformation):
+                raise TypeError(
+                    f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
+                )
         self._transformation = value

--- a/depthai_nodes/ml/messages/clusters.py
+++ b/depthai_nodes/ml/messages/clusters.py
@@ -124,8 +124,10 @@ class Clusters(dai.Buffer):
         @type value: dai.ImgTransformation
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
-        if not isinstance(value, dai.ImgTransformation):
-            raise TypeError(
-                f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
-            )
+
+        if value is not None:
+            if not isinstance(value, dai.ImgTransformation):
+                raise TypeError(
+                    f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
+                )
         self._transformation = value

--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -247,8 +247,9 @@ class ImgDetectionsExtended(dai.Buffer):
         @type value: dai.ImgTransformation
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
-        if not isinstance(value, dai.ImgTransformation):
-            raise TypeError(
-                f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
-            )
+        if value is not None:
+            if not isinstance(value, dai.ImgTransformation):
+                raise TypeError(
+                    f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
+                )
         self._transformation = value

--- a/depthai_nodes/ml/messages/keypoints.py
+++ b/depthai_nodes/ml/messages/keypoints.py
@@ -178,8 +178,10 @@ class Keypoints(dai.Buffer):
         @type value: dai.ImgTransformation
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
-        if not isinstance(value, dai.ImgTransformation):
-            raise TypeError(
-                f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
-            )
+
+        if value is not None:
+            if not isinstance(value, dai.ImgTransformation):
+                raise TypeError(
+                    f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
+                )
         self._transformation = value

--- a/depthai_nodes/ml/messages/lines.py
+++ b/depthai_nodes/ml/messages/lines.py
@@ -151,8 +151,10 @@ class Lines(dai.Buffer):
         @type value: dai.ImgTransformation
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
-        if not isinstance(value, dai.ImgTransformation):
-            raise TypeError(
-                f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
-            )
+
+        if value is not None:
+            if not isinstance(value, dai.ImgTransformation):
+                raise TypeError(
+                    f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
+                )
         self._transformation = value

--- a/depthai_nodes/ml/messages/map.py
+++ b/depthai_nodes/ml/messages/map.py
@@ -92,8 +92,10 @@ class Map2D(dai.Buffer):
         @type value: dai.ImgTransformation
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
-        if not isinstance(value, dai.ImgTransformation):
-            raise TypeError(
-                f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
-            )
+
+        if value is not None:
+            if not isinstance(value, dai.ImgTransformation):
+                raise TypeError(
+                    f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
+                )
         self._transformation = value

--- a/depthai_nodes/ml/messages/prediction.py
+++ b/depthai_nodes/ml/messages/prediction.py
@@ -110,8 +110,10 @@ class Predictions(dai.Buffer):
         @type value: dai.ImgTransformation
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
-        if not isinstance(value, dai.ImgTransformation):
-            raise TypeError(
-                f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
-            )
+
+        if value is not None:
+            if not isinstance(value, dai.ImgTransformation):
+                raise TypeError(
+                    f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
+                )
         self._transformation = value

--- a/depthai_nodes/ml/messages/segmentation.py
+++ b/depthai_nodes/ml/messages/segmentation.py
@@ -69,8 +69,10 @@ class SegmentationMask(dai.Buffer):
         @type value: dai.ImgTransformation
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
-        if not isinstance(value, dai.ImgTransformation):
-            raise TypeError(
-                f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
-            )
+
+        if value is not None:
+            if not isinstance(value, dai.ImgTransformation):
+                raise TypeError(
+                    f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
+                )
         self._transformation = value


### PR DESCRIPTION
This PR adds a hotfix for using RVC2 device with depthai v3_develop. The issue is that the dai.NNdata has self.transformation set to `None`. This is a know issue in depthai and will be fixed in comming updates.

The PR was tested on both RVC2 and RVC4 on the following models:
lane detection, depth anything, face landmarks, yolov8 instance seg, selfie seg, scfrd face detection, yolo v6, text detection