### PR TITLE
Set label names in detection parsers.

### DIFF
--- a/depthai_nodes/ml/messages/creators/detection.py
+++ b/depthai_nodes/ml/messages/creators/detection.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 import depthai as dai
 import numpy as np
 
@@ -15,6 +17,7 @@ def create_detection_message(
     scores: np.ndarray,
     angles: np.ndarray = None,
     labels: np.ndarray = None,
+    label_names: Optional[List[str]] = None,
     keypoints: np.ndarray = None,
     keypoints_scores: np.ndarray = None,
     masks: np.ndarray = None,
@@ -32,6 +35,8 @@ def create_detection_message(
     @type angles: Optional[np.ndarray]
     @param labels: Labels of detected objects of shape (N,).
     @type labels: Optional[np.ndarray]
+    @param label_names: Names of the labels (classes)
+    @type label_names: Optional[List[str]]
     @param keypoints: Keypoints of detected objects of shape (N, n_keypoints, dim) where
         dim is 2 or 3.
     @type keypoints: Optional[np.array]
@@ -99,6 +104,12 @@ def create_detection_message(
             raise ValueError(
                 f"Labels should have same length as bboxes, got {len(labels)} labels and {n_bboxes} bounding boxes."
             )
+
+    if label_names is not None:
+        if not isinstance(label_names, list):
+            raise ValueError(f"Label names should be a list, got {type(label_names)}.")
+        if not all(isinstance(label_name, str) for label_name in label_names):
+            raise ValueError(f"Label names should be strings, got {label_names}.")
 
     if angles is not None:
         if not isinstance(angles, np.ndarray):
@@ -184,6 +195,8 @@ def create_detection_message(
 
         if labels is not None:
             detection.label = int(labels[detection_idx])
+            if label_names is not None:
+                detection.label_name = label_names[detection_idx]
         if keypoints is not None:
             if keypoints_scores is not None:
                 detection.keypoints = transform_to_keypoints(

--- a/depthai_nodes/ml/parsers/detection.py
+++ b/depthai_nodes/ml/parsers/detection.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from depthai_nodes.ml.parsers.base_parser import BaseParser
 
 
@@ -17,6 +19,8 @@ class DetectionParser(BaseParser):
         Non-maximum suppression threshold.
     max_det : int
         Maximum number of detections to keep.
+    label_names : List[str]
+        List of label names for detected objects.
 
     Output Message/s
         -------
@@ -31,6 +35,7 @@ class DetectionParser(BaseParser):
         conf_threshold: float,
         iou_threshold: float,
         max_det: int,
+        label_names: Optional[List[str]] = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -45,6 +50,7 @@ class DetectionParser(BaseParser):
         self.conf_threshold = conf_threshold
         self.iou_threshold = iou_threshold
         self.max_det = max_det
+        self.label_names = label_names
 
     def setConfidenceThreshold(self, threshold: float) -> None:
         """Sets the confidence score threshold for detected objects.
@@ -76,6 +82,18 @@ class DetectionParser(BaseParser):
             raise ValueError("Max detections must be an integer.")
         self.max_det = max_det
 
+    def setLabelNames(self, label_names: List[str]) -> None:
+        """Sets the label names for detected objects.
+
+        @param label_names: List of label names for detected objects.
+        @type label_names: List[str]
+        """
+        if not isinstance(label_names, list):
+            raise ValueError("Label names must be a list.")
+        if not all(isinstance(label, str) for label in label_names):
+            raise ValueError("Each label name must be a string.")
+        self.label_names = label_names
+
     def build(self, head_config) -> "DetectionParser":
         """Configures the parser.
 
@@ -88,5 +106,6 @@ class DetectionParser(BaseParser):
         self.conf_threshold = head_config.get("conf_threshold", self.conf_threshold)
         self.iou_threshold = head_config.get("iou_threshold", self.iou_threshold)
         self.max_det = head_config.get("max_det", self.max_det)
+        self.label_names = head_config.get("classes", self.label_names)
 
         return self

--- a/depthai_nodes/ml/parsers/mediapipe_palm_detection.py
+++ b/depthai_nodes/ml/parsers/mediapipe_palm_detection.py
@@ -68,6 +68,7 @@ class MPPalmDetectionParser(DetectionParser):
         self.iou_threshold = iou_threshold
         self.max_det = max_det
         self.scale = scale
+        self.label_names = ["Palm"]
 
     def setOutputLayerNames(self, output_layer_names: List[str]) -> None:
         """Sets the output layer name(s) for the parser.
@@ -194,9 +195,26 @@ class MPPalmDetectionParser(DetectionParser):
             points = np.clip(points, 0, 1)
             angles = np.round(angles, 0)
 
-            detections_msg = create_detection_message(
-                bboxes=bboxes, scores=scores, angles=angles, keypoints=points
-            )
+            labels = np.array([0] * len(bboxes))
+
+            if self.label_names:
+                label_names = [self.label_names[label] for label in labels]
+                detections_msg = create_detection_message(
+                    bboxes=bboxes,
+                    scores=scores,
+                    angles=angles,
+                    keypoints=points,
+                    labels=labels,
+                    label_names=label_names,
+                )
+            else:
+                detections_msg = create_detection_message(
+                    bboxes=bboxes,
+                    scores=scores,
+                    angles=angles,
+                    keypoints=points,
+                    labels=labels,
+                )
             detections_msg.setTimestamp(output.getTimestamp())
             detections_msg.transformation = output.getTransformation()
             detections_msg.setSequenceNum(output.getSequenceNum())

--- a/depthai_nodes/ml/parsers/mediapipe_palm_detection.py
+++ b/depthai_nodes/ml/parsers/mediapipe_palm_detection.py
@@ -197,24 +197,19 @@ class MPPalmDetectionParser(DetectionParser):
 
             labels = np.array([0] * len(bboxes))
 
-            if self.label_names:
-                label_names = [self.label_names[label] for label in labels]
-                detections_msg = create_detection_message(
-                    bboxes=bboxes,
-                    scores=scores,
-                    angles=angles,
-                    keypoints=points,
-                    labels=labels,
-                    label_names=label_names,
-                )
-            else:
-                detections_msg = create_detection_message(
-                    bboxes=bboxes,
-                    scores=scores,
-                    angles=angles,
-                    keypoints=points,
-                    labels=labels,
-                )
+            label_names = (
+                [self.label_names[label] for label in labels]
+                if self.label_names
+                else None
+            )
+            detections_msg = create_detection_message(
+                bboxes=bboxes,
+                scores=scores,
+                angles=angles,
+                keypoints=points,
+                labels=labels,
+                label_names=label_names,
+            )
             detections_msg.setTimestamp(output.getTimestamp())
             detections_msg.transformation = output.getTransformation()
             detections_msg.setSequenceNum(output.getSequenceNum())

--- a/depthai_nodes/ml/parsers/scrfd.py
+++ b/depthai_nodes/ml/parsers/scrfd.py
@@ -217,20 +217,18 @@ class SCRFDParser(DetectionParser):
 
             labels = np.array([0] * len(bboxes))
 
-            if self.label_names:
-                label_names = [self.label_names[label] for label in labels]
-                message = create_detection_message(
-                    bboxes=bboxes,
-                    scores=scores,
-                    labels=labels,
-                    label_names=label_names,
-                    keypoints=keypoints,
-                )
-            else:
-                message = create_detection_message(
-                    bboxes=bboxes, scores=scores, keypoints=keypoints, labels=labels
-                )
-
+            label_names = (
+                [self.label_names[label] for label in labels]
+                if self.label_names
+                else None
+            )
+            message = create_detection_message(
+                bboxes=bboxes,
+                scores=scores,
+                labels=labels,
+                label_names=label_names,
+                keypoints=keypoints,
+            )
             message.setTimestamp(output.getTimestamp())
             message.transformation = output.getTransformation()
             message.setSequenceNum(output.getSequenceNum())

--- a/depthai_nodes/ml/parsers/scrfd.py
+++ b/depthai_nodes/ml/parsers/scrfd.py
@@ -71,6 +71,7 @@ class SCRFDParser(DetectionParser):
         self.feat_stride_fpn = feat_stride_fpn
         self.num_anchors = num_anchors
         self.input_size = input_size
+        self.label_names = ["Face"]
 
     def setOutputLayerNames(self, output_layer_names: List[str]) -> None:
         """Sets the output layer name(s) for the parser.
@@ -213,9 +214,23 @@ class SCRFDParser(DetectionParser):
             )
             bboxes = xyxy_to_xywh(bboxes)
             bboxes = np.clip(bboxes, 0, 1)
-            message = create_detection_message(
-                bboxes=bboxes, scores=scores, keypoints=keypoints
-            )
+
+            labels = np.array([0] * len(bboxes))
+
+            if self.label_names:
+                label_names = [self.label_names[label] for label in labels]
+                message = create_detection_message(
+                    bboxes=bboxes,
+                    scores=scores,
+                    labels=labels,
+                    label_names=label_names,
+                    keypoints=keypoints,
+                )
+            else:
+                message = create_detection_message(
+                    bboxes=bboxes, scores=scores, keypoints=keypoints, labels=labels
+                )
+
             message.setTimestamp(output.getTimestamp())
             message.transformation = output.getTransformation()
             message.setSequenceNum(output.getSequenceNum())

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -298,20 +298,19 @@ class YuNetParser(DetectionParser):
 
             labels = np.array([0] * len(bboxes))
 
-            if self.label_names:
-                label_names = [self.label_names[label] for label in labels]
+            label_names = (
+                [self.label_names[label] for label in labels]
+                if self.label_names
+                else None
+            )
 
-                detections_message = create_detection_message(
-                    bboxes=bboxes,
-                    scores=scores,
-                    keypoints=keypoints,
-                    labels=labels,
-                    label_names=label_names,
-                )
-            else:
-                detections_message = create_detection_message(
-                    bboxes=bboxes, scores=scores, keypoints=keypoints, labels=labels
-                )
+            detections_message = create_detection_message(
+                bboxes=bboxes,
+                scores=scores,
+                keypoints=keypoints,
+                labels=labels,
+                label_names=label_names,
+            )
 
             detections_message.setTimestamp(output.getTimestamp())
             detections_message.transformation = output.getTransformation()

--- a/depthai_nodes/ml/parsers/yunet.py
+++ b/depthai_nodes/ml/parsers/yunet.py
@@ -78,6 +78,7 @@ class YuNetParser(DetectionParser):
         self.conf_output_layer_name = conf_output_layer_name
         self.iou_output_layer_name = iou_output_layer_name
         self.input_size = input_size
+        self.label_names = ["Face"]
 
     def setInputSize(self, input_size: Tuple[int, int]) -> None:
         """Sets the input size of the model.
@@ -295,9 +296,22 @@ class YuNetParser(DetectionParser):
             bboxes = np.clip(bboxes, 0, 1)
             keypoints = np.clip(keypoints, 0, 1)
 
-            detections_message = create_detection_message(
-                bboxes=bboxes, scores=scores, keypoints=keypoints
-            )
+            labels = np.array([0] * len(bboxes))
+
+            if self.label_names:
+                label_names = [self.label_names[label] for label in labels]
+
+                detections_message = create_detection_message(
+                    bboxes=bboxes,
+                    scores=scores,
+                    keypoints=keypoints,
+                    labels=labels,
+                    label_names=label_names,
+                )
+            else:
+                detections_message = create_detection_message(
+                    bboxes=bboxes, scores=scores, keypoints=keypoints, labels=labels
+                )
 
             detections_message.setTimestamp(output.getTimestamp())
             detections_message.transformation = output.getTransformation()

--- a/tests/integration_tests/main.py
+++ b/tests/integration_tests/main.py
@@ -73,7 +73,7 @@ def main():
         f"--models={models}",
         f"--parsers={parsers}",
         "-v",
-        "--tb=no",
+        "--tb=short",
         "-r a",
         "--log-cli-level=DEBUG",
         "--color=yes",

--- a/tests/unittests/test_creators/test_detections.py
+++ b/tests/unittests/test_creators/test_detections.py
@@ -22,7 +22,13 @@ ONE_SCORE = np.array([0.9])
 
 def test_valid_input():
     message = create_detection_message(
-        BBOXES, SCORES, ANGLES, LABELS, KPTS, KPTS_SCORES, MASKS
+        bboxes=BBOXES,
+        scores=SCORES,
+        labels=LABELS,
+        angles=ANGLES,
+        keypoints=KPTS,
+        keypoints_scores=KPTS_SCORES,
+        masks=MASKS,
     )
 
     assert isinstance(message, ImgDetectionsExtended)


### PR DESCRIPTION
## Purpose
We have `label_name` in the `ImgDetectionExtended` message but we do not set this field in the parsers. Setting this will allow the user to extract the class with `detection.label_name`.

## Specification
I adjusted `YOLOExtendedParser` and `DetectionParser` to get the class names from nn archive inside the `build` method. Relevant detection parsers are also adjusted.

## Dependencies & Potential Impact
No breaking changes.

## Deployment Plan
No plan.

## Testing & Validation
It was tested on all affected parsers. For yolo versions I tested pose estimation model and YOLOP.
