### PR TITLE
Default AnnotationHelper colors.

### DIFF
--- a/depthai_nodes/constants.py
+++ b/depthai_nodes/constants.py
@@ -1,6 +1,11 @@
 import depthai as dai
 
-OUTLINE_COLOR = dai.Color(1.0, 0.5, 0.5, 1.0)
-TEXT_COLOR = dai.Color(0.5, 0.5, 1.0, 1.0)
-BACKGROUND_COLOR = dai.Color(1.0, 1.0, 0.5, 1.0)
-KEYPOINT_COLOR = dai.Color(1.0, 0.35, 0.367, 1.0)
+PRIMARY_COLOR = dai.Color(
+    float(78 / 255), float(56 / 255), float(237 / 255), float(1.0)
+)
+TRANSPARENT_PRIMARY_COLOR = dai.Color(
+    float(78 / 255), float(56 / 255), float(237 / 255), float(0.2)
+)
+SECONDARY_COLOR = dai.Color(
+    float(240 / 255), float(240 / 255), float(240 / 255), float(1.0)
+)

--- a/depthai_nodes/constants.py
+++ b/depthai_nodes/constants.py
@@ -1,10 +1,10 @@
 import depthai as dai
 
 PRIMARY_COLOR = dai.Color(
-    float(78 / 255), float(56 / 255), float(237 / 255), float(1.0)
+    float(87 / 255), float(36 / 255), float(232 / 255), float(1.0)
 )
 TRANSPARENT_PRIMARY_COLOR = dai.Color(
-    float(78 / 255), float(56 / 255), float(237 / 255), float(0.2)
+    float(87 / 255), float(36 / 255), float(232 / 255), float(0.2)
 )
 SECONDARY_COLOR = dai.Color(
     float(240 / 255), float(240 / 255), float(240 / 255), float(1.0)

--- a/depthai_nodes/message/classification.py
+++ b/depthai_nodes/message/classification.py
@@ -5,10 +5,7 @@ import depthai as dai
 import numpy as np
 from numpy.typing import NDArray
 
-from depthai_nodes.constants import (
-    BACKGROUND_COLOR,
-    TEXT_COLOR,
-)
+from depthai_nodes import PRIMARY_COLOR, SECONDARY_COLOR
 
 
 class Classifications(dai.Buffer):
@@ -159,14 +156,22 @@ class Classifications(dai.Buffer):
         """
         img_annotations = dai.ImgAnnotations()
         annotation = dai.ImgAnnotation()
+        w, h = self.transformation.getSize()
 
-        for i in range(len(self._scores)):
+        font_size = h / 30
+        x_offset = 2 / w
+        y_offset = 2 / h
+
+        for i in range(5):
             text = dai.TextAnnotation()
-            text.position = dai.Point2f(1.05, 0.1 + i * 0.1)
+            text.position = dai.Point2f(
+                x_offset,
+                y_offset + (font_size / h) + i * (font_size / h),
+                normalized=True,
+            )
             text.text = f"{self._classes[i]} {self._scores[i] * 100:.0f}%"
-            text.fontSize = 15
-            text.textColor = TEXT_COLOR
-            text.backgroundColor = BACKGROUND_COLOR
+            text.fontSize = font_size
+            text.textColor = PRIMARY_COLOR if i == 0 else SECONDARY_COLOR
             annotation.texts.append(text)
 
         img_annotations.annotations.append(annotation)

--- a/depthai_nodes/message/classification.py
+++ b/depthai_nodes/message/classification.py
@@ -162,7 +162,7 @@ class Classifications(dai.Buffer):
         x_offset = 2 / w
         y_offset = 2 / h
 
-        for i in range(5):
+        for i in range(min(5, len(self._classes))):
             text = dai.TextAnnotation()
             text.position = dai.Point2f(
                 x_offset,

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -6,10 +6,9 @@ import numpy as np
 from numpy.typing import NDArray
 
 from depthai_nodes import (
-    BACKGROUND_COLOR,
-    KEYPOINT_COLOR,
-    OUTLINE_COLOR,
-    TEXT_COLOR,
+    PRIMARY_COLOR,
+    SECONDARY_COLOR,
+    TRANSPARENT_PRIMARY_COLOR,
 )
 from depthai_nodes.logging import get_logger
 
@@ -341,16 +340,20 @@ class ImgDetectionsExtended(dai.Buffer):
             pointsAnnotation = dai.PointsAnnotation()
             pointsAnnotation.type = dai.PointsAnnotationType.LINE_LOOP
             pointsAnnotation.points = dai.VectorPoint2f(points)
-            pointsAnnotation.outlineColor = OUTLINE_COLOR
-            pointsAnnotation.thickness = 2.0
+            pointsAnnotation.outlineColor = PRIMARY_COLOR
+            pointsAnnotation.fillColor = TRANSPARENT_PRIMARY_COLOR
+            pointsAnnotation.thickness = 1.0
             annotation.points.append(pointsAnnotation)
 
             text = dai.TextAnnotation()
             text.position = points[0]
+            font_size = h / 30
+            text.position.y += font_size / h
+            text.position.x += 1 / w
+            text.position.y += 1 / h
             text.text = f"{detection.label_name} {int(detection.confidence * 100)}%"
-            text.fontSize = 15
-            text.textColor = TEXT_COLOR
-            text.backgroundColor = BACKGROUND_COLOR
+            text.fontSize = font_size
+            text.textColor = SECONDARY_COLOR
             annotation.texts.append(text)
 
             if len(detection.keypoints) > 0:
@@ -361,8 +364,8 @@ class ImgDetectionsExtended(dai.Buffer):
                 keypointAnnotation = dai.PointsAnnotation()
                 keypointAnnotation.type = dai.PointsAnnotationType.POINTS
                 keypointAnnotation.points = dai.VectorPoint2f(keypoints)
-                keypointAnnotation.outlineColor = KEYPOINT_COLOR
-                keypointAnnotation.fillColor = KEYPOINT_COLOR
+                keypointAnnotation.outlineColor = PRIMARY_COLOR
+                keypointAnnotation.fillColor = PRIMARY_COLOR
                 keypointAnnotation.thickness = 2
                 annotation.points.append(keypointAnnotation)
 
@@ -375,8 +378,8 @@ class ImgDetectionsExtended(dai.Buffer):
                         skeletonAnnotation.points = dai.VectorPoint2f(
                             [dai.Point2f(pt1.x, pt1.y), dai.Point2f(pt2.x, pt2.y)]
                         )
-                        skeletonAnnotation.outlineColor = KEYPOINT_COLOR
-                        skeletonAnnotation.fillColor = KEYPOINT_COLOR
+                        skeletonAnnotation.outlineColor = SECONDARY_COLOR
+                        skeletonAnnotation.fillColor = SECONDARY_COLOR
                         skeletonAnnotation.thickness = 1
                         annotation.points.append(skeletonAnnotation)
 

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -331,9 +331,6 @@ class ImgDetectionsExtended(dai.Buffer):
         transformation = self.transformation
         w, h = transformation.getSize()
 
-        if w == 0 or h == 0:
-            return img_annotations
-
         for detection in self.detections:
             detection: ImgDetectionExtended = detection
             rotated_rect = detection.rotated_rect

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -331,6 +331,9 @@ class ImgDetectionsExtended(dai.Buffer):
         transformation = self.transformation
         w, h = transformation.getSize()
 
+        if w == 0 or h == 0:
+            return img_annotations
+
         for detection in self.detections:
             detection: ImgDetectionExtended = detection
             rotated_rect = detection.rotated_rect

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 import depthai as dai
 
-from depthai_nodes import KEYPOINT_COLOR
+from depthai_nodes import PRIMARY_COLOR, SECONDARY_COLOR
 from depthai_nodes.logging import get_logger
 
 
@@ -317,9 +317,9 @@ class Keypoints(dai.Buffer):
         pointsAnnotation = dai.PointsAnnotation()
         pointsAnnotation.type = dai.PointsAnnotationType.POINTS
         pointsAnnotation.points = self.getPoints2f()
-        pointsAnnotation.outlineColor = KEYPOINT_COLOR
-        pointsAnnotation.fillColor = KEYPOINT_COLOR
-        pointsAnnotation.thickness = 2
+        pointsAnnotation.outlineColor = PRIMARY_COLOR
+        pointsAnnotation.fillColor = PRIMARY_COLOR
+        pointsAnnotation.thickness = 1
         annotation.points.append(pointsAnnotation)
 
         for edge in self.edges:
@@ -331,8 +331,8 @@ class Keypoints(dai.Buffer):
             pointsAnnotation.points = dai.VectorPoint2f(
                 [dai.Point2f(pt1.x, pt1.y), dai.Point2f(pt2.x, pt2.y)]
             )
-            pointsAnnotation.outlineColor = KEYPOINT_COLOR
-            pointsAnnotation.fillColor = KEYPOINT_COLOR
+            pointsAnnotation.outlineColor = SECONDARY_COLOR
+            pointsAnnotation.fillColor = SECONDARY_COLOR
             pointsAnnotation.thickness = 1
             annotation.points.append(pointsAnnotation)
 

--- a/depthai_nodes/message/lines.py
+++ b/depthai_nodes/message/lines.py
@@ -3,7 +3,7 @@ from typing import List
 
 import depthai as dai
 
-from depthai_nodes import OUTLINE_COLOR
+from depthai_nodes import PRIMARY_COLOR
 
 from .utils import (
     copy_message,
@@ -215,7 +215,7 @@ class Lines(dai.Buffer):
             pointsAnnotation.points = dai.VectorPoint2f(
                 [line.start_point, line.end_point]
             )
-            pointsAnnotation.outlineColor = OUTLINE_COLOR
+            pointsAnnotation.outlineColor = PRIMARY_COLOR
             pointsAnnotation.thickness = 2.0
             annotation.points.append(pointsAnnotation)
 

--- a/depthai_nodes/message/prediction.py
+++ b/depthai_nodes/message/prediction.py
@@ -4,8 +4,7 @@ from typing import List
 import depthai as dai
 
 from depthai_nodes import (
-    BACKGROUND_COLOR,
-    TEXT_COLOR,
+    PRIMARY_COLOR,
 )
 
 
@@ -165,13 +164,22 @@ class Predictions(dai.Buffer):
         img_annotations = dai.ImgAnnotations()
         annotation = dai.ImgAnnotation()
 
+        w, h = self.transformation.getSize()
+
+        font_size = h / 30
+        x_offset = 3 / w
+        y_offset = 3 / h
+
         for i, prediction in enumerate(self.predictions):
             text = dai.TextAnnotation()
-            text.position = dai.Point2f(1.05, 0.1 + i * 0.1)
+            text.position = dai.Point2f(
+                x_offset,
+                y_offset + (font_size / h) + i * (font_size / h),
+                normalized=True,
+            )
             text.text = f"{prediction.prediction:.2f}"
-            text.fontSize = 15
-            text.textColor = TEXT_COLOR
-            text.backgroundColor = BACKGROUND_COLOR
+            text.fontSize = font_size
+            text.textColor = PRIMARY_COLOR
             annotation.texts.append(text)
 
         img_annotations.annotations.append(annotation)

--- a/depthai_nodes/utils/annotation_helper.py
+++ b/depthai_nodes/utils/annotation_helper.py
@@ -4,6 +4,11 @@ from typing import List, Optional, Tuple
 import depthai as dai
 import numpy as np
 
+from depthai_nodes.constants import (
+    PRIMARY_COLOR,
+    TRANSPARENT_PRIMARY_COLOR,
+)
+
 Point = Tuple[float, float]
 ColorRGBA = Tuple[float, float, float, float]
 
@@ -18,7 +23,11 @@ class AnnotationHelper:
         self.annotation: dai.ImgAnnotation = dai.ImgAnnotation()
 
     def draw_line(
-        self, pt1: Point, pt2: Point, color: ColorRGBA, thickness: float
+        self,
+        pt1: Point,
+        pt2: Point,
+        color: ColorRGBA = PRIMARY_COLOR,
+        thickness: float = 2,
     ) -> "AnnotationHelper":
         """Draws a line between two points.
 
@@ -46,8 +55,8 @@ class AnnotationHelper:
     def draw_polyline(
         self,
         points: List[Point],
-        outline_color: ColorRGBA,
-        fill_color: Optional[ColorRGBA] = None,
+        outline_color: ColorRGBA = PRIMARY_COLOR,
+        fill_color: Optional[ColorRGBA] = TRANSPARENT_PRIMARY_COLOR,
         thickness: float = 1,
         closed: bool = False,
     ) -> "AnnotationHelper":
@@ -71,6 +80,8 @@ class AnnotationHelper:
             if not closed
             else dai.PointsAnnotationType.LINE_LOOP
         )
