### PR TITLE
Fix/yoloextendedparser classes keypoints

### DIFF
--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -337,7 +337,9 @@ def parse_yolo_output(
         )
     else:
         # Keypoints
-        kpts[:, 2::3] = sigmoid(kpts[:, 2::3])
+        sigmoid_applied = np.all((kpts[:, 2::3] >= 0) & (kpts[:, 2::3] <= 1))
+        if not sigmoid_applied:
+            kpts[:, 2::3] = sigmoid(kpts[:, 2::3])
         kpts_out = kpts.transpose(0, 2, 1)
         out = out.reshape(bs, ny * nx, -1)
         out = np.concatenate((out, kpts_out), axis=2)

--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -337,9 +337,13 @@ def parse_yolo_output(
         )
     else:
         # Keypoints
-        sigmoid_applied = np.all((kpts[:, 2::3] >= 0) & (kpts[:, 2::3] <= 1))
-        if not sigmoid_applied:
-            kpts[:, 2::3] = sigmoid(kpts[:, 2::3])
+
+        # NOTE: For now we omit "guessing" if sigmoid is applied, should be better handled with flags in NNarchive/Parser 
+        # sigmoid_applied = np.all((kpts[:, 2::3] >= 0) & (kpts[:, 2::3] <= 1))
+        # if not sigmoid_applied:
+        #     kpts[:, 2::3] = sigmoid(kpts[:, 2::3])
+
+        kpts[:, 2::3] = sigmoid(kpts[:, 2::3])
         kpts_out = kpts.transpose(0, 2, 1)
         out = out.reshape(bs, ny * nx, -1)
         out = np.concatenate((out, kpts_out), axis=2)

--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -338,7 +338,7 @@ def parse_yolo_output(
     else:
         # Keypoints
 
-        # NOTE: For now we omit "guessing" if sigmoid is applied, should be better handled with flags in NNarchive/Parser 
+        # NOTE: For now we omit "guessing" if sigmoid is applied, should be better handled with flags in NNarchive/Parser
         # sigmoid_applied = np.all((kpts[:, 2::3] >= 0) & (kpts[:, 2::3] <= 1))
         # if not sigmoid_applied:
         #     kpts[:, 2::3] = sigmoid(kpts[:, 2::3])

--- a/depthai_nodes/ml/parsers/utils/yolo.py
+++ b/depthai_nodes/ml/parsers/utils/yolo.py
@@ -96,15 +96,8 @@ def non_max_suppression(
     """
     bs = prediction.shape[0]  # batch size
 
-    # Detection: 4 (bbox) + 1 (objectness) = 5
-    # Keypoints: 4 (bbox) + 1 (objectness) + 51 (kpts) = 56
-    # Segmentation: 4 (bbox) + 1 (objectness) + 4 (pos) = 9
-    if det_mode:
-        num_classes_check = prediction.shape[2] - 5
-    else:
-        num_classes_check = prediction.shape[2] - (
-            56 if kpts_mode else 9
-        )  # number of classes
+    offset = prediction.shape[2] - num_classes
+    num_classes_check = prediction.shape[2] - offset
 
     nm = prediction.shape[2] - num_classes - 5
     pred_candidates = prediction[..., 4] > conf_thres  # candidates
@@ -344,8 +337,7 @@ def parse_yolo_output(
         )
     else:
         # Keypoints
-        if (kpts.shape[1] // 17) == 3:
-            kpts[:, 2::3] = sigmoid(kpts[:, 2::3])
+        kpts[:, 2::3] = sigmoid(kpts[:, 2::3])
         kpts_out = kpts.transpose(0, 2, 1)
         out = out.reshape(bs, ny * nx, -1)
         out = np.concatenate((out, kpts_out), axis=2)

--- a/depthai_nodes/ml/parsers/yolo.py
+++ b/depthai_nodes/ml/parsers/yolo.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict, List, Optional
 
 import cv2
@@ -20,8 +19,6 @@ from depthai_nodes.ml.parsers.utils.yolo import (
     decode_yolo_output,
     parse_kpts,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class YOLOExtendedParser(BaseParser):
@@ -317,22 +314,20 @@ class YOLOExtendedParser(BaseParser):
             if self.anchors is not None:
                 self.anchors = np.array(self.anchors).reshape(len(strides), -1)
 
-            # Enusre the number of classes is correct
+            # Ensure the number of classes is correct
             num_classes_check = outputs_values[0].shape[1] - 5
             if num_classes_check != self.n_classes:
-                logger.warning(
-                    f"The provided number of classes {self.n_classes} does not match the model's {num_classes_check}. Updating the number of classes to {num_classes_check}."
+                raise ValueError(
+                    f"The provided number of classes {self.n_classes} does not match the model's {num_classes_check}."
                 )
-                self.n_classes = num_classes_check
 
             # Ensure the number of keypoints is correct
             if mode == self._KPTS_MODE:
                 num_keypoints_check = kpts_outputs[0].shape[1] // 3
                 if num_keypoints_check != self.n_keypoints:
-                    logger.warning(
-                        f"The provided number of keypoints {self.n_keypoints} does not match the model's {num_keypoints_check}. Updating the number of keypoints to {num_keypoints_check}."
+                    raise ValueError(
+                        f"The provided number of keypoints {self.n_keypoints} does not match the model's {num_keypoints_check}."
                     )
-                    self.n_keypoints = num_keypoints_check
 
             # Decode the outputs
             results = decode_yolo_output(


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Previously NMS for keypoints was hardcoded to COCO person keypoints (17 points) which caused it to fail for custom models (e.g. [barcode](https://hub.luxonis.com/ai/models/75edea0f-79c9-4091-a48c-f81424b3ccab?view=page) model on HubAI). This PR fixes this.

## Specification
<!-- Briefly describe what’s changing and any relevant details. -->
Changed NMS to remove some checks which caused other models to fail. Now we also apply sigmoid on kpt confidences by default (this can be changed down the line with new NNArchive/parser argument)

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? -->
No breaking changes.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. -->

## Testing & Validation
<!-- How was this tested? Include relevant test results. -->