### PR TITLE
Add setTransformation and getPoints methods

### DIFF
--- a/depthai_nodes/message/classification.py
+++ b/depthai_nodes/message/classification.py
@@ -125,6 +125,15 @@ class Classifications(dai.Buffer):
                 )
         self._transformation = value
 
+    def setTransformation(self, transformation: dai.ImgTransformation):
+        """Sets the Image Transformation object.
+
+        @param transformation: The Image Transformation object.
+        @type transformation: dai.ImgTransformation
+        @raise TypeError: If value is not a dai.ImgTransformation object.
+        """
+        self.transformation = transformation
+
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Returns default visualization message for classification.
 

--- a/depthai_nodes/message/clusters.py
+++ b/depthai_nodes/message/clusters.py
@@ -134,6 +134,15 @@ class Clusters(dai.Buffer):
                 )
         self._transformation = value
 
+    def setTransformation(self, transformation: dai.ImgTransformation):
+        """Sets the Image Transformation object.
+
+        @param transformation: The Image Transformation object.
+        @type transformation: dai.ImgTransformation
+        @raise TypeError: If value is not a dai.ImgTransformation object.
+        """
+        self.transformation = transformation
+
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Creates a default visualization message for clusters and colors each one
         separately."""

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -267,6 +267,16 @@ class ImgDetectionsExtended(dai.Buffer):
                 )
         self._transformation = value
 
+    def setTransformation(self, transformation: dai.ImgTransformation):
+        """Sets the Image Transformation object.
+
+        @param transformation: The Image Transformation object.
+        @type transformation: dai.ImgTransformation
+        @raise TypeError: If value is not a dai.ImgTransformation object.
+        """
+
+        self.transformation = transformation
+
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         img_annotations = dai.ImgAnnotations()
         annotation = dai.ImgAnnotation()

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -199,14 +199,38 @@ class Keypoints(dai.Buffer):
                 )
         self._transformation = value
 
+    def setTransformation(self, transformation: dai.ImgTransformation):
+        """Sets the Image Transformation object.
+
+        @param transformation: The Image Transformation object.
+        @type transformation: dai.ImgTransformation
+        @raise TypeError: If value is not a dai.ImgTransformation object.
+        """
+        self.transformation = transformation
+
+    def getPoints2f(self) -> dai.VectorPoint2f:
+        """Returns the keypoints in the form of a dai.VectorPoint2f object."""
+
+        return dai.VectorPoint2f(
+            [dai.Point2f(keypoint.x, keypoint.y) for keypoint in self.keypoints]
+        )
+
+    def getPoints3f(self) -> List[dai.Point3f]:
+        """Returns the keypoints in the form of a list of dai.Point3f objects."""
+
+        return [
+            dai.Point3f(keypoint.x, keypoint.y, keypoint.z)
+            for keypoint in self.keypoints
+        ]
+
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Creates a default visualization message for the keypoints."""
         img_annotations = dai.ImgAnnotations()
         annotation = dai.ImgAnnotation()
-        keypoints = [dai.Point2f(keypoint.x, keypoint.y) for keypoint in self.keypoints]
+
         pointsAnnotation = dai.PointsAnnotation()
         pointsAnnotation.type = dai.PointsAnnotationType.POINTS
-        pointsAnnotation.points = dai.VectorPoint2f(keypoints)
+        pointsAnnotation.points = self.getPoints2f()
         pointsAnnotation.outlineColor = KEYPOINT_COLOR
         pointsAnnotation.fillColor = KEYPOINT_COLOR
         pointsAnnotation.thickness = 2

--- a/depthai_nodes/message/lines.py
+++ b/depthai_nodes/message/lines.py
@@ -161,6 +161,15 @@ class Lines(dai.Buffer):
                 )
         self._transformation = value
 
+    def setTransformation(self, transformation: dai.ImgTransformation):
+        """Sets the Image Transformation object.
+
+        @param transformation: The Image Transformation object.
+        @type transformation: dai.ImgTransformation
+        @raise TypeError: If value is not a dai.ImgTransformation object.
+        """
+        self.transformation = transformation
+
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Returns default visualization message for lines.
 

--- a/depthai_nodes/message/map.py
+++ b/depthai_nodes/message/map.py
@@ -101,6 +101,15 @@ class Map2D(dai.Buffer):
 
         self._transformation = value
 
+    def setTransformation(self, transformation: dai.ImgTransformation):
+        """Sets the Image Transformation object.
+
+        @param transformation: The Image Transformation object.
+        @type transformation: dai.ImgTransformation
+        @raise TypeError: If value is not a dai.ImgTransformation object.
+        """
+        self.transformation = transformation
+
     def getVisualizationMessage(self) -> dai.ImgFrame:
         """Returns default visualization message for 2D maps in the form of a
         colormapped image."""

--- a/depthai_nodes/message/prediction.py
+++ b/depthai_nodes/message/prediction.py
@@ -123,6 +123,15 @@ class Predictions(dai.Buffer):
                 )
         self._transformation = value
 