+        if not closed:
+            fill_color = None
         points_annot = self._create_points_annotation(
             points, outline_color, fill_color, points_type
         )
@@ -79,7 +90,10 @@ class AnnotationHelper:
         return self
 
     def draw_points(
-        self, points: List[Point], color: ColorRGBA, thickness: float = 2
+        self,
+        points: List[Point],
+        color: ColorRGBA = PRIMARY_COLOR,
+        thickness: float = 2,
     ) -> "AnnotationHelper":
         """Draws points.
 
@@ -104,7 +118,7 @@ class AnnotationHelper:
         self,
         center: Point,
         radius: float,
-        outline_color: ColorRGBA,
+        outline_color: ColorRGBA = PRIMARY_COLOR,
         fill_color: Optional[ColorRGBA] = None,
         thickness: float = 1,
     ) -> "AnnotationHelper":
@@ -137,8 +151,8 @@ class AnnotationHelper:
         self,
         top_left: Point,
         bottom_right: Point,
-        outline_color: ColorRGBA,
-        fill_color: Optional[ColorRGBA] = None,
+        outline_color: ColorRGBA = PRIMARY_COLOR,
+        fill_color: Optional[ColorRGBA] = TRANSPARENT_PRIMARY_COLOR,
         thickness: float = 1,
     ) -> "AnnotationHelper":
         """Draws a rectangle.
