### PR TITLE
Feat: Host Parsing Neural Network

### DIFF
--- a/depthai_nodes/node/__init__.py
+++ b/depthai_nodes/node/__init__.py
@@ -1,5 +1,6 @@
 from .apply_colormap import ApplyColormap
 from .depth_merger import DepthMerger
+from .host_parsing_neural_network import HostParsingNeuralNetwork
 from .host_spatials_calc import HostSpatialsCalc
 from .img_detections_bridge import ImgDetectionsBridge
 from .img_detections_filter import ImgDetectionsFilter
@@ -37,6 +38,7 @@ __all__ = [
     "TilesPatcher",
     "ParserGenerator",
     "ParsingNeuralNetwork",
+    "HostParsingNeuralNetwork",
     "HostSpatialsCalc",
     "ImageOutputParser",
     "YuNetParser",

--- a/depthai_nodes/node/host_parsing_neural_network.py
+++ b/depthai_nodes/node/host_parsing_neural_network.py
@@ -1,0 +1,6 @@
+from depthai_nodes.node import ParsingNeuralNetwork
+
+
+class HostParsingNeuralNetwork(ParsingNeuralNetwork):
+    def _generateParsers(self, parserGenerator, nnArchive):
+        return parserGenerator.build(nnArchive, host_only=True)

--- a/depthai_nodes/node/host_parsing_neural_network.py
+++ b/depthai_nodes/node/host_parsing_neural_network.py
@@ -1,4 +1,4 @@
-from depthai_nodes.node import ParsingNeuralNetwork
+from depthai_nodes.node.parsing_neural_network import ParsingNeuralNetwork
 
 
 class HostParsingNeuralNetwork(ParsingNeuralNetwork):

--- a/depthai_nodes/node/parsing_neural_network.py
+++ b/depthai_nodes/node/parsing_neural_network.py
@@ -274,13 +274,18 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
 
     def _getParserNodes(self, nnArchive: dai.NNArchive) -> Dict[int, BaseParser]:
         parser_generator = self._pipeline.create(ParserGenerator)
-        parsers = parser_generator.build(nnArchive)
+        parsers = self._generateParsers(parser_generator, nnArchive)
         for parser in parsers.values():
             self._nn.out.link(
                 parser.input
             )  # TODO: once NN node has output dictionary, link to the correct output
         self._pipeline.remove(parser_generator)
         return parsers
+
+    def _generateParsers(
+        self, parserGenerator: ParserGenerator, nnArchive: dai.NNArchive
+    ) -> Dict[int, BaseParser]:
+        return parserGenerator.build(nnArchive)
 
     def _getModelHeadsLen(self):
         heads = self._getModelHeads()

--- a/depthai_nodes/node/parsing_neural_network.py
+++ b/depthai_nodes/node/parsing_neural_network.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Type, TypeVar, Union, overload
 
 import depthai as dai
 
-from depthai_nodes.node import ParserGenerator
+from depthai_nodes.node.parser_generator import ParserGenerator
 from depthai_nodes.node.parsers import BaseParser
 
 TParser = TypeVar("TParser", bound=Union[BaseParser, dai.DeviceNode])

--- a/tests/unittests/test_nodes/test_threaded_host_nodes/test_host_parsing_neural_network_node.py
+++ b/tests/unittests/test_nodes/test_threaded_host_nodes/test_host_parsing_neural_network_node.py
@@ -1,0 +1,33 @@
+import depthai as dai
+import pytest
+from stability_tests.conftest import Input, NeuralNetworkMock, PipelineMock
+
+from depthai_nodes.node import HostParsingNeuralNetwork, YOLOExtendedParser
+
+
+@pytest.fixture
+def pipeline():
+    dai.node.NeuralNetwork = NeuralNetworkMock
+    return PipelineMock()
+
+
+def test_yolo(pipeline: PipelineMock):
+    nn_archive = dai.NNArchive(
+        dai.getModelFromZoo(dai.NNModelDescription("luxonis/yolov6-nano", "RVC2"))
+    )
+    nn = pipeline.create(HostParsingNeuralNetwork).build(
+        input=Input(), nn_source=nn_archive, fps=30
+    )
+    parser = nn.getParser()
+    assert isinstance(parser, YOLOExtendedParser)
+
+
+def test_unsupported(pipeline: PipelineMock):
+    nn_archive = dai.NNArchive(
+        dai.getModelFromZoo(
+            dai.NNModelDescription("luxonis/mobilenet-ssd:300x300", "RVC2")
+        )
+    )
+    nn = pipeline.create(HostParsingNeuralNetwork)
+    with pytest.raises(ValueError):
+        nn.build(input=Input(), nn_source=nn_archive, fps=30)


### PR DESCRIPTION
## Purpose
Have alternative to `ParsingNeuralNetwork` that uses no device nodes parsers (e.g. `dai.node.DetectionParser`) and restricts only to host node parsers (e.g. `YOLOExtendedParser`). Main advantages of host node parsers is possibility to configure them at runtime, which is not possible for parsers running on device.

## Specification
`ParserGenerator` is changed such that `build` method accepts `host_only` flag. `ParsingNeuralNetwork` is changed to have the parser generation easily changed by inheritance. The `HostParsingNeuralNetwork` class is added.

## Dependencies & Potential Impact
No breaking changes.

## Deployment Plan
None / not applicable

## Testing & Validation
Tests for the node added and passing. More tests added and passing for `ParsingGenerator`, covering the new `host_only` flag functionality.