### PR TITLE
Feat: Add BaseHostNode

### DIFF
--- a/depthai_nodes/node/__init__.py
+++ b/depthai_nodes/node/__init__.py
@@ -5,6 +5,7 @@ from .host_spatials_calc import HostSpatialsCalc
 from .img_detections_bridge import ImgDetectionsBridge
 from .img_detections_filter import ImgDetectionsFilter
 from .img_frame_overlay import ImgFrameOverlay
+from .img_frame_sender import ImgFrameSender
 from .parser_generator import ParserGenerator
 from .parsers.base_parser import BaseParser
 from .parsers.classification import ClassificationParser
@@ -65,4 +66,5 @@ __all__ = [
     "ImgFrameOverlay",
     "ImgDetectionsBridge",
     "ImgDetectionsFilter",
+    "ImgFrameSender",
 ]

--- a/depthai_nodes/node/__init__.py
+++ b/depthai_nodes/node/__init__.py
@@ -1,11 +1,11 @@
 from .apply_colormap import ApplyColormap
+from .base_host_node import BaseHostNode
 from .depth_merger import DepthMerger
 from .host_parsing_neural_network import HostParsingNeuralNetwork
 from .host_spatials_calc import HostSpatialsCalc
 from .img_detections_bridge import ImgDetectionsBridge
 from .img_detections_filter import ImgDetectionsFilter
 from .img_frame_overlay import ImgFrameOverlay
-from .img_frame_sender import ImgFrameSender
 from .parser_generator import ParserGenerator
 from .parsers.base_parser import BaseParser
 from .parsers.classification import ClassificationParser
@@ -66,5 +66,5 @@ __all__ = [
     "ImgFrameOverlay",
     "ImgDetectionsBridge",
     "ImgDetectionsFilter",
-    "ImgFrameSender",
+    "BaseHostNode",
 ]

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -6,7 +6,7 @@ from depthai_nodes.message import ImgDetectionsExtended, Map2D, SegmentationMask
 from depthai_nodes.message.utils import copy_message
 
 
-class ApplyColormap(dai.node.HostNode):
+class ApplyColormap(ImgFrameSender):
     """A host node that applies a colormap to a given 2D array (e.g. depth maps,
     segmentation masks, heatmaps, etc.).
 
@@ -37,10 +37,6 @@ class ApplyColormap(dai.node.HostNode):
         self.setColormap(colormap_value)
         self.setMaxValue(max_value)
         self.setInstanceToSemanticMask(instance_to_semantic_mask)
-
-        self._platform = (
-            self.getParentPipeline().getDefaultDevice().getPlatformAsString()
-        )
 
     def setColormap(self, colormap_value: int) -> None:
         """Sets the applied color mapping.
@@ -138,11 +134,7 @@ class ApplyColormap(dai.node.HostNode):
         frame = dai.ImgFrame()
         frame.setCvFrame(
             color_arr,
-            (
-                dai.ImgFrame.Type.BGR888i
-                if self._platform == "RVC4"
-                else dai.ImgFrame.Type.BGR888p
-            ),
+            self._img_frame_type,
         )
         frame.setTimestamp(msg.getTimestamp())
         frame.setSequenceNum(msg.getSequenceNum())

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -3,9 +3,8 @@ import depthai as dai
 import numpy as np
 
 from depthai_nodes.message import ImgDetectionsExtended, Map2D, SegmentationMask
+from depthai_nodes.message.utils import copy_message
 from depthai_nodes.node.base_host_node import BaseHostNode
-
-from .utils import copy_message
 
 
 class ApplyColormap(BaseHostNode):

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -3,10 +3,12 @@ import depthai as dai
 import numpy as np
 
 from depthai_nodes.message import ImgDetectionsExtended, Map2D, SegmentationMask
