### PR TITLE
Integration tests: Small updates & triggering in every PR.

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -58,7 +58,7 @@ jobs:
           
       - name: Run Test
         run: |
-          CMD="hil --testbed ${{ github.event.inputs.testbed }} --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/end_to_end' 'source <(python setup_camera_ips.py)' 'export HUBAI_TEAM_ID=${{ secrets.HUBAI_TEAM_ID }}' 'export HUBAI_API_KEY=${{ secrets.HUBAI_API_KEY }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          CMD="hil --testbed ${{ github.event.inputs.testbed }} --wait --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/end_to_end' 'source <(python setup_camera_ips.py)' 'export HUBAI_TEAM_ID=${{ secrets.HUBAI_TEAM_ID }}' 'export HUBAI_API_KEY=${{ secrets.HUBAI_API_KEY }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
           eval $CMD
 
       - name: Stop WireGuard

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -15,6 +15,10 @@ on:
         description: 'Testbed to run the tests on. Default: oak4-pro'
         required: true
         default: 'oak4-pro'
+      depthai-version:
+        description: 'Version of depthai to install. Default: alpha6'
+        required: true
+        default: '3.0.0a6'
 
 jobs:
   HIL-test:
@@ -54,7 +58,7 @@ jobs:
           
       - name: Run Test
         run: |
-          CMD="hil --testbed ${{ github.event.inputs.testbed }} --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'cd tests/end_to_end' 'source <(python setup_camera_ips.py)' 'export HUBAI_TEAM_ID=${{ secrets.HUBAI_TEAM_ID }}' 'export HUBAI_API_KEY=${{ secrets.HUBAI_API_KEY }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          CMD="hil --testbed ${{ github.event.inputs.testbed }} --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/end_to_end' 'source <(python setup_camera_ips.py)' 'export HUBAI_TEAM_ID=${{ secrets.HUBAI_TEAM_ID }}' 'export HUBAI_API_KEY=${{ secrets.HUBAI_API_KEY }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
           eval $CMD
 
       - name: Stop WireGuard

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -15,6 +15,10 @@ on:
         description: 'Testbed to run the tests on. Default: oak4-s'
         required: true
         default: 'oak4-s'
+      depthai-version:
+        description: 'Version of depthai to install. Default: alpha6'
+        required: true
+        default: '3.0.0a6'
 
 jobs:
   Integration-test:
@@ -54,7 +58,7 @@ jobs:
           
       - name: Run Test
         run: |
-          CMD="hil --testbed ${{ github.event.inputs.testbed }} --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          CMD="hil --testbed ${{ github.event.inputs.testbed }} --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
           eval $CMD
 
       - name: Stop WireGuard

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -22,8 +22,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - ready_for_review
     paths:
       - 'depthai_nodes/**'
       - 'tests/integration_tests/**'

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -27,6 +27,7 @@ on:
     paths:
       - 'depthai_nodes/**'
       - 'tests/integration_tests/**'
+      - .github/workflows/integration_tests.yaml
 
 jobs:
   Integration-test:

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -58,7 +58,7 @@ jobs:
           
       - name: Run Test
         run: |
-          CMD="hil --testbed ${{ github.event.inputs.testbed }} --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          CMD="hil --testbed ${{ github.event.inputs.testbed }} --wait --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
           eval $CMD
 
       - name: Stop WireGuard

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -19,6 +19,14 @@ on:
         description: 'Version of depthai to install. Default: alpha6'
         required: true
         default: '3.0.0a6'
+  pull_request:
+    branches:
+      - main
+    types:
+      - ready_for_review
+    paths:
+      - 'depthai_nodes/**'
+      - 'tests/integration_tests/**'
 
 jobs:
   Integration-test:
@@ -58,7 +66,11 @@ jobs:
           
       - name: Run Test
         run: |
-          CMD="hil --testbed ${{ github.event.inputs.testbed }} --wait --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            CMD="hil --testbed ${{ github.event.inputs.testbed }} --wait --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          else
+            CMD="hil --testbed oak4-s --wait --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.head_ref }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==3.0.0a6' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py -all --download' 'deactivate'"
+          fi
           eval $CMD
 
       - name: Stop WireGuard

--- a/depthai_nodes/ml/parsers/image_output.py
+++ b/depthai_nodes/ml/parsers/image_output.py
@@ -113,6 +113,7 @@ class ImageOutputParser(BaseParser):
                 is_bgr=self.output_is_bgr,
             )
             image_message.setTimestamp(output.getTimestamp())
-            image_message.transformation = output.getTransformation()
+            if output.getTransformation():
+                image_message.setTransformation(output.getTransformation())
 
             self.out.send(image_message)

--- a/tests/integration_tests/manual.py
+++ b/tests/integration_tests/manual.py
@@ -42,13 +42,15 @@ device_platform = device.getPlatform().name
 
 # Get the model from the HubAI
 try:
-    model_description = dai.NNModelDescription(
-        model=model_slug, platform=device_platform
-    )
+    model_description = dai.NNModelDescription(model=model_slug, platform="RVC2")
     archive_path = dai.getModelFromZoo(model_description)
-except Exception as e:
-    print(f"Error: {e}")
-    exit(7)
+except Exception:
+    try:
+        model_description = dai.NNModelDescription(model=model_slug, platform="RVC4")
+        archive_path = dai.getModelFromZoo(model_description)
+    except Exception as e:
+        print(f"Error: {e}")
+        exit(7)
 
 try:
     nn_archive = dai.NNArchive(archive_path)

--- a/tests/integration_tests/parser_test.py
+++ b/tests/integration_tests/parser_test.py
@@ -17,11 +17,18 @@ def get_parametrized_values(models: List[str], parsers: List[str]) -> List[List[
 
     devices = dai.Device.getAllConnectedDevices()
     if not devices:
-        pytest.skip("Couldn't find any devices.")
+        pytest.skip("Couldn't find any connected devices.")
 
     devices = [
         ("RVC2" if "MYRIAD" in device.platform.name else "RVC4", device.getMxId())
         for device in devices
+    ]
+
+    unique_devices = set()
+    devices = [
+        item
+        for item in devices
+        if item[0] not in unique_devices and not unique_devices.add(item[0])
     ]
 
     if models:


### PR DESCRIPTION
This PR adds the ability to run integration tests on all connected platforms (RVC2, RVC4). If there are multiple RVC2 devices connected it will only select one. 

Additionally, there was a bug in `ImageOutputParser` because we were setting the attribute `transformation` of the `dai.ImgFrame` which doesn't have this attribute - fixing it with the method `setTransformations()`. Hopefully, this bugs will be catched now:)

Lastly, we updated the CI workflows for E2E and integration tests with the option to specify which depthai version we want - the specified version will then be installed in the testbed server before the tests run. CI jobs will also wait until testbed is free and wont fail the job if testbed is reserved.

Integration tests are included in the CI for every PR. They are triggered only if the affected files are from `/depthai-nodes` or `/tests/integration-tests folder`.

Successful CI run for integration tests is [HERE](https://github.com/luxonis/depthai-nodes/actions/runs/12167384160/job/33961700756). It took 10 minutes.