### PR TITLE
Message: Add skeleton to Keypoints.

### DIFF
--- a/depthai_nodes/message/creators/detection.py
+++ b/depthai_nodes/message/creators/detection.py
@@ -18,6 +18,8 @@ def create_detection_message(
     label_names: Optional[List[str]] = None,
     keypoints: np.ndarray = None,
     keypoints_scores: np.ndarray = None,
+    keypoint_labels: Optional[List[str]] = None,
+    keypoint_edges: Optional[List[List[int]]] = None,
     masks: np.ndarray = None,
 ) -> ImgDetectionsExtended:
     """Create a DepthAI message for object detection. The message contains the bounding
@@ -41,6 +43,10 @@ def create_detection_message(
     @param keypoints_scores: Confidence scores of detected keypoints of shape (N,
         n_keypoints, 1). Defaults to None.
     @type keypoints_scores: Optional[np.ndarray]
+    @param keypoint_labels: Labels of keypoints. Defaults to None.
+    @type keypoint_labels: Optional[List[str]]
+    @param keypoint_edges: Connection pairs of keypoints. Defaults to None.
+    @type keypoint_edges: Optional[List[List[int]]]
     @param masks: Masks of detected objects of shape (H, W). Defaults to None.
     @type masks: Optional[np.ndarray]
     @return: Message containing the bounding boxes, labels, confidence scores, and
@@ -164,6 +170,33 @@ def create_detection_message(
         if not all(0 <= score <= 1 for score in keypoints_scores.flatten()):
             raise ValueError("Keypoints scores should be between 0 and 1.")
 
+    if keypoint_labels is not None:
+        if not isinstance(keypoint_labels, list):
+            raise ValueError(
+                f"Keypoint labels should be a list, got {type(keypoint_labels)}."
+            )
+        if not all(isinstance(label, str) for label in keypoint_labels):
+            raise ValueError(
+                f"Keypoint labels should be a list of strings, got {keypoint_labels}."
+            )
+
+    if keypoint_edges is not None:
+        if not isinstance(keypoint_edges, list) and not isinstance(
+            keypoint_edges, tuple
+        ):
+            raise ValueError(
+                f"Keypoint edges should be a list or tuple, got {type(keypoint_edges)}."
+            )
+        if not all(
+            (isinstance(edge, list) or isinstance(edge, tuple))
+            and len(edge) == 2
+            and all(isinstance(i, int) for i in edge)
+            for edge in keypoint_edges
+        ):
+            raise ValueError(
+                f"Keypoint edges should be a list of lists or tuples of integers, got {keypoint_edges}."
+            )
+
     if masks is not None:
         if not isinstance(masks, np.ndarray):
             raise ValueError(f"Masks should be a numpy array, got {type(masks)}.")
@@ -201,9 +234,10 @@ def create_detection_message(
                 scores=None
                 if keypoints_scores is None
                 else keypoints_scores[detection_idx],
+                labels=keypoint_labels,
+                edges=keypoint_edges,
             )
-            detection.keypoints = keypoints_msg.keypoints
-
+            detection.keypoints = keypoints_msg
         detections.append(detection)
 
     detections_msg = ImgDetectionsExtended()

--- a/depthai_nodes/message/creators/detection.py
+++ b/depthai_nodes/message/creators/detection.py
@@ -175,11 +175,11 @@ def create_detection_message(
     if keypoint_label_names is not None:
         if not isinstance(keypoint_label_names, list):
             raise ValueError(
-                f"Keypoint labels should be a list, got {type(keypoint_label_names)}."
+                f"Keypoint label names should be a list, got {type(keypoint_label_names)}."
             )
         if not all(isinstance(label, str) for label in keypoint_label_names):
             raise ValueError(
-                f"Keypoint labels should be a list of strings, got {keypoint_label_names}."
+                f"Keypoint label names should be a list of strings, got {keypoint_label_names}."
             )
 
     if keypoint_edges is not None:
@@ -234,7 +234,7 @@ def create_detection_message(
                 scores=None
                 if keypoints_scores is None
                 else keypoints_scores[detection_idx],
-                labels=keypoint_label_names,
+                label_names=keypoint_label_names,
                 edges=keypoint_edges,
             )
             detection.keypoints = keypoints_msg

--- a/depthai_nodes/message/creators/keypoints.py
+++ b/depthai_nodes/message/creators/keypoints.py
@@ -14,6 +14,8 @@ def create_keypoints_message(
 ) -> Keypoints:
     """Create a DepthAI message for the keypoints.
 
