### PR TITLE
fix: ApplyColormap output message

### DIFF
--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -2,7 +2,7 @@ import cv2
 import depthai as dai
 import numpy as np
 
-from depthai_nodes.message import ImgDetectionsExtended, Map2D
+from depthai_nodes.message import ImgDetectionsExtended, Map2D, SegmentationMask
 
 
 class ApplyColormap(dai.node.HostNode):
@@ -95,7 +95,9 @@ class ApplyColormap(dai.node.HostNode):
         @type instance_to_semantic_segmentation: bool
         """
 
-        if isinstance(msg, dai.ImgFrame):
+        if isinstance(msg, SegmentationMask):
+            arr = msg.mask
+        elif isinstance(msg, dai.ImgFrame):
             if not msg.getType().name.startswith("RAW"):
                 raise TypeError(f"Expected image type RAW, got {msg.getType().name}")
             arr = msg.getCvFrame()
@@ -113,7 +115,7 @@ class ApplyColormap(dai.node.HostNode):
             else:
                 arr = msg.masks  # semantic segmentation mask
         else:
-            raise ValueError("Unsupported input type. Cannot obtain a 2D array.")
+            raise ValueError(f"Unsupported input type {type(msg)}.")
 
         # make sure that min value == 0 to ensure proper normalization
         arr += np.abs(arr.min()) if arr.min() < 0 else 0

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -139,7 +139,7 @@ class ApplyColormap(dai.node.HostNode):
                 else dai.ImgFrame.Type.BGR888p
             ),
         )
-        frame.setTimestamp(frame.getTimestamp())
-        frame.setSequenceNum(frame.getSequenceNum())
+        frame.setTimestamp(msg.getTimestamp())
+        frame.setSequenceNum(msg.getSequenceNum())
 
         self.out.send(frame)


### PR DESCRIPTION
## Purpose
Fixing bugs in `ApplyColormap` node:

- The `timestamp` and `sequence number` info of the outgoing message are not set correctly which is causing syncing issues in examples where the outgoing message is overlaid on top of other messages (e.g. in the `depthai-experiments/.../generic-example` with the `--overlay` attribute);
- the `process()` method is not accepting the `SegmentationMask` messages produced by some models.

## Specification

- The `timestamp` and `sequence number` values of the outgoing message are matched with those of the incoming message;
- the `process()` method is modified to also accept the `SegmentationMask` message type.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
The changes were tested by running the updated `generic-example` (taken from [#631](https://github.com/luxonis/depthai-experiments/pull/631)) both on RVC2 and RVC4 using the following models:

- `yolov8-instance-segmentation-nano:coco-512x288`
- `midas-v2-1:small-256x192`
- `fastsam-s:512x288`
- `mediapipe-selfie-segmentation:256x144`
