### PR TITLE
Update ImgExtractedDetection: Soften confidence check

### DIFF
--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -83,7 +83,8 @@ class ImgDetectionExtended(dai.Buffer):
         """
         if not isinstance(value, float):
             raise TypeError("Confidence must be a float.")
-        if value < 0 or value > 1:
+        eps = 1e-3
+        if not (0 - eps <= value <= 1 + eps):
             raise ValueError("Confidence must be between 0 and 1.")
         self._confidence = value
 


### PR DESCRIPTION
This PR softens the confidence check in `ImgDetectionExtended` class, so that values like `1.0000001192092896` would pass.