+    def setTransformation(self, transformation: dai.ImgTransformation):
+        """Sets the Image Transformation object.
+
+        @param transformation: The Image Transformation object.
+        @type transformation: dai.ImgTransformation
+        @raise TypeError: If value is not a dai.ImgTransformation object.
+        """
+        self.transformation = transformation
+
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Returns the visualization message for the predictions.
 

--- a/depthai_nodes/message/segmentation.py
+++ b/depthai_nodes/message/segmentation.py
@@ -78,6 +78,15 @@ class SegmentationMask(dai.Buffer):
                 )
         self._transformation = value
 
+    def setTransformation(self, transformation: dai.ImgTransformation):
+        """Sets the Image Transformation object.
+
+        @param transformation: The Image Transformation object.
+        @type transformation: dai.ImgTransformation
+        @raise TypeError: If value is not a dai.ImgTransformation object.
+        """
+        self.transformation = transformation
+
     def getVisualizationMessage(self) -> dai.ImgFrame:
         """Returns the default visualization message for segmentation masks."""
         img_frame = dai.ImgFrame()

--- a/depthai_nodes/node/parsers/classification.py
+++ b/depthai_nodes/node/parsers/classification.py
@@ -141,7 +141,7 @@ class ClassificationParser(BaseParser):
                 scores = softmax(scores)
 
             msg = create_classification_message(self.classes, scores)
-            msg.transformation = output.getTransformation()
+            msg.setTransformation(output.getTransformation())
             msg.setTimestamp(output.getTimestamp())
             msg.setSequenceNum(output.getSequenceNum())
 

--- a/depthai_nodes/node/parsers/classification_sequence.py
+++ b/depthai_nodes/node/parsers/classification_sequence.py
@@ -179,7 +179,7 @@ class ClassificationSequenceParser(ClassificationParser):
                 ignored_indexes=self.ignored_indexes,
                 concatenate_classes=self.concatenate_classes,
             )
-            msg.transformation = output.getTransformation()
+            msg.setTransformation(output.getTransformation())
             msg.setTimestamp(output.getTimestamp())
             msg.setSequenceNum(output.getSequenceNum())
 

--- a/depthai_nodes/node/parsers/detection.py
+++ b/depthai_nodes/node/parsers/detection.py
@@ -163,7 +163,7 @@ class DetectionParser(BaseParser):
                 bboxes = xyxy_to_xywh(bboxes)
 
                 message = create_detection_message(bboxes=bboxes, scores=scores)
-                message.transformation = output.getTransformation()
+                message.setTransformation(output.getTransformation())
                 message.setTimestamp(output.getTimestamp())
                 message.setSequenceNum(output.getSequenceNum())
 

--- a/depthai_nodes/node/parsers/fastsam.py
+++ b/depthai_nodes/node/parsers/fastsam.py
@@ -353,7 +353,7 @@ class FastSAMParser(BaseParser):
             results_masks = merge_masks(results_masks)
 
             segmentation_message = create_segmentation_message(results_masks)
-            segmentation_message.transformation = output.getTransformation()
+            segmentation_message.setTransformation(output.getTransformation())
             segmentation_message.setTimestamp(output.getTimestamp())
             segmentation_message.setSequenceNum(output.getSequenceNum())
 

--- a/depthai_nodes/node/parsers/hrnet.py
+++ b/depthai_nodes/node/parsers/hrnet.py
@@ -113,7 +113,7 @@ class HRNetParser(KeypointParser):
                 confidence_threshold=self.score_threshold,
             )
             keypoints_message.setTimestamp(output.getTimestamp())
-            keypoints_message.transformation = output.getTransformation()
+            keypoints_message.setTransformation(output.getTransformation())
             keypoints_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(keypoints_message)

--- a/depthai_nodes/node/parsers/keypoints.py
+++ b/depthai_nodes/node/parsers/keypoints.py
@@ -172,7 +172,7 @@ class KeypointParser(BaseParser):
 
             msg = create_keypoints_message(keypoints)
             msg.setTimestamp(output.getTimestamp())
-            msg.transformation = output.getTransformation()
+            msg.setTransformation(output.getTransformation())
             msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(msg)

--- a/depthai_nodes/node/parsers/lane_detection.py
+++ b/depthai_nodes/node/parsers/lane_detection.py
@@ -203,7 +203,7 @@ class LaneDetectionParser(BaseParser):
 
             msg = create_cluster_message(points)
             msg.setTimestamp(output.getTimestamp())
-            msg.transformation = output.getTransformation()
+            msg.setTransformation(output.getTransformation())
             msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(msg)

--- a/depthai_nodes/node/parsers/map_output.py
+++ b/depthai_nodes/node/parsers/map_output.py
@@ -106,7 +106,7 @@ class MapOutputParser(BaseParser):
                 map=map, min_max_scaling=self.min_max_scaling
             )
             map_message.setTimestamp(output.getTimestamp())
-            map_message.transformation = output.getTransformation()
+            map_message.setTransformation(output.getTransformation())
             map_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(map_message)