+    NOTE: If you provide a confidence threshold for filtering the keypoints based on scores, the edges will be filtered to only include the edges between the keypoints that are present in the filtered keypoints. This is done to ensure that the edges are only drawn between the keypoints that are present in the filtered keypoints. You can always access the full set of edges in the model's NN archive.
+
     @param keypoints: Detected 2D or 3D keypoints of shape (N,2 or 3) meaning [...,[x, y],...] or [...,[x, y, z],...].
     @type keypoints: np.ndarray or List[List[float]]
     @param scores: Confidence scores of the detected keypoints. Defaults to None.

--- a/depthai_nodes/message/creators/keypoints.py
+++ b/depthai_nodes/message/creators/keypoints.py
@@ -9,7 +9,7 @@ def create_keypoints_message(
     keypoints: Union[np.ndarray, List[List[float]]],
     scores: Union[np.ndarray, List[float], None] = None,
     confidence_threshold: Optional[float] = None,
-    labels: Optional[List[str]] = None,
+    label_names: Optional[List[str]] = None,
     edges: Optional[List[Tuple[int, int]]] = None,
 ) -> Keypoints:
     """Create a DepthAI message for the keypoints.
@@ -20,8 +20,8 @@ def create_keypoints_message(
     @type scores: Union[np.ndarray, List[float], None]
     @param confidence_threshold: Confidence threshold of keypoint detections. Defaults to None.
     @type confidence_threshold: Optional[float]
-    @param labels: Labels of the detected keypoints. Defaults to None.
-    @type labels: Optional[List[str]]
+    @param label_names: label_names of the detected keypoints. Defaults to None.
+    @type label_names: Optional[List[str]]
     @param edges: Connection pairs of the detected keypoints. Defaults to None. Example: [[0,1], [1,2], [2,3], [3,0]] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is connected to keypoint 2, etc.
     @type edges: Optional[List[Tuple[int, int]]]
     @return: Keypoints message containing the detected keypoints.
@@ -95,11 +95,11 @@ def create_keypoints_message(
                         f"Keypoints inner list should contain only float, got {type(coord)}."
                     )
 
-    if labels is not None:
-        if not isinstance(labels, list):
-            raise ValueError(f"Labels should be list, got {type(labels)}.")
-        if not all(isinstance(label, str) for label in labels):
-            raise ValueError("Labels should be a list of strings.")
+    if label_names is not None:
+        if not isinstance(label_names, list):
+            raise ValueError(f"label_names should be list, got {type(label_names)}.")
+        if not all(isinstance(label, str) for label in label_names):
+            raise ValueError("label_names should be a list of strings.")
 
     if edges is not None:
         if not isinstance(edges, list):
@@ -138,8 +138,8 @@ def create_keypoints_message(
         pt.z = float(keypoint[2]) if use_3d else 0.0
         if scores is not None:
             pt.confidence = float(scores[i])
-        if labels is not None:
-            pt.label = labels[i]
+        if label_names is not None:
+            pt.label_name = label_names[i]
         points.append(pt)
         included_keypoints.append(i)
 

--- a/depthai_nodes/message/creators/keypoints.py
+++ b/depthai_nodes/message/creators/keypoints.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -10,7 +10,7 @@ def create_keypoints_message(
     scores: Union[np.ndarray, List[float], None] = None,
     confidence_threshold: Optional[float] = None,
     labels: Optional[List[str]] = None,
-    edges: Optional[List[List[int]]] = None,
+    edges: Optional[List[Tuple[int, int]]] = None,
 ) -> Keypoints:
     """Create a DepthAI message for the keypoints.
 
