### PR TITLE
Add sequence number inheritence to all parsers

### DIFF
--- a/depthai_nodes/ml/messages/creators/classification.py
+++ b/depthai_nodes/ml/messages/creators/classification.py
@@ -136,7 +136,9 @@ def create_classification_sequence_message(
         raise ValueError("Scores should be in the range [0, 1].")
 
     if np.any(~np.isclose(scores.sum(axis=1), 1.0, atol=1e-2)):
-        raise ValueError("Each row of scores should sum to 1.")
+        raise ValueError(
+            f"Each row of scores should sum to 1, got {scores.sum(axis=1)}."
+        )
 
     scores = scores.astype(np.float32)
 

--- a/depthai_nodes/ml/parsers/classification.py
+++ b/depthai_nodes/ml/parsers/classification.py
@@ -143,5 +143,6 @@ class ClassificationParser(BaseParser):
             msg = create_classification_message(self.classes, scores)
             msg.transformation = output.getTransformation()
             msg.setTimestamp(output.getTimestamp())
+            msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(msg)

--- a/depthai_nodes/ml/parsers/classification_sequence.py
+++ b/depthai_nodes/ml/parsers/classification_sequence.py
@@ -180,5 +180,6 @@ class ClassificationSequenceParser(ClassificationParser):
             )
             msg.transformation = output.getTransformation()
             msg.setTimestamp(output.getTimestamp())
+            msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(msg)

--- a/depthai_nodes/ml/parsers/embeddings.py
+++ b/depthai_nodes/ml/parsers/embeddings.py
@@ -64,5 +64,6 @@ class EmbeddingsParser(BaseParser):
             assert (
                 len(output_names) == 1
             ), "Embeddings head should have only one output layer"
+            output.setSequenceNum(output.getSequenceNum())
 
             self.out.send(output)

--- a/depthai_nodes/ml/parsers/fastsam.py
+++ b/depthai_nodes/ml/parsers/fastsam.py
@@ -355,4 +355,6 @@ class FastSAMParser(BaseParser):
             segmentation_message = create_segmentation_message(results_masks)
             segmentation_message.transformation = output.getTransformation()
             segmentation_message.setTimestamp(output.getTimestamp())
+            segmentation_message.setSequenceNum(output.getSequenceNum())
+
             self.out.send(segmentation_message)

--- a/depthai_nodes/ml/parsers/hrnet.py
+++ b/depthai_nodes/ml/parsers/hrnet.py
@@ -114,5 +114,6 @@ class HRNetParser(KeypointParser):
             )
             keypoints_message.setTimestamp(output.getTimestamp())
             keypoints_message.transformation = output.getTransformation()
+            keypoints_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(keypoints_message)

--- a/depthai_nodes/ml/parsers/image_output.py
+++ b/depthai_nodes/ml/parsers/image_output.py
@@ -115,5 +115,6 @@ class ImageOutputParser(BaseParser):
             image_message.setTimestamp(output.getTimestamp())
             if output.getTransformation():
                 image_message.setTransformation(output.getTransformation())
+            image_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(image_message)

--- a/depthai_nodes/ml/parsers/keypoints.py
+++ b/depthai_nodes/ml/parsers/keypoints.py
@@ -173,5 +173,6 @@ class KeypointParser(BaseParser):
             msg = create_keypoints_message(keypoints)
             msg.setTimestamp(output.getTimestamp())
             msg.transformation = output.getTransformation()
+            msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(msg)

--- a/depthai_nodes/ml/parsers/lane_detection.py
+++ b/depthai_nodes/ml/parsers/lane_detection.py
@@ -204,5 +204,6 @@ class LaneDetectionParser(BaseParser):
             msg = create_cluster_message(points)
             msg.setTimestamp(output.getTimestamp())
             msg.transformation = output.getTransformation()
+            msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(msg)

--- a/depthai_nodes/ml/parsers/map_output.py
+++ b/depthai_nodes/ml/parsers/map_output.py
@@ -107,5 +107,6 @@ class MapOutputParser(BaseParser):
             )
             map_message.setTimestamp(output.getTimestamp())
             map_message.transformation = output.getTransformation()
+            map_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(map_message)

--- a/depthai_nodes/ml/parsers/mediapipe_palm_detection.py
+++ b/depthai_nodes/ml/parsers/mediapipe_palm_detection.py
@@ -199,5 +199,6 @@ class MPPalmDetectionParser(DetectionParser):
             )
             detections_msg.setTimestamp(output.getTimestamp())
             detections_msg.transformation = output.getTransformation()
+            detections_msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(detections_msg)

--- a/depthai_nodes/ml/parsers/mlsd.py
+++ b/depthai_nodes/ml/parsers/mlsd.py
@@ -172,5 +172,6 @@ class MLSDParser(BaseParser):
             message = create_line_detection_message(lines, np.array(scores))
             message.setTimestamp(output.getTimestamp())
             message.transformation = output.getTransformation()
+            message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(message)

--- a/depthai_nodes/ml/parsers/ppdet.py
+++ b/depthai_nodes/ml/parsers/ppdet.py
@@ -127,5 +127,6 @@ class PPTextDetectionParser(DetectionParser):
             )
             message.setTimestamp(output.getTimestamp())
             message.transformation = output.getTransformation()
+            message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(message)

