### PR TITLE
Fix: Background flickering

### DIFF
--- a/depthai_nodes/message/map.py
+++ b/depthai_nodes/message/map.py
@@ -1,8 +1,9 @@
+import copy
+
 import cv2
 import depthai as dai
 import numpy as np
 from numpy.typing import NDArray
-import copy
 
 
 class Map2D(dai.Buffer):
@@ -29,8 +30,7 @@ class Map2D(dai.Buffer):
         self._transformation: dai.ImgTransformation = None
 
     def copy(self):
-        """Creates a new instance of the Map2D class and copies the
-        attributes.
+        """Creates a new instance of the Map2D class and copies the attributes.
 
         @return: A new instance of the Map2D class.
         @rtype: Map2D

--- a/depthai_nodes/message/map.py
+++ b/depthai_nodes/message/map.py
@@ -2,6 +2,7 @@ import cv2
 import depthai as dai
 import numpy as np
 from numpy.typing import NDArray
+import copy
 
 
 class Map2D(dai.Buffer):
@@ -26,6 +27,18 @@ class Map2D(dai.Buffer):
         self._width: int = None
         self._height: int = None
         self._transformation: dai.ImgTransformation = None
+
+    def copy(self):
+        """Creates a new instance of the Map2D class and copies the
+        attributes.
+
+        @return: A new instance of the Map2D class.
+        @rtype: Map2D
+        """
+        new_obj = Map2D()
+        new_obj.map = copy.deepcopy(self._map)
+        new_obj.transformation = self._transformation
+        return new_obj
 
     @property
     def map(self) -> NDArray[np.float32]:

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -2,6 +2,7 @@ import cv2
 import depthai as dai
 import numpy as np
 
+from .utils import copy_message
 from depthai_nodes.message import ImgDetectionsExtended, Map2D, SegmentationMask
 
 
