### PR TITLE
feat: Parsers Dynamic Configuration

### DIFF
--- a/depthai_nodes/ml/messages/configuration_change.py
+++ b/depthai_nodes/ml/messages/configuration_change.py
@@ -1,0 +1,8 @@
+import depthai as dai
+
+
+class ConfigurationChange(dai.Buffer):
+    def __init__(self, parameter: str, value_as_string: str):
+        super().__init__()
+        self.parameter = parameter
+        self.value_as_string = value_as_string

--- a/depthai_nodes/ml/parsers/classification.py
+++ b/depthai_nodes/ml/parsers/classification.py
@@ -103,6 +103,10 @@ class ClassificationParser(BaseParser):
         """
 
         output_layers = head_config.get("outputs", [])
+        if not isinstance(output_layers, list):
+            raise TypeError(
+                f"Outputs config must be a list. Got {type(output_layers).__name__} instead."
+            )
         if len(output_layers) != 1:
             raise ValueError(
                 f"Only one output layer supported for Classification, got {output_layers} layers."

--- a/depthai_nodes/ml/parsers/classification_sequence.py
+++ b/depthai_nodes/ml/parsers/classification_sequence.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from ..messages.creators import create_classification_sequence_message
 from .classification import ClassificationParser
+from .configuration import BoolParameter, IntListParameter
 from .utils.softmax import softmax
 
 
@@ -73,6 +74,11 @@ class ClassificationSequenceParser(ClassificationParser):
         self.ignored_indexes = ignored_indexes if ignored_indexes is not None else []
         self.remove_duplicates = remove_duplicates
         self.concatenate_classes = concatenate_classes
+        self._configurable_parameters.add(
+            BoolParameter(self.getRemoveDuplicates, self.setRemoveDuplicates)
+        ).add(IntListParameter(self.getIgnoredIndexes, self.setIgnoredIndexes)).add(
+            BoolParameter(self.getConcatenateClasses, self.setConcatenateClasses)
+        )
 
     def getRemoveDuplicates(self) -> bool:
         """Gets the remove_duplicates flag for the classification sequence model.

--- a/depthai_nodes/ml/parsers/classification_sequence.py
+++ b/depthai_nodes/ml/parsers/classification_sequence.py
@@ -74,6 +74,14 @@ class ClassificationSequenceParser(ClassificationParser):
         self.remove_duplicates = remove_duplicates
         self.concatenate_classes = concatenate_classes
 
+    def getRemoveDuplicates(self) -> bool:
+        """Gets the remove_duplicates flag for the classification sequence model.
+
+        @return: Returns the remove_duplicates flag.
+        @rtype: bool
+        """
+        return self.remove_duplicates
+
     def setRemoveDuplicates(self, remove_duplicates: bool) -> None:
         """Sets the remove_duplicates flag for the classification sequence model.
 
@@ -84,6 +92,14 @@ class ClassificationSequenceParser(ClassificationParser):
         if not isinstance(remove_duplicates, bool):
             raise ValueError("remove_duplicates must be a boolean.")
         self.remove_duplicates = remove_duplicates
+
+    def getIgnoredIndexes(self) -> List[int]:
+        """Gets the ignored_indexes for the classification sequence model.
+
+        @return: Returns the ignored_indexes list.
+        @rtype: List[int]
+        """
+        return self.ignored_indexes
 
     def setIgnoredIndexes(self, ignored_indexes: List[int]) -> None:
         """Sets the ignored_indexes for the classification sequence model.
@@ -97,6 +113,14 @@ class ClassificationSequenceParser(ClassificationParser):
         if not all(isinstance(index, int) for index in ignored_indexes):
             raise ValueError("All ignored indexes must be integers.")
         self.ignored_indexes = ignored_indexes
