### PR TITLE
Fix: Correct argument passing in config generator.

### DIFF
--- a/depthai_nodes/node/utils/detection_config_generator.py
+++ b/depthai_nodes/node/utils/detection_config_generator.py
@@ -45,7 +45,7 @@ def generate_script_content(
             rect.size.height = rect.size.height + {padding} * 2
             rect.angle = 0
 
-            cfg.addCropRotatedRect(rect, normalizedCoords=True)
+            cfg.addCropRotatedRect(rect, True)
             cfg.setOutputSize({resize_width}, {resize_height}, ImageManipConfigV2.ResizeMode.{resize_mode})
         """
     validate_label = (


### PR DESCRIPTION
## Purpose
DAI throws error when using `detection_config_generator`.

## Specification
Passing the arguments in the correct form.

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
Tested on dai alpha14 and one experiment.