--- a/depthai_nodes/ml/parsers/regression.py
+++ b/depthai_nodes/ml/parsers/regression.py
@@ -89,5 +89,6 @@ class RegressionParser(BaseParser):
             regression_message = create_regression_message(predictions=predictions)
             regression_message.setTimestamp(output.getTimestamp())
             regression_message.transformation = output.getTransformation()
+            regression_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(regression_message)

--- a/depthai_nodes/ml/parsers/scrfd.py
+++ b/depthai_nodes/ml/parsers/scrfd.py
@@ -218,5 +218,6 @@ class SCRFDParser(DetectionParser):
             )
             message.setTimestamp(output.getTimestamp())
             message.transformation = output.getTransformation()
+            message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(message)

--- a/depthai_nodes/ml/parsers/segmentation.py
+++ b/depthai_nodes/ml/parsers/segmentation.py
@@ -154,5 +154,6 @@ class SegmentationParser(BaseParser):
             mask_message = create_segmentation_message(class_map)
             mask_message.setTimestamp(output.getTimestamp())
             mask_message.transformation = output.getTransformation()
+            mask_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(mask_message)

--- a/depthai_nodes/ml/parsers/superanimal_landmarker.py
+++ b/depthai_nodes/ml/parsers/superanimal_landmarker.py
@@ -100,5 +100,6 @@ class SuperAnimalParser(KeypointParser):
             msg = create_keypoints_message(keypoints, scores, self.score_threshold)
             msg.setTimestamp(output.getTimestamp())
             msg.transformation = output.getTransformation()
+            msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(msg)

--- a/depthai_nodes/ml/parsers/utils/ppdet.py
+++ b/depthai_nodes/ml/parsers/utils/ppdet.py
@@ -81,7 +81,7 @@ def _box_score(predictions: np.ndarray, _corners: np.ndarray) -> float:
 
 def _unclip(
     box: np.ndarray,
-    unclip_ratio: float = 3,
+    unclip_ratio: float = 2,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Internal function to dilate the bounding box area by a specified ratio.
 
@@ -94,7 +94,7 @@ def _unclip(
     """
 
     box[2] = box[2] * np.sqrt(unclip_ratio)
-    box[3] = box[3] * unclip_ratio
+    box[3] = box[3] * np.sqrt(unclip_ratio)
 
     return box
 

--- a/depthai_nodes/ml/parsers/xfeat.py
+++ b/depthai_nodes/ml/parsers/xfeat.py
@@ -335,6 +335,7 @@ class XFeatMonoParser(XFeatBaseParser):
             else:
                 matched_points = dai.TrackedFeatures()
                 matched_points.setTimestamp(output.getTimestamp())
+                matched_points.setSequenceNum(output.getSequenceNum())
                 self.out.send(matched_points)
                 continue
 
@@ -342,10 +343,14 @@ class XFeatMonoParser(XFeatBaseParser):
                 mkpts0, mkpts1 = match(self.previous_results, result)
                 matched_points = create_tracked_features_message(mkpts0, mkpts1)
                 matched_points.setTimestamp(output.getTimestamp())
+                matched_points.setSequenceNum(output.getSequenceNum())
+
                 self.out.send(matched_points)
             else:
                 matched_points = dai.TrackedFeatures()
                 matched_points.setTimestamp(output.getTimestamp())
+                matched_points.setSequenceNum(output.getSequenceNum())
+
                 self.out.send(matched_points)
 
             if self.trigger:
@@ -473,6 +478,8 @@ class XFeatStereoParser(XFeatBaseParser):
             else:
                 matched_points = dai.TrackedFeatures()
                 matched_points.setTimestamp(reference_output.getTimestamp())
+                matched_points.setSequenceNum(reference_output.getSequenceNum())
+
                 self.out.send(matched_points)
                 continue
 
@@ -481,10 +488,14 @@ class XFeatStereoParser(XFeatBaseParser):
             else:
                 matched_points = dai.TrackedFeatures()
                 matched_points.setTimestamp(target_output.getTimestamp())
+                matched_points.setSequenceNum(reference_output.getSequenceNum())
+
                 self.out.send(matched_points)
                 continue
 
             mkpts0, mkpts1 = match(reference_result, target_result)
             matched_points = create_tracked_features_message(mkpts0, mkpts1)
             matched_points.setTimestamp(target_output.getTimestamp())
+            matched_points.setSequenceNum(reference_output.getSequenceNum())
+
             self.out.send(matched_points)

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -398,5 +398,6 @@ class YOLOExtendedParser(BaseParser):
 
             detections_message.setTimestamp(output.getTimestamp())
             detections_message.transformation = output.getTransformation()
+            detections_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(detections_message)

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -297,5 +297,6 @@ class YuNetParser(DetectionParser):
 
             detections_message.setTimestamp(output.getTimestamp())
             detections_message.transformation = output.getTransformation()
+            detections_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(detections_message)


### PR DESCRIPTION
This PR adds inheritance of frame sequence numbers to all parser output messages. When a frame is created in camera node it has a sequence number, this number is then forwarded (similarly like timestamp) in nodes that manipulate the frame such as NeuralNetwork, ImageManipV2, .... 

To keep forwarding consistent with these nodes, I added it to all message outputs of parsers.

In addition I also added a small change to Text Detection post processing.