@@ -95,14 +96,16 @@ class ApplyColormap(dai.node.HostNode):
         @type instance_to_semantic_segmentation: bool
         """
 
+        msg_copy = copy_message(msg)
+
         if isinstance(msg, SegmentationMask):
-            arr = msg.mask
+            arr = msg_copy.mask
         elif isinstance(msg, dai.ImgFrame):
             if not msg.getType().name.startswith("RAW"):
                 raise TypeError(f"Expected image type RAW, got {msg.getType().name}")
             arr = msg.getCvFrame()
         elif isinstance(msg, Map2D):
-            arr = msg.map
+            arr = msg_copy.map
         elif isinstance(msg, ImgDetectionsExtended):
             if self._instance_to_semantic_mask:
                 labels = {
@@ -110,10 +113,10 @@ class ApplyColormap(dai.node.HostNode):
                 }
                 labels[-1] = -1  # background class
                 arr = np.vectorize(lambda x: labels.get(x, -1))(
-                    msg.masks  # instance segmentation mask
+                    msg_copy.masks  # instance segmentation mask
                 )  # semantic segmentation mask
             else:
-                arr = msg.masks  # semantic segmentation mask
+                arr = msg_copy.masks  # semantic segmentation mask
         else:
             raise ValueError(f"Unsupported input type {type(msg)}.")
 

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -2,8 +2,9 @@ import cv2
 import depthai as dai
 import numpy as np
 
-from .utils import copy_message
 from depthai_nodes.message import ImgDetectionsExtended, Map2D, SegmentationMask
+
+from .utils import copy_message
 
 
 class ApplyColormap(dai.node.HostNode):

--- a/depthai_nodes/node/utils/copy_message.py
+++ b/depthai_nodes/node/utils/copy_message.py
@@ -31,7 +31,6 @@ def copy_message(msg: dai.Buffer) -> dai.Buffer:
 
 
 def _copy(msg: dai.Buffer) -> dai.Buffer:
-
     def _copy_metadata(msg: dai.Buffer) -> dai.Buffer:
         msg_type = type(msg)
         msg_copy = msg_type()

--- a/depthai_nodes/node/utils/copy_message.py
+++ b/depthai_nodes/node/utils/copy_message.py
@@ -31,14 +31,32 @@ def copy_message(msg: dai.Buffer) -> dai.Buffer:
 
 
 def _copy(msg: dai.Buffer) -> dai.Buffer:
+
+    def _copy_metadata(msg: dai.Buffer) -> dai.Buffer:
+        msg_type = type(msg)
+        msg_copy = msg_type()
+        if hasattr(msg, "getSequenceNum"):
+            msg_copy.setSequenceNum(msg.getSequenceNum())
+        if hasattr(msg, "getTimestamp"):
+            msg_copy.setTimestamp(msg.getTimestamp())
+        if hasattr(msg, "getTimestampDevice"):
+            msg_copy.setTimestampDevice(msg.getTimestampDevice())
+        if hasattr(msg, "getTransformation"):
+            msg_copy.setTransformation(msg.getTransformation())
+        return msg_copy
+
+    def _copy_img_frame(img_frame: dai.ImgFrame) -> dai.ImgFrame:
+        img_frame_copy = _copy_metadata(img_frame)
+        img_frame_copy.setCvFrame(img_frame.getCvFrame(), img_frame.getType())
+        img_frame_copy.setCategory(img_frame.getCategory())
+        return img_frame_copy
+
     def _copy_img_detection(
         img_det: Union[dai.ImgDetection, dai.SpatialImgDetection],
     ) -> Union[dai.ImgDetection, dai.SpatialImgDetection]:
         assert isinstance(img_det, (dai.ImgDetection, dai.SpatialImgDetection))
-        if isinstance(img_det, dai.ImgDetection):
-            img_det_copy = dai.ImgDetection()
+        img_det_copy = _copy_metadata(img_det)
         if isinstance(img_det, dai.SpatialImgDetection):
-            img_det_copy = dai.SpatialImgDetection()
             img_det_copy.spatialCoordinates = img_det.spatialCoordinates
             img_det_copy.boundingBoxMapping = img_det.boundingBoxMapping
         img_det_copy.xmin = img_det.xmin
@@ -53,20 +71,15 @@ def _copy(msg: dai.Buffer) -> dai.Buffer:
         img_dets: Union[dai.ImgDetections, dai.SpatialImgDetections],
     ) -> Union[dai.ImgDetections, dai.SpatialImgDetections]:
         assert isinstance(img_dets, (dai.ImgDetections, dai.SpatialImgDetections))
-        if isinstance(img_dets, dai.ImgDetections):
-            img_dets_copy = dai.ImgDetections()
-        if isinstance(img_dets, dai.SpatialImgDetections):
-            img_dets_copy = dai.SpatialImgDetections()
+        img_dets_copy = _copy_metadata(img_dets)
         img_dets_copy.detections = [
             _copy_img_detection(img_det) for img_det in img_dets.detections
         ]
-        img_dets_copy.setSequenceNum(img_dets.getSequenceNum())
-        img_dets_copy.setTimestamp(img_dets.getTimestamp())
-        img_dets_copy.setTimestampDevice(img_dets.getTimestampDevice())
-        img_dets_copy.setTransformation(img_dets.getTransformation())
         return img_dets_copy
 
-    if isinstance(msg, (dai.ImgDetection, dai.SpatialImgDetection)):
+    if isinstance(msg, dai.ImgFrame):
+        return _copy_img_frame(msg)
+    elif isinstance(msg, (dai.ImgDetection, dai.SpatialImgDetection)):
         return _copy_img_detection(msg)
     elif isinstance(msg, (dai.ImgDetections, dai.SpatialImgDetections)):
         return _copy_img_detections(msg)

--- a/tests/unittests/test_nodes/test_host_nodes/test_copy_message.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_copy_message.py
@@ -9,8 +9,8 @@ from depthai_nodes.node.utils import copy_message
 from .utils import create_message
 
 ATTRS_TO_IGNORE = [
-    "transformation"
-]  # TODO: remove after getTransformation() is implemented
+    "Type",  # dai.ImgFrame attribute
+]
 
 
 def equal_attributes(obj1, obj2):
@@ -57,7 +57,5 @@ def test_message_copying(message_creator: Tuple[str, Callable]):
             assert msg.getTimestamp() == msg_copy.getTimestamp()
         if hasattr(msg, "getTimestampDevice"):
             assert msg.getTimestampDevice() == msg_copy.getTimestampDevice()
-        if hasattr(msg, "getTransformation"):
-            assert msg_copy.getTransformation() == msg.getTransformation()
     except TypeError:  # copying not implemented for all messages
         pass


### PR DESCRIPTION
## Purpose
Fixing a bug in `ApplyColor` node that was causing "flickering" visualizations.

## Specification
`ApplyColor` node was mistakenly modifying the incoming messages. Adding a message copy mechanism to prevent this from happening.

## Dependencies & Potential Impact
None

## Deployment Plan
None

## Testing & Validation
Was tested using the following models:
- mediapipe-selfie-segmentation:256x144 (`SegmentationMask` output)
- midas-v2-1:small-256x192 (`Map2D` output)