-from depthai_nodes.message.utils import copy_message
+from depthai_nodes.node.base_host_node import BaseHostNode
+
+from .utils import copy_message
 
 
-class ApplyColormap(ImgFrameSender):
+class ApplyColormap(BaseHostNode):
     """A host node that applies a colormap to a given 2D array (e.g. depth maps,
     segmentation masks, heatmaps, etc.).
 

--- a/depthai_nodes/node/base_host_node.py
+++ b/depthai_nodes/node/base_host_node.py
@@ -9,8 +9,8 @@ class CombinedMeta(ABCMeta, HostNodeMeta):
     pass
 
 
-class ImgFrameSender(dai.node.HostNode, metaclass=CombinedMeta):
-    """An abstract base class for host nodes that send out dai.ImgFrame objects.
+class BaseHostNode(dai.node.HostNode, metaclass=CombinedMeta):
+    """An abstract base class for host nodes.
 
     Designed to encapsulate and abstract the configuration of platform-specific
     attributes, providing a clean and consistent interface for derived classes.

--- a/depthai_nodes/node/depth_merger.py
+++ b/depthai_nodes/node/depth_merger.py
@@ -3,11 +3,12 @@ from typing import Union
 import depthai as dai
 
 from depthai_nodes import ImgDetectionExtended, ImgDetectionsExtended
+from depthai_nodes.node.base_host_node import BaseHostNode
 
 from .host_spatials_calc import HostSpatialsCalc
 
 
-class DepthMerger(dai.node.HostNode):
+class DepthMerger(BaseHostNode):
     """DepthMerger is a custom host node for merging 2D detections with depth
     information to produce spatial detections.
 

--- a/depthai_nodes/node/img_detections_bridge.py
+++ b/depthai_nodes/node/img_detections_bridge.py
@@ -2,9 +2,10 @@ import depthai as dai
 
 from depthai_nodes import ImgDetectionExtended, ImgDetectionsExtended
 from depthai_nodes.logging import get_logger
+from depthai_nodes.node.base_host_node import BaseHostNode
 
 
-class ImgDetectionsBridge(dai.node.HostNode):
+class ImgDetectionsBridge(BaseHostNode):
     """Transforms the dai.ImgDetections to ImgDetectionsExtended object or vice versa.
     Note that conversion from ImgDetectionsExtended to ImgDetection loses information
     about segmentation, keypoints and rotation.

--- a/depthai_nodes/node/img_detections_filter.py
+++ b/depthai_nodes/node/img_detections_filter.py
@@ -3,10 +3,11 @@ from typing import List
 import depthai as dai
 
 from depthai_nodes import ImgDetectionsExtended
-from depthai_nodes.message.utils import copy_message
+from depthai_nodes.node.base_host_node import BaseHostNode
+from depthai_nodes.node.utils import copy_message
 
 
-class ImgDetectionsFilter(dai.node.HostNode):
+class ImgDetectionsFilter(BaseHostNode):
     """Filters out detections based on the specified criteria and outputs them as a separate message.
     The order of operations:
         1. Filter by label/confidence;

--- a/depthai_nodes/node/img_detections_filter.py
+++ b/depthai_nodes/node/img_detections_filter.py
@@ -3,8 +3,8 @@ from typing import List
 import depthai as dai
 
 from depthai_nodes import ImgDetectionsExtended
+from depthai_nodes.message.utils import copy_message
 from depthai_nodes.node.base_host_node import BaseHostNode
-from depthai_nodes.node.utils import copy_message
 
 
 class ImgDetectionsFilter(BaseHostNode):

--- a/depthai_nodes/node/img_frame_overlay.py
+++ b/depthai_nodes/node/img_frame_overlay.py
@@ -1,8 +1,10 @@
 import cv2
 import depthai as dai
 
+from .img_frame_sender import ImgFrameSender
 
-class ImgFrameOverlay(dai.node.HostNode):
+
+class ImgFrameOverlay(ImgFrameSender):
     """A host node that receives two dai.ImgFrame objects and overlays them into a
     single one.
 
@@ -22,10 +24,6 @@ class ImgFrameOverlay(dai.node.HostNode):
     def __init__(self, alpha: float = 0.5) -> None:
         super().__init__()
         self.setAlpha(alpha)
-
-        self._platform = (
-            self.getParentPipeline().getDefaultDevice().getPlatformAsString()
-        )
 
     def setAlpha(self, alpha: float) -> None:
         """Sets the alpha.