@@ -22,8 +22,8 @@ def create_keypoints_message(
     @type confidence_threshold: Optional[float]
     @param labels: Labels of the detected keypoints. Defaults to None.
     @type labels: Optional[List[str]]
-    @param edges: Connection pairs of the detected keypoints. Defaults to None.
-    @type edges: Optional[List[List[int]]]
+    @param edges: Connection pairs of the detected keypoints. Defaults to None. Example: [[0,1], [1,2], [2,3], [3,0]] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is connected to keypoint 2, etc.
+    @type edges: Optional[List[Tuple[int, int]]]
     @return: Keypoints message containing the detected keypoints.
     @rtype: Keypoints
 
@@ -102,15 +102,15 @@ def create_keypoints_message(
             raise ValueError("Labels should be a list of strings.")
 
     if edges is not None:
-        if not isinstance(edges, list) and not isinstance(edges, tuple):
-            raise ValueError(f"Edges should be list or tuple, got {type(edges)}.")
+        if not isinstance(edges, list):
+            raise ValueError(f"Edges should be list, got {type(edges)}.")
         if not all(
-            (isinstance(edge, list) or isinstance(edge, tuple))
+            isinstance(edge, tuple)
             and len(edge) == 2
             and all(isinstance(i, int) for i in edge)
             for edge in edges
         ):
-            raise ValueError("Edges should be a list of lists or tuples of integers.")
+            raise ValueError("Edges should be a list of tuples of integers.")
 
     keypoints = np.array(keypoints)
     if scores is not None:

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -64,10 +64,19 @@ class ImgDetectionExtended(dai.Buffer):
         new_obj.confidence = copy.deepcopy(self.confidence)
         new_obj.label = copy.deepcopy(self.label)
         new_obj.label_name = copy.deepcopy(self.label_name)
-        new_kpts = Keypoints()
-        new_kpts.keypoints = copy.deepcopy(self.keypoints)
-        new_kpts.edges = copy.deepcopy(self._keypoints.edges)
-        new_obj.keypoints = new_kpts
+        new_kpts_msg = Keypoints()
+        new_kpts = []
+        for kpt in self.keypoints:
+            new_kpt = Keypoint()
+            new_kpt.x = kpt.x
+            new_kpt.y = kpt.y
+            new_kpt.z = kpt.z
+            new_kpt.confidence = kpt.confidence
+            new_kpt.label = kpt.label
+            new_kpts.append(new_kpt)
+        new_kpts_msg.keypoints = new_kpts
+        new_kpts_msg.edges = copy.deepcopy(self._keypoints.edges)
+        new_obj.keypoints = new_kpts_msg
         return new_obj
 
     @property

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -64,7 +64,10 @@ class ImgDetectionExtended(dai.Buffer):
         new_obj.confidence = copy.deepcopy(self.confidence)
         new_obj.label = copy.deepcopy(self.label)
         new_obj.label_name = copy.deepcopy(self.label_name)
-        new_obj.keypoints = copy.deepcopy(self.keypoints)
+        new_kpts = Keypoints()
+        new_kpts.keypoints = copy.deepcopy(self.keypoints)
+        new_kpts.edges = copy.deepcopy(self._keypoints.edges)
+        new_obj.keypoints = new_kpts
         return new_obj
 
     @property

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -19,8 +19,8 @@ class Keypoint(dai.Buffer):
         Z coordinate of the keypoint.
     confidence: Optional[float]
         Confidence of the keypoint.
-    label: Optional[str]
-        Label of the keypoint.
+    label_name: Optional[str]
+        Label name of the keypoint.
     """
 
     def __init__(self):
@@ -30,7 +30,7 @@ class Keypoint(dai.Buffer):
         self._y: float = None
         self._z: float = 0.0
         self._confidence: float = -1.0
-        self._label: str = None
+        self._label_name: str = None
         self._logger = get_logger(__name__)
 
     @property
@@ -136,24 +136,24 @@ class Keypoint(dai.Buffer):
         self._confidence = value
 
     @property
-    def label(self) -> str:
-        """Returns the label of the keypoint.
+    def label_name(self) -> str:
+        """Returns the label name of the keypoint.
 
-        @return: Label of the keypoint.
+        @return: Label name of the keypoint.
         @rtype: str
         """
-        return self._label
+        return self._label_name
 
-    @label.setter
-    def label(self, value: str):
-        """Sets the label of the keypoint.
+    @label_name.setter
+    def label_name(self, value: str):
+        """Sets the label name of the keypoint.
 
-        @param value: Label of the keypoint.
+        @param value: Label name of the keypoint.
         @type value: str
         """
         if not isinstance(value, str):
-            raise TypeError("label must be a string.")
-        self._label = value
+            raise TypeError("label_name must be a string.")
+        self._label_name = value
 
 
 class Keypoints(dai.Buffer):
@@ -163,6 +163,8 @@ class Keypoints(dai.Buffer):
     ----------
     keypoints: List[Keypoint]
         List of Keypoint objects, each representing a keypoint.
+    edges: List[Tuple[int, int]]
+        List of edges, each representing a connection between two keypoints.
     transformation : dai.ImgTransformation
         Image transformation object.
     """

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -164,7 +164,7 @@ class Keypoints(dai.Buffer):
     keypoints: List[Keypoint]
         List of Keypoint objects, each representing a keypoint.
     edges: List[Tuple[int, int]]
-        List of edges, each representing a connection between two keypoints.
+        List of edges, each representing a connection between two keypoints. NOTE: If you create a Keypoints message with a `create_keypoints_message` function, the edges will be filtered to only include the edges between the keypoints that are present in the filtered keypoints. This is done to ensure that the edges are only drawn between the keypoints that are present in the filtered keypoints. You can always access the full set of edges in the model's NN archive.
     transformation : dai.ImgTransformation
         Image transformation object.
     """

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 import depthai as dai
 
@@ -19,6 +19,8 @@ class Keypoint(dai.Buffer):
         Z coordinate of the keypoint.
     confidence: Optional[float]
         Confidence of the keypoint.
+    label: Optional[str]
+        Label of the keypoint.
     """
 
     def __init__(self):
@@ -28,6 +30,7 @@ class Keypoint(dai.Buffer):
         self._y: float = None
         self._z: float = 0.0
         self._confidence: float = -1.0
+        self._label: str = None
         self._logger = get_logger(__name__)
 
     @property
@@ -132,6 +135,26 @@ class Keypoint(dai.Buffer):
             self._logger.info("Confidence value was clipped to [0, 1].")
         self._confidence = value
 
+    @property
+    def label(self) -> str:
+        """Returns the label of the keypoint.
+
+        @return: Label of the keypoint.
+        @rtype: str
+        """
+        return self._label
+
+    @label.setter
+    def label(self, value: str):
+        """Sets the label of the keypoint.
+
+        @param value: Label of the keypoint.
+        @type value: str
+        """
+        if not isinstance(value, str):
+            raise TypeError("label must be a string.")
+        self._label = value
+
 
 class Keypoints(dai.Buffer):
     """Keypoints class for storing keypoints.
@@ -148,6 +171,7 @@ class Keypoints(dai.Buffer):
         """Initializes the Keypoints object."""
         super().__init__()
         self._keypoints: List[Keypoint] = []
+        self._edges: List[Tuple[int, int]] = []
         self._transformation: dai.ImgTransformation = None
 
     @property
@@ -173,6 +197,35 @@ class Keypoints(dai.Buffer):
         if not all(isinstance(item, Keypoint) for item in value):
             raise ValueError("keypoints must be a list of Keypoint objects.")
         self._keypoints = value
+
+    @property
+    def edges(self) -> List[Tuple[int, int]]:
+        """Returns the edges.
+
+        @return: List of edges.
+        @rtype: List[Tuple[int, int]]
+        """
+        return self._edges
+
+    @edges.setter
+    def edges(self, value: List[Tuple[int, int]]):
+        """Sets the edges.
+
+        @param value: List of edges.
+        @type value: List[Tuple[int, int]]
+        @raise TypeError: If value is not a list.
+        @raise TypeError: If each each element is not of type Tuple[int, int].
+        """
+        if not isinstance(value, list):
+            raise TypeError("edges must be a list.")
+        if not all(
+            (isinstance(item, tuple) or isinstance(item, list))
+            and len(item) == 2
+            and all(isinstance(i, int) for i in item)
+            for item in value
+        ):
+            raise TypeError("edges must be a list of tuples or lists of integers.")
+        self._edges = value
 
     @property
     def transformation(self) -> dai.ImgTransformation:
@@ -235,6 +288,20 @@ class Keypoints(dai.Buffer):
         pointsAnnotation.fillColor = KEYPOINT_COLOR
         pointsAnnotation.thickness = 2
         annotation.points.append(pointsAnnotation)
+
+        for edge in self.edges:
+            pt1_ix, pt2_ix = edge
+            pt1 = self.keypoints[pt1_ix]
+            pt2 = self.keypoints[pt2_ix]
+            pointsAnnotation = dai.PointsAnnotation()
+            pointsAnnotation.type = dai.PointsAnnotationType.LINE_STRIP
+            pointsAnnotation.points = dai.VectorPoint2f(
+                [dai.Point2f(pt1.x, pt1.y), dai.Point2f(pt2.x, pt2.y)]
+            )
+            pointsAnnotation.outlineColor = KEYPOINT_COLOR
+            pointsAnnotation.fillColor = KEYPOINT_COLOR
+            pointsAnnotation.thickness = 1
+            annotation.points.append(pointsAnnotation)
 
         img_annotations.annotations.append(annotation)
         img_annotations.setTimestamp(self.getTimestamp())

--- a/depthai_nodes/node/parsers/hrnet.py
+++ b/depthai_nodes/node/parsers/hrnet.py
@@ -16,6 +16,12 @@ class HRNetParser(KeypointParser):
         Name of the output layer relevant to the parser.
     score_threshold : float
         Confidence score threshold for detected keypoints.
+    label_names: Optional[List[str]]
+        Label names for the keypoints.
+    edges: Optional[List[Tuple[int, int]]]
+        Keypoint connection pairs for visualizing the skeleton. Example:
+            [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
+            1, keypoint 1 is connected to keypoint 2, etc.
 
     Output Message/s
     ----------------
@@ -28,7 +34,7 @@ class HRNetParser(KeypointParser):
         self,
         output_layer_name: str = "",
         score_threshold: float = 0.5,
-        labels: Optional[List[str]] = None,
+        label_names: Optional[List[str]] = None,
         edges: Optional[List[Tuple[int, int]]] = None,
     ) -> None:
         """Initializes the parser node.
@@ -37,8 +43,8 @@ class HRNetParser(KeypointParser):
         @type output_layer_name: str
         @param score_threshold: Confidence score threshold for detected keypoints.
         @type score_threshold: float
-        @param labels: Labels for the keypoints.
-        @type labels: Optional[List[str]]
+        @param label_names: Label names for the keypoints.
+        @type label_names: Optional[List[str]]
         @param edges: Keypoint connection pairs for visualizing the skeleton. Example:
             [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
             1, keypoint 1 is connected to keypoint 2, etc.
@@ -47,7 +53,7 @@ class HRNetParser(KeypointParser):
         super().__init__(
             output_layer_name,
             score_threshold=score_threshold,
-            labels=labels,
+            label_names=label_names,
             edges=edges,
         )
 
@@ -127,7 +133,7 @@ class HRNetParser(KeypointParser):
                 scores=scores,
                 confidence_threshold=self.score_threshold,
                 edges=self.edges,
-                labels=self.labels,
+                label_names=self.label_names,
             )
             keypoints_message.setTimestamp(output.getTimestamp())
             keypoints_message.setTransformation(output.getTransformation())

--- a/depthai_nodes/node/parsers/hrnet.py
+++ b/depthai_nodes/node/parsers/hrnet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import depthai as dai
 import numpy as np
@@ -29,7 +29,7 @@ class HRNetParser(KeypointParser):
         output_layer_name: str = "",
         score_threshold: float = 0.5,
         labels: Optional[List[str]] = None,
-        edges: Optional[List[List[int]]] = None,
+        edges: Optional[List[Tuple[int, int]]] = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -39,8 +39,10 @@ class HRNetParser(KeypointParser):
         @type score_threshold: float
         @param labels: Labels for the keypoints.
         @type labels: Optional[List[str]]
-        @param edges: Keypoint connection pairs for visualizing the skeleton.
-        @type edges: Optional[List[List[int]]]
+        @param edges: Keypoint connection pairs for visualizing the skeleton. Example:
+            [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
+            1, keypoint 1 is connected to keypoint 2, etc.
+        @type edges: Optional[List[Tuple[int, int]]]
         """
         super().__init__(
             output_layer_name,

--- a/depthai_nodes/node/parsers/hrnet.py
+++ b/depthai_nodes/node/parsers/hrnet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import depthai as dai
 import numpy as np
@@ -25,7 +25,11 @@ class HRNetParser(KeypointParser):
     """
 
     def __init__(
-        self, output_layer_name: str = "", score_threshold: float = 0.5
+        self,
+        output_layer_name: str = "",
+        score_threshold: float = 0.5,
+        labels: Optional[List[str]] = None,
+        edges: Optional[List[List[int]]] = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -33,8 +37,17 @@ class HRNetParser(KeypointParser):
         @type output_layer_name: str
         @param score_threshold: Confidence score threshold for detected keypoints.
         @type score_threshold: float
+        @param labels: Labels for the keypoints.
+        @type labels: Optional[List[str]]
+        @param edges: Keypoint connection pairs for visualizing the skeleton.
+        @type edges: Optional[List[List[int]]]
         """
-        super().__init__(output_layer_name, score_threshold=score_threshold)
+        super().__init__(
+            output_layer_name,
+            score_threshold=score_threshold,
+            labels=labels,
+            edges=edges,
+        )
 
     def setOutputLayerName(self, output_layer_name: str) -> None:
         """Sets the name of the output layer.
@@ -111,6 +124,8 @@ class HRNetParser(KeypointParser):
                 keypoints=keypoints,
                 scores=scores,
                 confidence_threshold=self.score_threshold,
+                edges=self.edges,
+                labels=self.labels,
             )
             keypoints_message.setTimestamp(output.getTimestamp())
             keypoints_message.setTransformation(output.getTransformation())

--- a/depthai_nodes/node/parsers/keypoints.py
+++ b/depthai_nodes/node/parsers/keypoints.py
@@ -22,8 +22,8 @@ class KeypointParser(BaseParser):
         Number of keypoints the model detects.
     score_threshold : float
         Confidence score threshold for detected keypoints.
-    labels : List[str]
-        Labels for the keypoints.
+    label_names : List[str]
+        Label names for the keypoints.
     edges : List[Tuple[int, int]]
         Keypoint connection pairs for visualizing the skeleton. Example: [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is connected to keypoint 2, etc.
 
@@ -48,7 +48,7 @@ class KeypointParser(BaseParser):
         scale_factor: float = 1.0,
         n_keypoints: int = None,
         score_threshold: float = None,
-        labels: Optional[List[str]] = None,
+        label_names: Optional[List[str]] = None,
         edges: Optional[List[List[int]]] = None,
     ) -> None:
         """Initializes the parser node.
@@ -59,8 +59,8 @@ class KeypointParser(BaseParser):
         @type scale_factor: float
         @param n_keypoints: Number of keypoints.
         @type n_keypoints: int
-        @param labels: Labels for the keypoints.
-        @type labels: Optional[List[str]]
+        @param label_names: Label names for the keypoints.
+        @type label_names: Optional[List[str]]
         @param edges: Keypoint connection pairs for visualizing the skeleton. Example:
             [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
             1, keypoint 1 is connected to keypoint 2, etc.
@@ -71,7 +71,7 @@ class KeypointParser(BaseParser):
         self.scale_factor = scale_factor
         self.n_keypoints = n_keypoints
         self.score_threshold = score_threshold
-        self.labels = labels
+        self.label_names = label_names
         self.edges = edges
 
     def setOutputLayerName(self, output_layer_name: str) -> None:
@@ -126,17 +126,17 @@ class KeypointParser(BaseParser):
 
         self.score_threshold = threshold
 
-    def setLabels(self, labels: List[str]) -> None:
-        """Sets the labels for the keypoints.
+    def setLabelNames(self, label_names: List[str]) -> None:
+        """Sets the label names for the keypoints.
 
-        @param labels: List of labels for the keypoints.
-        @type labels: List[str]
+        @param label_names: List of label names for the keypoints.
+        @type label_names: List[str]
         """
-        if not isinstance(labels, list):
-            raise ValueError("Labels must be a list.")
-        if not all(isinstance(label, str) for label in labels):
-            raise ValueError("Labels must be a list of strings.")
-        self.labels = labels
+        if not isinstance(label_names, list):
+            raise ValueError("Label names must be a list.")
+        if not all(isinstance(label, str) for label in label_names):
+            raise ValueError("Label names must be a list of strings.")
+        self.label_names = label_names
 
     def setEdges(self, edges: List[Tuple[int, int]]) -> None:
         """Sets the edges for the keypoints.
@@ -178,7 +178,7 @@ class KeypointParser(BaseParser):
         self.scale_factor = head_config.get("scale_factor", self.scale_factor)
         self.n_keypoints = head_config.get("n_keypoints", self.n_keypoints)
         self.score_threshold = head_config.get("score_threshold", self.score_threshold)
-        self.labels = head_config.get("keypoint_labels", self.labels)
+        self.label_names = head_config.get("keypoint_labels", self.label_names)
         keypoint_edges = head_config.get("skeleton_edges", self.edges)
         if keypoint_edges:
             self.edges = [tuple(edge) for edge in keypoint_edges]
@@ -220,7 +220,7 @@ class KeypointParser(BaseParser):
             keypoints = np.clip(keypoints, 0, 1)
 
             msg = create_keypoints_message(
-                keypoints, edges=self.edges, labels=self.labels
+                keypoints, edges=self.edges, label_names=self.label_names
             )
             msg.setTimestamp(output.getTimestamp())
             msg.setTransformation(output.getTransformation())

--- a/depthai_nodes/node/parsers/keypoints.py
+++ b/depthai_nodes/node/parsers/keypoints.py
@@ -179,9 +179,9 @@ class KeypointParser(BaseParser):
         self.n_keypoints = head_config.get("n_keypoints", self.n_keypoints)
         self.score_threshold = head_config.get("score_threshold", self.score_threshold)
         self.labels = head_config.get("keypoint_labels", self.labels)
-        self.edges = [
-            tuple(edge) for edge in head_config.get("skeleton_edges", self.edges)
-        ]
+        keypoint_edges = head_config.get("skeleton_edges", self.edges)
+        if keypoint_edges:
+            self.edges = [tuple(edge) for edge in keypoint_edges]
 
         return self
 

--- a/depthai_nodes/node/parsers/superanimal_landmarker.py
+++ b/depthai_nodes/node/parsers/superanimal_landmarker.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import depthai as dai
 import numpy as np
@@ -23,8 +23,8 @@ class SuperAnimalParser(KeypointParser):
         Confidence score threshold for detected keypoints.
     labels : List[str]
         Labels for the keypoints.
-    edges : List[List[int]]
-        Keypoint connection pairs for visualizing the skeleton.
+    edges : List[Tuple[int, int]]
+        Keypoint connection pairs for visualizing the skeleton. Example: [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is connected to keypoint 2, etc.
 
     Output Message/s
     ----------------
@@ -40,7 +40,7 @@ class SuperAnimalParser(KeypointParser):
         n_keypoints: int = 39,
         score_threshold: float = 0.5,
         labels: Optional[List[str]] = None,
-        edges: Optional[List[List[int]]] = None,
+        edges: Optional[List[Tuple[int, int]]] = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -52,6 +52,12 @@ class SuperAnimalParser(KeypointParser):
         @type score_threshold: float
         @param scale_factor: Scale factor to divide the keypoints by.
         @type scale_factor: float
+        @param labels: Labels for the keypoints.
+        @type labels: Optional[List[str]]
+        @param edges: Keypoint connection pairs for visualizing the skeleton. Example:
+            [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
+            1, keypoint 1 is connected to keypoint 2, etc.
+        @type edges: Optional[List[Tuple[int, int]]]
         """
         super().__init__(
             output_layer_name,

--- a/depthai_nodes/node/parsers/superanimal_landmarker.py
+++ b/depthai_nodes/node/parsers/superanimal_landmarker.py
@@ -21,8 +21,8 @@ class SuperAnimalParser(KeypointParser):
         Number of keypoints.
     score_threshold : float
         Confidence score threshold for detected keypoints.
-    labels : List[str]
-        Labels for the keypoints.
+    label_names : List[str]
+        Label names for the keypoints.
     edges : List[Tuple[int, int]]
         Keypoint connection pairs for visualizing the skeleton. Example: [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is connected to keypoint 2, etc.
 
@@ -39,7 +39,7 @@ class SuperAnimalParser(KeypointParser):
         scale_factor: float = 256.0,
         n_keypoints: int = 39,
         score_threshold: float = 0.5,
-        labels: Optional[List[str]] = None,
+        label_names: Optional[List[str]] = None,
         edges: Optional[List[Tuple[int, int]]] = None,
     ) -> None:
         """Initializes the parser node.
@@ -52,8 +52,8 @@ class SuperAnimalParser(KeypointParser):
         @type score_threshold: float
         @param scale_factor: Scale factor to divide the keypoints by.
         @type scale_factor: float
-        @param labels: Labels for the keypoints.
-        @type labels: Optional[List[str]]
+        @param label_names: Label names for the keypoints.
+        @type label_names: Optional[List[str]]
         @param edges: Keypoint connection pairs for visualizing the skeleton. Example:
             [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
             1, keypoint 1 is connected to keypoint 2, etc.
@@ -64,7 +64,7 @@ class SuperAnimalParser(KeypointParser):
             scale_factor=scale_factor,
             n_keypoints=n_keypoints,
             score_threshold=score_threshold,
-            labels=labels,
+            label_names=label_names,
             edges=edges,
         )
 
@@ -115,7 +115,7 @@ class SuperAnimalParser(KeypointParser):
                 keypoints,
                 scores,
                 self.score_threshold,
-                labels=self.labels,
+                label_names=self.label_names,
                 edges=self.edges,
             )
             msg.setTimestamp(output.getTimestamp())

--- a/depthai_nodes/node/parsers/superanimal_landmarker.py
+++ b/depthai_nodes/node/parsers/superanimal_landmarker.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
 import depthai as dai
 import numpy as np
@@ -21,6 +21,10 @@ class SuperAnimalParser(KeypointParser):
         Number of keypoints.
     score_threshold : float
         Confidence score threshold for detected keypoints.
+    labels : List[str]
+        Labels for the keypoints.
+    edges : List[List[int]]
+        Keypoint connection pairs for visualizing the skeleton.
 
     Output Message/s
     ----------------
@@ -35,6 +39,8 @@ class SuperAnimalParser(KeypointParser):
         scale_factor: float = 256.0,
         n_keypoints: int = 39,
         score_threshold: float = 0.5,
+        labels: Optional[List[str]] = None,
+        edges: Optional[List[List[int]]] = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -52,6 +58,8 @@ class SuperAnimalParser(KeypointParser):
             scale_factor=scale_factor,
             n_keypoints=n_keypoints,
             score_threshold=score_threshold,
+            labels=labels,
+            edges=edges,
         )
 
     def build(
@@ -97,7 +105,13 @@ class SuperAnimalParser(KeypointParser):
             scores = keypoints[:, 2]
             keypoints = keypoints[:, :2] / self.scale_factor
 
-            msg = create_keypoints_message(keypoints, scores, self.score_threshold)
+            msg = create_keypoints_message(
+                keypoints,
+                scores,
+                self.score_threshold,
+                labels=self.labels,
+                edges=self.edges,
+            )
             msg.setTimestamp(output.getTimestamp())
             msg.setTransformation(output.getTransformation())
             msg.setSequenceNum(output.getSequenceNum())

--- a/depthai_nodes/node/parsers/yolo.py
+++ b/depthai_nodes/node/parsers/yolo.py
@@ -314,10 +314,9 @@ class YOLOExtendedParser(BaseParser):
         self.keypoint_label_names = head_config.get(
             "keypoint_label_names", self.keypoint_label_names
         )
-        self.keypoint_edges = [
-            tuple(edge)
-            for edge in head_config.get("skeleton_edges", self.keypoint_edges)
-        ]
+        keypoint_edges = head_config.get("skeleton_edges", self.keypoint_edges)
+        if keypoint_edges:
+            self.keypoint_edges = [tuple(edge) for edge in keypoint_edges]
         try:
             self.subtype = YOLOSubtype(subtype.lower())
         except ValueError as err:

--- a/tests/unittests/test_messages/test_img_detections_msg.py
+++ b/tests/unittests/test_messages/test_img_detections_msg.py
@@ -6,6 +6,7 @@ from depthai_nodes import (
     ImgDetectionExtended,
     ImgDetectionsExtended,
     Keypoint,
+    Keypoints,
 )
 
 
@@ -25,7 +26,6 @@ def test_img_detection_extended_initialization(
     assert img_detection_extended.confidence == -1.0
     assert img_detection_extended.label == -1
     assert img_detection_extended.label_name == ""
-    assert img_detection_extended.keypoints == []
 
 
 def test_img_detection_extended_set_rotated_rect(
@@ -83,16 +83,15 @@ def test_img_detection_extended_set_keypoints(
     kp2.y = 0.4
     keypoints.append(kp1)
     keypoints.append(kp2)
-    img_detection_extended.keypoints = keypoints
+    kpts = Keypoints()
+    kpts.keypoints = keypoints
+    img_detection_extended.keypoints = kpts
     for i, kp in enumerate(img_detection_extended.keypoints):
         assert kp.x == keypoints[i].x
         assert kp.y == keypoints[i].y
 
-    with pytest.raises(ValueError):
-        img_detection_extended.keypoints = "not a list"
-
-    with pytest.raises(ValueError):
-        img_detection_extended.keypoints = [Keypoint(), "not a Keypoint"]
+    with pytest.raises(TypeError):
+        img_detection_extended.keypoints = "not a Keypoints object"
 
 
 def test_img_detections_extended_initialization(


### PR DESCRIPTION
## Purpose
`Keypoints` message does not contain information about skeleton edges (connection pairs between kpts to draw a skeleton). Its useful when visualizing default message.

## Specification
We modify `Keypoints` and `ImgDetectionExtedend` messages. `Keypoints` now also have `labels` (optional name of keypoints) and `edges` (connection pairs). `ImgDetectionExtended` now has `_keypoints` attribute as `Keypoints` object (and not `List[Keypoint]` anymore), so setter accepts `Keypoints` object and getter returns `List[Keypoint]`. `Keypoint` object is needed because we need to access the skeleton information inside visualization method.

## Dependencies & Potential Impact
I changed the NN archives, so they all have field `skeleton_edges` (only relevant models - Objectron, HRNet, etc.).

## Deployment Plan
None / not applicable

## Testing & Validation
Tested with generic example and models: Objectron, YOLOv8 Pose, HRNet, SuperAnimal, Hand Landmarker.