+
+    def getConcatenateClasses(self) -> bool:
+        """Gets the concatenate_classes flag for the classification sequence model.
+
+        @return: Returns the concatenate_classes flag.
+        @rtype: bool
+        """
+        return self.concatenate_classes
 
     def setConcatenateClasses(self, concatenate_classes: bool) -> None:
         """Sets the concatenate_classes flag for the classification sequence model.

--- a/depthai_nodes/ml/parsers/configuration/__init__.py
+++ b/depthai_nodes/ml/parsers/configuration/__init__.py
@@ -1,0 +1,15 @@
+from .bool_parameter import BoolParameter
+from .configuration import Configuration
+from .float_parameter import FloatParameter
+from .int_list_parameter import IntListParameter
+from .int_parameter import IntParameter
+from .runtime_parameters import RuntimeParameters
+
+__all__ = [
+    "BoolParameter",
+    "Configuration",
+    "FloatParameter",
+    "IntListParameter",
+    "IntParameter",
+    "RuntimeParameters",
+]

--- a/depthai_nodes/ml/parsers/configuration/bool_parameter.py
+++ b/depthai_nodes/ml/parsers/configuration/bool_parameter.py
@@ -1,0 +1,24 @@
+from typing import Callable, Optional
+
+from .parameter import Parameter
+
+
+class BoolParameter(Parameter[bool]):
+    def __init__(
+        self,
+        getter: Callable[[], bool],
+        setter: Callable[[bool], None],
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        super().__init__(bool, getter, setter, name, description)
+
+    def get_type_name(self) -> str:
+        return "bool"  # Haven't used self._type.__name__ in order to make the C++ conversion easy
+
+    def get_as_string(self) -> str:
+        return str(self.get())
+
+    def set_from_string(self, string_value: str):
+        value = bool(string_value)
+        return self.set(value)

--- a/depthai_nodes/ml/parsers/configuration/configuration.py
+++ b/depthai_nodes/ml/parsers/configuration/configuration.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Configuration:
+    parameter: str
+    string_value: str
+    type_name: str
+    description: Optional[str]

--- a/depthai_nodes/ml/parsers/configuration/float_parameter.py
+++ b/depthai_nodes/ml/parsers/configuration/float_parameter.py
@@ -1,0 +1,24 @@
+from typing import Callable, Optional
+
+from .parameter import Parameter
+
+
+class FloatParameter(Parameter[float]):
+    def __init__(
+        self,
+        getter: Callable[[], float],
+        setter: Callable[[float], None],
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        super().__init__(float, getter, setter, name, description)
+
+    def get_type_name(self) -> str:
+        return "float"  # Haven't used self._type.__name__ in order to make the C++ conversion easy
+
+    def get_as_string(self) -> str:
+        return str(self.get())
+
+    def set_from_string(self, string_value: str):
+        value = float(string_value)
+        return self.set(value)

--- a/depthai_nodes/ml/parsers/configuration/int_list_parameter.py
+++ b/depthai_nodes/ml/parsers/configuration/int_list_parameter.py
@@ -1,0 +1,25 @@
+from typing import Callable, List, Optional
+
+from .parameter import Parameter
+
+
+class IntListParameter(Parameter[List[int]]):
+    def __init__(
+        self,
+        getter: Callable[[], List[int]],
+        setter: Callable[[List[int]], None],
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        super().__init__(List[int], getter, setter, name, description)
+
+    def get_type_name(self) -> str:
+        return "list[int]"  # Haven't used typing.get_origin in order to make the C++ conversion easy
+
+    def get_as_string(self) -> str:
+        return str(self.get())
+
+    def set_from_string(self, string_value: str):
+        clean_str = string_value.strip("[]")
+        value = [int(x) for x in clean_str.split(",")]
+        return self.set(value)

--- a/depthai_nodes/ml/parsers/configuration/int_parameter.py
+++ b/depthai_nodes/ml/parsers/configuration/int_parameter.py
@@ -1,0 +1,24 @@
+from typing import Callable, Optional
+
+from .parameter import Parameter
+
+
+class IntParameter(Parameter[int]):
+    def __init__(
+        self,
+        getter: Callable[[], int],
+        setter: Callable[[int], None],
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        super().__init__(int, getter, setter, name, description)
+
+    def get_type_name(self) -> str:
+        return "int"  # Haven't used self._type.__name__ in order to make the C++ conversion easy
+
+    def get_as_string(self) -> str:
+        return str(self.get())
+
+    def set_from_string(self, string_value: str):
+        value = int(string_value)
+        return self.set(value)

--- a/depthai_nodes/ml/parsers/configuration/parameter.py
+++ b/depthai_nodes/ml/parsers/configuration/parameter.py
@@ -1,0 +1,52 @@
+from abc import ABC, abstractmethod
+from typing import Callable, Generic, Optional, Type, TypeVar
+
+T = TypeVar("T")
+
+
+class Parameter(Generic[T], ABC):
+    def __init__(
+        self,
+        type: Type[T],
+        getter: Callable[[], T],
+        setter: Callable[[T], None],
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        self._getter = getter
+        self._setter = setter
+        self._type = type
+        if description:
+            self._decription = description
+        else:  # Can be ommitted when porting the code to C++
+            self._decription = setter.__doc__
+        if name:
+            self._name = name
+        else:  # Can be ommitted when porting the code to C++
+            self._name = setter.__name__
+
+    def get(self) -> T:
+        return self._getter()
+
+    def set(self, value: T) -> None:
+        self._setter(value)
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._decription
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @abstractmethod
+    def get_type_name(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_as_string(self) -> str:
+        pass
+
+    @abstractmethod
+    def set_from_string(self, string_value: str):
+        pass

--- a/depthai_nodes/ml/parsers/configuration/runtime_parameters.py
+++ b/depthai_nodes/ml/parsers/configuration/runtime_parameters.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict, List
+
+from .parameter import Parameter
+
+
+class RuntimeParameters:
+    def __init__(self):
+        self._parameters: Dict[str, Parameter[Any]] = {}
+
+    def add(self, parameter: Parameter[Any]) -> "RuntimeParameters":
+        self._parameters[parameter.name] = parameter
+        return self
+
+    def get(self, name: str) -> Parameter[Any]:
+        return self._parameters[name]
+
+    def get_names(self) -> List[str]:
+        return list(self._parameters.keys())


### PR DESCRIPTION
Implementation of parser dynamic configuration settings and retrieval. Written with intention that the code will be in future ported to C++, hence heavily restricting "Python magic".

The core part of the feature is the `Parameter` class. The class basically contains getter and setter function reference for a configurable parameter e.g. `getIgnoredIndexes`&`setIgnoredIndexes`. Parser can then expose whichever configurable parameters by simply with `self._parameters.add`.
The `Parameter` class itself is abstract (cannot be instantiated). To add parameters use it's child classes like `BoolParameter` or `IntListParameter`. 
In Python-only context the child classes would be redundant and everything they do could be done with runtime reflection, type conversions etc., but for C++ they might be necessary.

Retrieving parser configuration is done by calling `configuration` property on a parser. The configuration parameter name, value as string, type as string and description will be returned.
Setting the configuration is done with `configuration_input`, which is standard `dai.Node.Input`. The input accepts `ConfigurationChange` message, inherited from `dai.Buffer`.