### PR TITLE
Updated DetectionParser.

### DIFF
--- a/depthai_nodes/node/parsers/detection.py
+++ b/depthai_nodes/node/parsers/detection.py
@@ -139,7 +139,7 @@ class DetectionParser(BaseParser):
 
             for layer in layers:
                 tensor: np.ndarray = output.getTensor(layer, dequantize=True)
-                if 4 in tensor.shape:
+                if tensor.shape[-1] == 4 and len(tensor.shape) != 1:
                     bboxes = tensor
                 else:
                     scores = tensor


### PR DESCRIPTION
## Purpose
By adding Mobile object localizer model to our ZOO we need a parser for it. I think we can use `DetectionParser` and just define the `run` method for `general simple` object detector - get bboxes and scores and compute NMS and return the message.

## Specification
We add the `run` method to the `DetectionParser` class so it can be used as standalone parser.

## Dependencies & Potential Impact
Does not affect other detection parsers as they all override `run` method.

## Deployment Plan
None / not applicable

## Testing & Validation
Tested with general example in dai-experiments on Mobile obj. localizer, YuNet, SCRFD, PalmDetection models.