@@ -169,7 +183,7 @@ class AnnotationHelper:
         self,
         text: str,
         position: Point,
-        color: ColorRGBA,
+        color: ColorRGBA = PRIMARY_COLOR,
         background_color: Optional[ColorRGBA] = None,
         size: float = 32,
     ) -> "AnnotationHelper":
@@ -204,8 +218,8 @@ class AnnotationHelper:
         center: Point,
         size: Tuple[float, float],
         angle: float,
-        outline_color: ColorRGBA,
-        fill_color: Optional[ColorRGBA] = None,
+        outline_color: ColorRGBA = PRIMARY_COLOR,
+        fill_color: Optional[ColorRGBA] = TRANSPARENT_PRIMARY_COLOR,
         thickness: float = 1,
     ) -> "AnnotationHelper":
         """Draws a rotated rectangle.
@@ -261,6 +275,8 @@ class AnnotationHelper:
         return points_annot
 
     def _create_color(self, color: ColorRGBA) -> dai.Color:
+        if isinstance(color, dai.Color):
+            return color
         c = dai.Color()
         c.a = color[3]
         c.r = color[0]


### PR DESCRIPTION
## Purpose
`AnnotaitonHelper` node can have default colors which are aligned with official Luxonis colors. Same goes for default visualizations of messages.

## Specification
Added primary, secondary, and primary transparent (used as fill color in bboxes - similar to Visualizer).

## Dependencies & Potential Impact
It has some naming changes which may lead to broken experiments.

## Deployment Plan
None / not applicable

## Testing & Validation
Tested on affected messages.