### PR TITLE
fix: Keypoint confidence setter

### DIFF
--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -143,7 +143,7 @@ class Keypoint(dai.Buffer):
         """
         if not isinstance(value, float):
             raise TypeError("confidence must be a float.")
-        if value < -0.1 or value > 1.1:
+        if (value < -0.1 or value > 1.1) and value != -1.0:
             raise ValueError("Confidence must be between 0 and 1.")
         if not (0 <= value <= 1):
             value = max(0, min(1, value))


### PR DESCRIPTION
## Purpose
`Keypoint` message `confidencesetter` doesn't accept `-1.0` (the default confidence value).

## Specification
Add an exception to the `confidence.setter` to also accept `-1.0`.

## Dependencies & Potential Impact
None

## Deployment Plan
None

## Testing & Validation
Unittests.