--- a/depthai_nodes/node/parsers/mediapipe_palm_detection.py
+++ b/depthai_nodes/node/parsers/mediapipe_palm_detection.py
@@ -205,7 +205,7 @@ class MPPalmDetectionParser(DetectionParser):
                 label_names=label_names,
             )
             detections_msg.setTimestamp(output.getTimestamp())
-            detections_msg.transformation = output.getTransformation()
+            detections_msg.setTransformation(output.getTransformation())
             detections_msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(detections_msg)

--- a/depthai_nodes/node/parsers/mlsd.py
+++ b/depthai_nodes/node/parsers/mlsd.py
@@ -171,7 +171,7 @@ class MLSDParser(BaseParser):
 
             message = create_line_detection_message(lines, np.array(scores))
             message.setTimestamp(output.getTimestamp())
-            message.transformation = output.getTransformation()
+            message.setTransformation(output.setTransformation())
             message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(message)

--- a/depthai_nodes/node/parsers/mlsd.py
+++ b/depthai_nodes/node/parsers/mlsd.py
@@ -171,7 +171,7 @@ class MLSDParser(BaseParser):
 
             message = create_line_detection_message(lines, np.array(scores))
             message.setTimestamp(output.getTimestamp())
-            message.setTransformation(output.setTransformation())
+            message.setTransformation(output.getTransformation())
             message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(message)

--- a/depthai_nodes/node/parsers/ppdet.py
+++ b/depthai_nodes/node/parsers/ppdet.py
@@ -126,7 +126,7 @@ class PPTextDetectionParser(DetectionParser):
                 bboxes=bboxes, scores=scores, angles=angles
             )
             message.setTimestamp(output.getTimestamp())
-            message.transformation = output.getTransformation()
+            message.setTransformation(output.getTransformation())
             message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(message)

--- a/depthai_nodes/node/parsers/regression.py
+++ b/depthai_nodes/node/parsers/regression.py
@@ -88,7 +88,7 @@ class RegressionParser(BaseParser):
 
             regression_message = create_regression_message(predictions=predictions)
             regression_message.setTimestamp(output.getTimestamp())
-            regression_message.transformation = output.getTransformation()
+            regression_message.setTransformation(output.getTransformation())
             regression_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(regression_message)

--- a/depthai_nodes/node/parsers/scrfd.py
+++ b/depthai_nodes/node/parsers/scrfd.py
@@ -230,7 +230,7 @@ class SCRFDParser(DetectionParser):
                 keypoints=keypoints,
             )
             message.setTimestamp(output.getTimestamp())
-            message.transformation = output.getTransformation()
+            message.setTransformation(output.getTransformation())
             message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(message)

--- a/depthai_nodes/node/parsers/segmentation.py
+++ b/depthai_nodes/node/parsers/segmentation.py
@@ -153,7 +153,7 @@ class SegmentationParser(BaseParser):
 
             mask_message = create_segmentation_message(class_map)
             mask_message.setTimestamp(output.getTimestamp())
-            mask_message.transformation = output.getTransformation()
+            mask_message.setTransformation(output.getTransformation())
             mask_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(mask_message)

--- a/depthai_nodes/node/parsers/superanimal_landmarker.py
+++ b/depthai_nodes/node/parsers/superanimal_landmarker.py
@@ -99,7 +99,7 @@ class SuperAnimalParser(KeypointParser):
 
             msg = create_keypoints_message(keypoints, scores, self.score_threshold)
             msg.setTimestamp(output.getTimestamp())
-            msg.transformation = output.getTransformation()
+            msg.setTransformation(output.getTransformation())
             msg.setSequenceNum(output.getSequenceNum())
 
             self.out.send(msg)

--- a/depthai_nodes/node/parsers/yolo.py
+++ b/depthai_nodes/node/parsers/yolo.py
@@ -444,7 +444,7 @@ class YOLOExtendedParser(BaseParser):
                 )
 
             detections_message.setTimestamp(output.getTimestamp())
-            detections_message.transformation = output.getTransformation()
+            detections_message.setTransformation(output.getTransformation())
             detections_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(detections_message)

--- a/depthai_nodes/node/parsers/yunet.py
+++ b/depthai_nodes/node/parsers/yunet.py
@@ -313,7 +313,7 @@ class YuNetParser(DetectionParser):
             )
 
             detections_message.setTimestamp(output.getTimestamp())
-            detections_message.transformation = output.getTransformation()
+            detections_message.setTransformation(output.getTransformation())
             detections_message.setSequenceNum(output.getSequenceNum())
 
             self.out.send(detections_message)


### PR DESCRIPTION

## Purpose
This PR adds the following methods:
1) `setTransformation()` wrapper method to all message types. This is done in an effort to unify the syntax with depthai-core. The usage can be seen in the parsers as now the `setTransformation()` is used instead of `msg.transformation = transformation`
2) `getPoints2f()` and `getPoints3f()` are helper methods for the Keypoints message type. The purpose is to simplify the conversion process from depthai-nodes types to depthai-core types.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
No breaking changes are expected as 1) are wrapper functions and 2) are helper functions.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable