### PR TITLE
Fix: Global Logging

### DIFF
--- a/depthai_nodes/ml/messages/img_detections.py
+++ b/depthai_nodes/ml/messages/img_detections.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Tuple
 
 import depthai as dai
@@ -13,8 +12,7 @@ from depthai_nodes.ml.helpers.constants import (
 )
 from depthai_nodes.ml.messages.keypoints import Keypoint
 from depthai_nodes.ml.messages.segmentation import SegmentationMask
-
-logger = logging.getLogger(__name__)
+from depthai_nodes.utils import get_logger
 
 
 class ImgDetectionExtended(dai.Buffer):
@@ -43,6 +41,7 @@ class ImgDetectionExtended(dai.Buffer):
         self._label: int = -1
         self._label_name: str = ""
         self._keypoints: List[Keypoint] = []
+        self._logger = get_logger(__name__)
 
     @property
     def rotated_rect(self) -> dai.RotatedRect:
@@ -89,7 +88,7 @@ class ImgDetectionExtended(dai.Buffer):
             raise ValueError("Confidence must be between 0 and 1.")
         if not (0 <= value <= 1):
             value = max(0, min(1, value))
-            logger.info("Confidence value was clipped to [0, 1].")
+            self._logger.info("Confidence value was clipped to [0, 1].")
 
         self._confidence = value
 

--- a/depthai_nodes/ml/messages/keypoints.py
+++ b/depthai_nodes/ml/messages/keypoints.py
@@ -1,11 +1,9 @@
-import logging
 from typing import List
 
 import depthai as dai
 
 from depthai_nodes.ml.helpers.constants import KEYPOINT_COLOR
-
-logger = logging.getLogger(__name__)
+from depthai_nodes.utils import get_logger
 
 
 class Keypoint(dai.Buffer):
@@ -30,6 +28,7 @@ class Keypoint(dai.Buffer):
         self._y: float = None
         self._z: float = 0.0
         self._confidence: float = -1.0
+        self._logger = get_logger(__name__)
 
     @property
     def x(self) -> float:
@@ -55,7 +54,7 @@ class Keypoint(dai.Buffer):
             raise ValueError("x must be between 0 and 1.")
         if not (0 <= value <= 1):
             value = max(0, min(1, value))
-            logger.info("x value was clipped to [0, 1].")
+            self._logger.info("x value was clipped to [0, 1].")
         self._x = value
 
     @property
@@ -82,7 +81,7 @@ class Keypoint(dai.Buffer):
             raise ValueError("y must be between 0 and 1.")
         if not (0 <= value <= 1):
             value = max(0, min(1, value))
-            logger.info("y value was clipped to [0, 1].")
+            self._logger.info("y value was clipped to [0, 1].")
         self._y = value
 
     @property
@@ -130,7 +129,7 @@ class Keypoint(dai.Buffer):
             raise ValueError("Confidence must be between 0 and 1.")
         if not (0 <= value <= 1):
             value = max(0, min(1, value))
-            logger.info("Confidence value was clipped to [0, 1].")
+            self._logger.info("Confidence value was clipped to [0, 1].")
         self._confidence = value
 
 

--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from enum import Enum
 from typing import List, Optional, Tuple
@@ -8,8 +7,9 @@ import numpy as np
 from depthai_nodes.ml.parsers.utils.bbox_format_converters import xywh_to_xyxy
 from depthai_nodes.ml.parsers.utils.masks_utils import sigmoid
 from depthai_nodes.ml.parsers.utils.nms import nms
+from depthai_nodes.utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class YOLOSubtype(str, Enum):

--- a/depthai_nodes/utils/__init__.py
+++ b/depthai_nodes/utils/__init__.py
@@ -1,3 +1,3 @@
-from .logging import setup_logging
+from .logging import get_logger, setup_logging
 
-__all__ = ["setup_logging"]
+__all__ = ["setup_logging", "get_logger"]

--- a/depthai_nodes/utils/logging.py
+++ b/depthai_nodes/utils/logging.py
@@ -20,7 +20,7 @@ def get_logger(name: Optional[str] = None) -> logging.Logger:
 
 
 def setup_logging(level: Optional[str] = None, file: Optional[str] = None):
-    """Globally configures logging.
+    """Globally configures logging for depthai_nodes package.
 
     @type level: str or None
     @param level: Logging level. One of "CRITICAL", "DEBUG", "ERR", "INFO", and "WARN".
@@ -30,6 +30,7 @@ def setup_logging(level: Optional[str] = None, file: Optional[str] = None):
     @param file: Path to a file where logs will be saved. If None, logs will not be
         saved. Defaults to None.
     """
+    logger = get_logger()
     passed_level = get_log_level(level)
     env_dai_nodes_level = get_log_level(os.environ.get("DEPTHAI_NODES_LEVEL", None))
     env_dai_level = get_log_level(os.environ.get("DEPTHAI_LEVEL", None))
@@ -41,18 +42,17 @@ def setup_logging(level: Optional[str] = None, file: Optional[str] = None):
     format = file_format = "%(asctime)s [depthai-nodes] [%(levelname)s] %(message)s"
     datefmt = "[%Y-%m-%d %H:%M:%S]"
 
-    handlers = [logging.StreamHandler()]
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(logging.Formatter(format, datefmt=datefmt))
+    logger.addHandler(console_handler)
 
     if file is not None:
         file_handler = logging.FileHandler(file)
         file_handler.setFormatter(logging.Formatter(file_format, datefmt=datefmt))
-        handlers.append(file_handler)  # type: ignore
+        logger.addHandler(file_handler)
 
-    logging.basicConfig(
-        level=used_level.value, format=format, datefmt=datefmt, handlers=handlers
-    )
-
-    logging.info(f"Using log level: {used_level}")
+    logger.setLevel(used_level.value)
+    logger.info(f"Using log level: {used_level}")
 
 
 def get_log_level(level_str: Optional[str]) -> Optional[LogLevel]:

--- a/depthai_nodes/utils/logging.py
+++ b/depthai_nodes/utils/logging.py
@@ -12,6 +12,13 @@ class LogLevel(Enum):
     WARN = "WARN"
 
 
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    logger = logging.getLogger("depthai-nodes")
+    if name:
+        logger = logger.getChild(name)
+    return logger
+
+
 def setup_logging(level: Optional[str] = None, file: Optional[str] = None):
     """Globally configures logging.
 


### PR DESCRIPTION
## Purpose
Previous setup of the logging module led to duplicit logs when using the Python `logging` module along the `depthai-nodes` package as a dependency. 

## Specification
To get the package logger use the `get_logger` method from `depthai_nodes.utils`.

## Dependencies & Potential Impact
All the files and classes that were using the logger were changed to use the package logger.

## Testing & Validation
Was tested on simple script, where a custom logger was configured and log message from `depthai-nodes` was triggered. The logs were not duplicated by `depthai-nodes` logger. The logs from `depthai-nodes` were successfully logged.
