### PR TITLE
Remove RVC2 specific check

### DIFF
--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -271,9 +271,7 @@ class ImgDetectionsExtended(dai.Buffer):
         img_annotations = dai.ImgAnnotations()
         annotation = dai.ImgAnnotation()
         transformation = self.transformation
-        w, h = 1, 1
-        if transformation is not None:  # remove once RVC2 supports ImgTransformation
-            w, h = transformation.getSize()
+        w, h = transformation.getSize()
 
         for detection in self.detections:
             detection: ImgDetectionExtended = detection


### PR DESCRIPTION
This PR removes a small, RVC2 specific, type check that was added due to a depthai bug. As of depthai 3.13 this bug has been patched and the type check is no longer needed. 