### PR TITLE
Tests: Update triggers & better reservation name.

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -18,7 +18,14 @@ on:
       depthai-version:
         description: 'Version of depthai to install. Default: alpha6'
         required: true
-        default: '3.0.0a6'
+        default: '3.0.0a11'
+  push:
+    branches:
+      - main
+    paths:
+      - 'depthai_nodes/**'
+      - 'tests/end_to_end/**'
+      - .github/workflows/e2e_tests.yaml
 
 jobs:
   HIL-test:
@@ -58,7 +65,12 @@ jobs:
           
       - name: Run Test
         run: |
-          CMD="hil --testbed ${{ github.event.inputs.testbed }} --wait --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/end_to_end' 'source <(python setup_camera_ips.py)' 'export HUBAI_TEAM_ID=${{ secrets.HUBAI_TEAM_ID }}' 'export HUBAI_API_KEY=${{ secrets.HUBAI_API_KEY }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          export RESERVATION_NAME="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#${{ matrix.python-version}}"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            CMD="hil --testbed ${{ github.event.inputs.testbed }} --wait --reservation-name $RESERVATION_NAME --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/end_to_end' 'source <(python setup_camera_ips.py)' 'export HUBAI_TEAM_SLUG=${{ secrets.HUBAI_TEAM_SLUG }}' 'export HUBAI_API_KEY=${{ secrets.HUBAI_API_KEY }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+          else
+            CMD="hil --testbed oak4-pro --wait --reservation-name $RESERVATION_NAME --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==3.0.0a11' 'cd tests/end_to_end' 'source <(python setup_camera_ips.py)' 'export HUBAI_TEAM_SLUG=${{ secrets.HUBAI_TEAM_SLUG }}' 'export HUBAI_API_KEY=${{ secrets.HUBAI_API_KEY }}' 'python main.py -all' 'deactivate'"
+          fi
           eval $CMD
 
       - name: Stop WireGuard

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -65,10 +65,11 @@ jobs:
 
       - name: Run Test
         run: |
+          export RESERVATION_NAME="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}#${{ matrix.python-version}}"
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            CMD="hil --testbed ${{ github.event.inputs.testbed }} --wait --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
+            CMD="hil --testbed ${{ github.event.inputs.testbed }} --wait --reservation-name $RESERVATION_NAME --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.event.inputs.branch }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==${{ github.event.inputs.depthai-version }}' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py ${{ github.event.inputs.additional-parameter }}' 'deactivate'"
           else
-            CMD="hil --testbed oak4-s --wait --reservation-name 'depthai_nodes_ml_team' --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.head_ref }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==3.0.0a11' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py -all --download' 'deactivate'"
+            CMD="hil --testbed oak4-s --wait --reservation-name $RESERVATION_NAME --commands 'cd /home/hil/depthai-nodes' 'git checkout main' 'git pull' 'git checkout ${{ github.head_ref }}' 'git pull' 'source venv/bin/activate' 'pip install --extra-index-url ${{secrets.LUXONIS_EXTRA_INDEX_URL}}  depthai==3.0.0a11' 'cd tests/integration_tests' 'export B2_APPLICATION_KEY=${{ secrets.B2_APPLICATION_KEY }}' 'export B2_APPLICATION_KEY_ID=${{ secrets.B2_APPLICATION_KEY_ID }}' 'python main.py -all --download' 'deactivate'"
           fi
           eval $CMD
 

--- a/tests/end_to_end/manual.py
+++ b/tests/end_to_end/manual.py
@@ -86,12 +86,12 @@ with dai.Pipeline(device) as pipeline:
 
     if input_size[0] % 2 != 0 or input_size[1] % 2 != 0:
         manip = pipeline.create(dai.node.ImageManipV2)
-        manip.initialConfig.addResize(input_size[0], input_size[1])
+        manip.initialConfig.setOutputSize(input_size[0], input_size[1])
         large_input_shape = (input_size[0] * 2, input_size[1] * 2)
 
     if input_size[0] < 128 and input_size[1] < 128:
         manip = pipeline.create(dai.node.ImageManipV2)
-        manip.initialConfig.addResize(input_size[0], input_size[1])
+        manip.initialConfig.setOutputSize(input_size[0], input_size[1])
         large_input_shape = (input_size[0] * 4, input_size[1] * 4)
 
     if manip:


### PR DESCRIPTION
This PR improves reservation name for reserving testbeds. The name reflects the current GH job.

We also introduce End-to-end tests on every PR. Actually, the E2E tests run on every push to main - that means every time when the PR is merged. This way we dont run the test on every commit push to the PR but rather when the PR is merged. If any tests fail we should address this in the new PR. Thoughts @klemen1999 @jkbmrz @aljazkonec1 ?