@@ -92,11 +90,7 @@ class ImgFrameOverlay(dai.node.HostNode):
         overlay = dai.ImgFrame()
         overlay.setCvFrame(
             overlay_frame,
-            (
-                dai.ImgFrame.Type.BGR888i
-                if self._platform == "RVC4"
-                else dai.ImgFrame.Type.BGR888p
-            ),
+            self._img_frame_type,
         )
         overlay.setTimestamp(frame1.getTimestamp())
         overlay.setSequenceNum(frame1.getSequenceNum())

--- a/depthai_nodes/node/img_frame_overlay.py
+++ b/depthai_nodes/node/img_frame_overlay.py
@@ -1,10 +1,10 @@
 import cv2
 import depthai as dai
 
-from .img_frame_sender import ImgFrameSender
+from depthai_nodes.node.base_host_node import BaseHostNode
 
 
-class ImgFrameOverlay(ImgFrameSender):
+class ImgFrameOverlay(BaseHostNode):
     """A host node that receives two dai.ImgFrame objects and overlays them into a
     single one.
 

--- a/depthai_nodes/node/img_frame_sender.py
+++ b/depthai_nodes/node/img_frame_sender.py
@@ -1,0 +1,38 @@
+import depthai as dai
+from abc import ABCMeta
+
+
+HostNodeMeta = type(dai.node.HostNode)  # metaclass of dai.node.HostNode
+
+
+class CombinedMeta(HostNodeMeta, ABCMeta):
+    pass
+
+
+class ImgFrameSender(dai.node.HostNode, metaclass=CombinedMeta):
+    """An abstract base class for host nodes that send out dai.ImgFrame objects. Designed to encapsulate and abstract the configuration of platform-specific attributes,
+    providing a clean and consistent interface for derived classes.
+
+    """
+
+    IMG_FRAME_TYPES = {
+        "RVC2": dai.ImgFrame.Type.BGR888p,
+        "RVC4": dai.ImgFrame.Type.BGR888i,
+    }  # TODO: extend for other platforms?
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self._platform = (
+            self.getParentPipeline().getDefaultDevice().getPlatformAsString()
+        )
+
+        try:
+            self._img_frame_type = self.IMG_FRAME_TYPES[self._platform]
+        except KeyError:
+            raise ValueError(
+                f"No dai.ImgFrame.Type defined for platform {self._platform}."
+            )
+
+    def process(self) -> None:
+        pass

--- a/depthai_nodes/node/img_frame_sender.py
+++ b/depthai_nodes/node/img_frame_sender.py
@@ -5,7 +5,7 @@ import depthai as dai
 HostNodeMeta = type(dai.node.HostNode)  # metaclass of dai.node.HostNode
 
 
-class CombinedMeta(HostNodeMeta, ABCMeta):
+class CombinedMeta(ABCMeta, HostNodeMeta):
     pass
 
 

--- a/depthai_nodes/node/img_frame_sender.py
+++ b/depthai_nodes/node/img_frame_sender.py
@@ -28,10 +28,10 @@ class ImgFrameSender(dai.node.HostNode, metaclass=CombinedMeta):
 
         try:
             self._img_frame_type = self.IMG_FRAME_TYPES[self._platform]
-        except KeyError:
+        except KeyError as e:
             raise ValueError(
                 f"No dai.ImgFrame.Type defined for platform {self._platform}."
-            )
+            ) from e
 
     def process(self) -> None:
         pass

--- a/depthai_nodes/node/img_frame_sender.py
+++ b/depthai_nodes/node/img_frame_sender.py
@@ -1,6 +1,6 @@
-import depthai as dai
 from abc import ABCMeta
 
+import depthai as dai
 
 HostNodeMeta = type(dai.node.HostNode)  # metaclass of dai.node.HostNode
 
@@ -10,9 +10,10 @@ class CombinedMeta(HostNodeMeta, ABCMeta):
 
 
 class ImgFrameSender(dai.node.HostNode, metaclass=CombinedMeta):
-    """An abstract base class for host nodes that send out dai.ImgFrame objects. Designed to encapsulate and abstract the configuration of platform-specific attributes,
-    providing a clean and consistent interface for derived classes.
+    """An abstract base class for host nodes that send out dai.ImgFrame objects.
 
+    Designed to encapsulate and abstract the configuration of platform-specific
+    attributes, providing a clean and consistent interface for derived classes.
     """
 
     IMG_FRAME_TYPES = {

--- a/depthai_nodes/node/img_frame_sender.py
+++ b/depthai_nodes/node/img_frame_sender.py
@@ -17,9 +17,9 @@ class ImgFrameSender(dai.node.HostNode, metaclass=CombinedMeta):
     """
 
     IMG_FRAME_TYPES = {
-        dai.Platform(0): dai.ImgFrame.Type.BGR888p,  # RVC2
-        dai.Platform(2): dai.ImgFrame.Type.BGR888i,  # RVC4
-    }  # TODO: extend for other platforms?
+        dai.Platform.RVC2: dai.ImgFrame.Type.BGR888p,
+        dai.Platform.RVC4: dai.ImgFrame.Type.BGR888i,
+    }
 
     def __init__(self) -> None:
         super().__init__()

--- a/depthai_nodes/node/img_frame_sender.py
+++ b/depthai_nodes/node/img_frame_sender.py
@@ -16,16 +16,14 @@ class ImgFrameSender(dai.node.HostNode, metaclass=CombinedMeta):
     """
 
     IMG_FRAME_TYPES = {
-        "RVC2": dai.ImgFrame.Type.BGR888p,
-        "RVC4": dai.ImgFrame.Type.BGR888i,
+        dai.Platform(0): dai.ImgFrame.Type.BGR888p,  # RVC2
+        dai.Platform(2): dai.ImgFrame.Type.BGR888i,  # RVC4
     }  # TODO: extend for other platforms?
 
     def __init__(self) -> None:
         super().__init__()
 
-        self._platform = (
-            self.getParentPipeline().getDefaultDevice().getPlatformAsString()
-        )
+        self._platform = self.getParentPipeline().getDefaultDevice().getPlatform()
 
         try:
             self._img_frame_type = self.IMG_FRAME_TYPES[self._platform]

--- a/depthai_nodes/node/tiles_patcher.py
+++ b/depthai_nodes/node/tiles_patcher.py
@@ -2,12 +2,13 @@ from typing import List
 
 import depthai as dai
 
+from depthai_nodes.node.base_host_node import BaseHostNode
 from depthai_nodes.node.utils import nms_detections
 
 from .tiling import Tiling
 
 
-class TilesPatcher(dai.node.HostNode):
+class TilesPatcher(BaseHostNode):
     """Handles the processing of tiled frames from neural network (NN) outputs, maps the
     detections from tiles back into the global frame, and sends out the combined
     detections for further processing.

--- a/tests/unittests/test_nodes/test_host_nodes/conftest.py
+++ b/tests/unittests/test_nodes/test_host_nodes/conftest.py
@@ -56,6 +56,9 @@ class Device:
     def getPlatformAsString(self):
         return self._platform.name
 
+    def getPlatform(self):
+        return self._platform
+
 
 class HostNodeMock:
     def __init__(self):


### PR DESCRIPTION
## Purpose
Based on the [comment](https://github.com/luxonis/depthai-nodes/pull/192#discussion_r2021554304) in #192, we are missing an abstract class with platform extraction functionality. Adding it limits code repetition in host nodes and centralizes the control over the `ImgFrame.Type` settings for individual platforms.

## Specification
Adding the `BaseHostNode`, an abstract class with platform extraction functionality, and using it as a parent in all of our host nodes.

## Dependencies & Potential Impact
None

## Deployment Plan
None

## Testing & Validation
Tested by running the `depthai-experiments/neural-networks/generic-example` using the `midas-v2-1:small-256x192` model both on RVC2 and RVC4.