### PR TITLE
Storage order fix in XFeat parser.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,5 +23,5 @@ repos:
     hooks:
       - id: mdformat
         additional_dependencies:
-          - mdformat-gfm
+          - mdformat-gfm==0.3.6
           - mdformat-toc

--- a/depthai_nodes/ml/parsers/xfeat.py
+++ b/depthai_nodes/ml/parsers/xfeat.py
@@ -199,7 +199,8 @@ class XFeatBaseParser(BaseParser):
         self, output: dai.NNData
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Extracts the tensors from the output. It returns the features, keypoints, and
-        heatmaps. It also handles the reshaping of the tensors.
+        heatmaps. It also handles the reshaping of the tensors by requesting the NCHW
+        storage order.
 
         @param output: Output from the Neural Network node.
         @type output: dai.NNData

--- a/depthai_nodes/ml/parsers/xfeat.py
+++ b/depthai_nodes/ml/parsers/xfeat.py
@@ -206,22 +206,21 @@ class XFeatBaseParser(BaseParser):
         @return: Tuple of features, keypoints, and heatmaps.
         @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
         """
-        feats = output.getTensor(self.output_layer_feats, dequantize=True).astype(
-            np.float32
-        )
-        keypoints = output.getTensor(
-            self.output_layer_keypoints, dequantize=True
+        feats = output.getTensor(
+            self.output_layer_feats,
+            dequantize=True,
+            storageOrder=dai.TensorInfo.StorageOrder.NCHW,
         ).astype(np.float32)
-        heatmaps = output.getTensor(self.output_layer_heatmaps, dequantize=True).astype(
-            np.float32
-        )
-
-        if len(feats.shape) == 3:
-            feats = feats.reshape((1,) + feats.shape).transpose(0, 3, 1, 2)
-        if len(keypoints.shape) == 3:
-            keypoints = keypoints.reshape((1,) + keypoints.shape).transpose(0, 3, 1, 2)
-        if len(heatmaps.shape) == 3:
-            heatmaps = heatmaps.reshape((1,) + heatmaps.shape).transpose(0, 3, 1, 2)
+        keypoints = output.getTensor(
+            self.output_layer_keypoints,
+            dequantize=True,
+            storageOrder=dai.TensorInfo.StorageOrder.NCHW,
+        ).astype(np.float32)
+        heatmaps = output.getTensor(
+            self.output_layer_heatmaps,
+            dequantize=True,
+            storageOrder=dai.TensorInfo.StorageOrder.NCHW,
+        ).astype(np.float32)
 
         return feats, keypoints, heatmaps
 


### PR DESCRIPTION
This PR fixes small bug in XFeat parser where we didn't request NCHW storage order, so RVC4 version didn't work.