### PR TITLE
Fix: GatherData initialization and AnnotationHelper importing

### DIFF
--- a/depthai_nodes/node/gather_data.py
+++ b/depthai_nodes/node/gather_data.py
@@ -51,6 +51,7 @@ class GatherData(dai.node.ThreadedHostNode, Generic[TReference, TGathered]):
 
     def __init__(self) -> None:
         """Initializes the GatherData node."""
+        super().__init__()
         self._camera_fps: Optional[int] = None
         self._unmatched_data: List[TGathered] = []
         self._data_by_reference_ts: Dict[float, List[TGathered]] = {}

--- a/depthai_nodes/utils/__init__.py
+++ b/depthai_nodes/utils/__init__.py
@@ -1,0 +1,1 @@
+from .annotation_helper import AnnotationHelper


### PR DESCRIPTION
## Purpose
When porting depthai-experiments to use GatherData and AnnotationHelper nodes, I've noticed that GatherData has problems initializing and that AnnotationHelper import is not smooth.

## Specification
Adding:
- `super().__init__()` call to the `GatherData` node initialization,
- `depthai-nodes/utils/`__init__.py` to make the module directly importable.
        
## Dependencies & Potential Impact
None

## Deployment Plan
None

## Testing & Validation
Unittests and a dummy `dai.pipeline`.