### PR TITLE
Feat/snaps producer

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -25,7 +25,7 @@ on:
       depthai-version:
         description: 'Version of depthai to install. Default: alpha13'
         required: true
-        default: '3.0.0a14'
+        default: '3.0.0a15'
   push:
     branches:
       - main

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -32,7 +32,7 @@ jobs:
         cache: pip
 
     - name: Install depthai
-      run: pip install --extra-index-url ${{ secrets.LUXONIS_EXTRA_INDEX_URL }} depthai==3.0.0a14
+      run: pip install --extra-index-url ${{ secrets.LUXONIS_EXTRA_INDEX_URL }} depthai==3.0.0a15
 
     - name: Install package
       run: pip install -e .[dev]

--- a/.github/workflows/stability_tests.yaml
+++ b/.github/workflows/stability_tests.yaml
@@ -10,7 +10,7 @@ on:
       depthai-version:
         description: 'Version of depthai to install. Default: alpha13'
         required: true
-        default: '3.0.0a14'
+        default: '3.0.0a15'
       duration:
         description: 'Duration of each test in seconds. Default: 10'
         required: true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `depthai_nodes` package requires Python 3.8 or later and `depthai v3` instal
 While the `depthai v3` is not yet released on PyPI, you can install it with the following command:
 
 ```bash
-pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/  depthai==3.0.0a14
+pip install --extra-index-url https://artifacts.luxonis.com/artifactory/luxonis-python-release-local/  depthai==3.0.0a15
 ```
 
 The `depthai_nodes` package is hosted on PyPI, so you can install it with `pip`.

--- a/depthai_nodes/node/__init__.py
+++ b/depthai_nodes/node/__init__.py
@@ -30,6 +30,7 @@ from .parsers.xfeat import XFeatMonoParser, XFeatStereoParser
 from .parsers.yolo import YOLOExtendedParser
 from .parsers.yunet import YuNetParser
 from .parsing_neural_network import ParsingNeuralNetwork
+from .snaps_producer import SnapsProducer
 from .tiles_patcher import TilesPatcher
 from .tiling import Tiling
 
@@ -68,5 +69,6 @@ __all__ = [
     "ImgFrameOverlay",
     "ImgDetectionsBridge",
     "ImgDetectionsFilter",
+    "SnapsProducer",
     "BaseHostNode",
 ]

--- a/depthai_nodes/node/__init__.py
+++ b/depthai_nodes/node/__init__.py
@@ -30,7 +30,7 @@ from .parsers.xfeat import XFeatMonoParser, XFeatStereoParser
 from .parsers.yolo import YOLOExtendedParser
 from .parsers.yunet import YuNetParser
 from .parsing_neural_network import ParsingNeuralNetwork
-from .snaps_producer import SnapsProducer
+from .snaps_producer import SnapsProducer, SnapsProducerFrameOnly
 from .tiles_patcher import TilesPatcher
 from .tiling import Tiling
 
@@ -69,6 +69,7 @@ __all__ = [
     "ImgFrameOverlay",
     "ImgDetectionsBridge",
     "ImgDetectionsFilter",
+    "SnapsProducerFrameOnly",
     "SnapsProducer",
     "BaseHostNode",
 ]

--- a/depthai_nodes/node/snaps_producer.py
+++ b/depthai_nodes/node/snaps_producer.py
@@ -1,0 +1,94 @@
+import time
+from typing import Callable, Dict, List, Optional
+
+import depthai as dai
+
+from depthai_nodes.logging import get_logger
+from depthai_nodes.node.base_host_node import BaseHostNode
+
+
+class SnapsProducer(BaseHostNode):
+    def __init__(
+        self,
+    ):
+        super().__init__()
+        self.last_update = time.time()
+
+        self.out.setPossibleDatatypes([(dai.DatatypeEnum.ImgFrame, True)])
+
+        self._em = dai.EventsManager()
+        self._em.setLogResponse(True)
+        self._time_interval = 60
+        self._process_fn = None
+        self._logger = get_logger(__name__)
+
+    def setToken(self, token: str):
+        self._em.setToken(token)
+
+    def setUrl(self, url: str):
+        self._em.setUrl(url)
+
+    def setTimeInterval(self, time_interval: float):
+        self._time_interval = time_interval
+
+    def setProcessFn(self, process_fn: Callable):
+        self._process_fn = process_fn
+
+    def build(
+        self,
+        frame: dai.Node.Output,
+        msg: Optional[dai.Node.Output] = None,
+        time_interval: float = 60.0,
+        process_fn: Optional[Callable] = None,
+    ) -> "SnapsProducer":
+        if msg is not None:
+            self.link_args(frame, msg)
+        self.setTimeInterval(time_interval)
+        if process_fn is not None:
+            self.setProcessFn(process_fn)
+        return self
+
+    def process(self, frame: dai.ImgFrame, msg: Optional[dai.Buffer] = None):
+        if self._process_fn is None:
+            self.sendSnap("frame", frame)
+        if self._process_fn is not None:
+            self._process_fn(self, frame, msg)
+
+    def sendSnap(
+        self,
+        name: str,
+        frame: dai.ImgFrame,
+        tags: List[dai.EventData] = [],  # noqa: B006
+        groups: List[str] = [],  # noqa: B006
+        extra_data: Dict[str, str] = {},  # noqa: B006
+    ):
+        now = time.time()
+        if now > self.last_update + self._time_interval:
+            self.last_update = now
+            self._em.sendSnap(name, frame, tags, groups, extra_data)
+            self._logger.info(f"Sent snap with name `{name}`")
+
+        # for det in detections.detections:
+        #     if (
+        #         det.confidence < self.confidence_threshold
+        #         and self.label_map[det.label] in self.labels
+        #         and time.time() > self.last_update + self.time_interval
+        #     ):
+        #         self.last_update = time.time()
+        #         det_xyxy = [det.xmin, det.ymin, det.xmax, det.ymax]
+        #         extra_data = {
+        #             "model": "luxonis/yolov6-nano:r2-coco-512x288",
+        #             "detection_xyxy": str(det_xyxy),
+        #             "detection_label": str(det.label),
+        #             "detection_label_str": self.label_map[det.label],
+        #             "detection_confidence": str(det.confidence),
+        #         }
+        #         self.em.sendSnap(
+        #             "rgb",
+        #             rgb,
+        #             [],
+        #             ["demo"],
+        #             extra_data,
+        #         )
+
+        #         print(f"Event sent: {extra_data}")

--- a/depthai_nodes/node/snaps_producer.py
+++ b/depthai_nodes/node/snaps_producer.py
@@ -1,83 +1,244 @@
 import time
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
 import depthai as dai
 
 from depthai_nodes.logging import get_logger
 from depthai_nodes.node.base_host_node import BaseHostNode
 
+ProcessFnFrameOnlyType = Callable[["SnapsProducerFrameOnly", dai.ImgFrame], None]
+ProcessFnType = Callable[["SnapsProducer", dai.ImgFrame, dai.Buffer], None]
 
-class SnapsProducer(BaseHostNode):
+
+class SnapsProducerFrameOnly(BaseHostNode):
+    """A host node that helps with creating and sending snaps. If you also have
+    additional message as input (e.g. detections) consider using `SnapsProducer` node
+    instead.
+
+    Attributes:
+    ----------
+    frame : dai.ImgFrame
+        The input message for snap creation.
+    time_interval : Union[int, float]
+        Time interval between snaps if no custom process function is provided. Defaults to 60s.
+    process_fn : Callable[['SnapsProducerFrameOnly', dai.ImgFrame], None]
+        Custom processing function for business logic regarding snaps. If None defaults to sending only frames on time intervals.
+    token : str
+        Hub API token of the team you want to save snaps under. Can be also set through `DEPTHAI_HUB_API_KEY` env variable.
+    url : str
+        Custom URL for events service. By default, the URL is set to https://events-ingest.cloud.luxonis.com
+    """
+
     def __init__(
         self,
+        time_interval: Union[int, float] = 60.0,
+        process_fn: Optional[ProcessFnFrameOnlyType] = None,
     ):
         super().__init__()
         self.last_update = time.time()
 
         self._em = dai.EventsManager()
         self._em.setLogResponse(True)
-        self._time_interval = 60
-        self._process_fn = None
+        self.setTimeInterval(time_interval)
+        if process_fn is None:
+            self._process_fn = None
+        else:
+            self.setProcessFn(process_fn)
+
         self._logger = get_logger(__name__)
 
     def setToken(self, token: str):
+        """Sets the Hub API token.
+
+        @param token: Hub API token of your team.
+        @type token: str
+        """
+        if not isinstance(token, str):
+            raise ValueError("token must of of type string.")
         self._em.setToken(token)
 
     def setUrl(self, url: str):
+        """Set the URL of the events service. By default, the URL is set to https://events-ingest.cloud.luxonis.com.
+
+        @param url: URL of the events service.
+        @type url: str
+        """
+        if not isinstance(url, str):
+            raise ValueError("url must of of type string.")
         self._em.setUrl(url)
 
-    def setTimeInterval(self, time_interval: float):
+    def setTimeInterval(self, time_interval: Union[int, float]):
+        """Sets time interval between snaps. Only relevant if using default processing.
+
+        @param time_interval: Time interval between snaps for default sending in
+            seconds.
+        @type time_interval: Union[int, float]
+        """
+        if not (isinstance(time_interval, int) or isinstance(time_interval, float)):
+            raise ValueError("time_interval must be of type int or float.")
+
         self._time_interval = time_interval
 
-    def setProcessFn(self, process_fn: Callable):
+    def setProcessFn(self, process_fn: ProcessFnFrameOnlyType):
+        """Sets custom processing function.
+
+        @param process_fn: Custom snaps processing function.
+        @type process_fn: Callable[['SnapsProducerFrameOnly', dai.ImgFrame], None]
+        """
+        if not isinstance(process_fn, Callable):
+            raise ValueError("process_fn must be a function.")
+
         self._process_fn = process_fn
 
     def build(
         self,
         frame: dai.Node.Output,
-        msg: dai.Node.Output = None,
-        time_interval: float = 60.0,
-        process_fn: Optional[Callable] = None,
-    ) -> "SnapsProducer":
-        if msg is not None:
-            self.link_args(frame, msg)
+        time_interval: Union[int, float] = 60.0,
+        process_fn: Optional[ProcessFnFrameOnlyType] = None,
+    ) -> "SnapsProducerFrameOnly":
+        """Configures the node.
+
+        @param frame: The input message for snap creation.
+        @type frame: dai.Node.Output
+        @param time_interval: Time interval between snaps for default sending in
+            seconds. Defualts to 60.
+        @type time_interval: Union[int, float]
+        @param process_fn: Custom snaps processing function. Defaults to None.
+        @type process_fn: Callable[['SnapsProducerFrameOnly', dai.ImgFrame], None]
+        @return: The node object which handles snap creation and sending.
+        @rtype: SnapsProducerFrameOnly
+        """
+        self.link_args(frame)
         self.setTimeInterval(time_interval)
         if process_fn is not None:
             self.setProcessFn(process_fn)
         return self
 
-    def process(self, frame: dai.Buffer, msg: dai.Buffer = None):
+    def process(self, frame: dai.Buffer):
+        """Processes incoming frames and sends out snaps. If not custom process function
+        is set then it sends only one frame every `time_interval` seconds. If using
+        custom process function make sure to call `self.sendSnap()` at the end.
+
+        @param frame: The input message for snap creation.
+        @type frame: dai.ImgFrame
+        """
         assert isinstance(frame, dai.ImgFrame)
         if self._process_fn is None:
             self.sendSnap("frame", frame)
-        if self._process_fn is not None:
-            self._process_fn(self, frame, msg)
+        else:
+            self._process_fn(self, frame)
 
     def sendSnap(
         self,
         name: str,
         frame: dai.ImgFrame,
-        tags: List[dai.EventData] = [],  # noqa: B006
-        groups: List[str] = [],  # noqa: B006
+        data: List[dai.EventData] = [],  # noqa: B006
+        tags: List[str] = [],  # noqa: B006
         extra_data: Dict[str, str] = {},  # noqa: B006
+        device_serial_num: str = "",
     ):
+        """Function that creates the snap and sends it out. Make sure to call this
+        function from any custom processing functions to send snaps.
+
+        @param name: Name of the snap.
+        @type name: str
+        @param frame: Image frame to send.
+        @type frame: dai.ImgFrame
+        @param data: List of EventData objects to send. Defualts to [].
+        @type data: List[dai.EventData]
+        @param tags: List of tags to send. Defaults to [].
+        @type tags: List[str]
+        @param extra_data: Extra data to send. Defaults to {}.
+        @type extra_data: Dict[str, str]
+        @param device_serial_num: Device serial number. Defualts to ''.
+        @type device_serial_num: str
+        """
         now = time.time()
         if now > self.last_update + self._time_interval:
             self.last_update = now
-            self._em.sendSnap(name, frame, tags, groups, extra_data)
-            self._logger.info(f"Sent snap with name `{name}`")
+            out = self._em.sendSnap(
+                name=name,
+                imgFrame=frame,
+                data=data,
+                tags=tags,
+                extraData=extra_data,
+                deviceSerialNo=device_serial_num,
+            )
+            if out:
+                self._logger.info(f"Snap `{name}` sent")
 
 
-# Example usage:
+class SnapsProducer(SnapsProducerFrameOnly):
+    """A host node that helps with creating and sending snaps. If you only have frame as
+    input consider using `SnapsProducerFrameOnly` node instead.
 
-# def filter_detections(producer, frame, msg):
-#     # some filtering on msg possible here ...
-#     extra_data = {"last_update":str(producer.last_update)}
-#     producer.sendSnap(name="test123", frame=frame, extra_data=extra_data)
+    Attributes:
+    ----------
+    frame : dai.ImgFrame
+        The frame input message for snap creation.
+    msg : dai.Buffer
+        The additional input message for snap creation.
+    time_interval : float
+        Time interval between snaps if no custom process function is provided. Defaults to 60s.
+    process_fn : Callable[['SnapsProducer', dai.ImgFrame, dai.Buffer], None]
+        Custom processing function for business logic regarding snaps. If None defaults to sending only frames on time intervals.
+    token : str
+        Hub API token of the team you want to save snaps under. Can be also set through `DEPTHAI_HUB_API_KEY` env variable.
+    url : str
+        Custom URL for events service. By default, the URL is set to https://events-ingest.cloud.luxonis.com
+    """
 
-# snaps_producer = pipeline.create(SnapsProducer).build(
-#     frame = nn_with_parser.passthrough,
-#     msg = nn_with_parser.out,
-#     process_fn=filter_detections,
-#     time_interval=5
-# )
+    def setProcessFn(self, process_fn: ProcessFnType):
+        """Sets custom processing function.
+
+        @param process_fn: Custom snaps processing function.
+        @type process_fn: Callable[['SnapsProducer', dai.ImgFrame, dai.Buffer], None]
+        """
+        if not isinstance(process_fn, Callable):
+            raise ValueError("process_fn must be a function.")
+
+        self._process_fn = process_fn
+
+    def build(
+        self,
+        frame: dai.Node.Output,
+        msg: dai.Node.Output,
+        time_interval: Union[int, float] = 60.0,
+        process_fn: Optional[ProcessFnType] = None,
+    ) -> "SnapsProducer":
+        """Configures the node.
+
+        @param frame: The frame input message for snap creation.
+        @type frame: dai.Node.Output
+        @param msg: The additonal input message for snap creation.
+        @type msg: dai.Node.Output
+        @param time_interval: Time interval between snaps for default sending in
+            seconds. Defualts to 60.
+        @type time_interval: Union[int, float]
+        @param process_fn: Custom snaps processing function. Defaults to None.
+        @type process_fn: Optional[Callable[['SnapsProducer', dai.ImgFrame, dai.Buffer],
+            None]]
+        @return: The node object which handles snap creation and sending.
+        @rtype: SnapsProducer
+        """
+        self.link_args(frame, msg)
+        self.setTimeInterval(time_interval)
+        if process_fn is not None:
+            self.setProcessFn(process_fn)
+        return self
+
+    def process(self, frame: dai.Buffer, msg: dai.Buffer):
+        """Processes incoming frames and sends out snaps. If not custom process function
+        is set then it sends only one frame every `time_interval` seconds. If using
+        custom process function make sure to call `self.sendSnap()` at the end.
+
+        @param frame: The frame input message for snap creation.
+        @type frame: dai.ImgFrame
+        @param frame: The additional input message for snap creation.
+        @type frame: dai.Buffer
+        """
+        assert isinstance(frame, dai.ImgFrame)
+        if self._process_fn is None:
+            self.sendSnap("frame", frame)
+        else:
+            self._process_fn(self, frame, msg)

--- a/tests/end_to_end/README.md
+++ b/tests/end_to_end/README.md
@@ -13,7 +13,7 @@ There are 3 required parameters that need to be set when triggering the Github a
 
 - `additional-parameter`: The parameter that specifies the desired test. Default is `-all` which runs tests on all public models. The available options are: `-all`, `-p <parser_name>`, `-m <model_1> <model_2> ...`.
 - `depthai-nodes-version`: The branch or release on which the tests will be run. Default is `main`.
-- `depthai-version`: The version of the DepthAI that will be used for the tests. Default is `3.0.0a14`.
+- `depthai-version`: The version of the DepthAI that will be used for the tests. Default is `3.0.0a15`.
 
 ## Running the tests locally
 

--- a/tests/stability_tests/README.md
+++ b/tests/stability_tests/README.md
@@ -73,7 +73,7 @@ You would need the B2 credentials to download the tests from the bucket and set 
 The stability tests are triggered in every PR. But you can also trigger them manually. Required parameters are:
 
 - `additional-parameter`: The parameter that specifies the desired test. Default is `-all` which runs tests on all parsers. The available options are: `-all`, `-p <parser_name>`.
-- `depthai-version`: The version of the DepthAI that will be used for the tests. Default is `3.0.0a14`.
+- `depthai-version`: The version of the DepthAI that will be used for the tests. Default is `3.0.0a15`.
 - `duration`: The duration of each test in seconds. Default is `10` seconds.
 
 ## How to create test for Host node or parser

--- a/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
@@ -82,9 +82,9 @@ def test_parameter_setting_frame_only(
 
     # time_interval
     snaps_producer_frame_only.setTimeInterval(time_interval)
-    assert snaps_producer_frame_only._time_interval == time_interval
+    assert snaps_producer_frame_only.time_interval == time_interval
     snaps_producer_frame_only.setTimeInterval(int(time_interval))
-    assert snaps_producer_frame_only._time_interval == int(time_interval)
+    assert snaps_producer_frame_only.time_interval == int(time_interval)
     with pytest.raises(ValueError):
         snaps_producer_frame_only.setTimeInterval("not an integer or float")
 
@@ -118,9 +118,9 @@ def test_parameter_setting(
 
     # time_interval
     snaps_producer.setTimeInterval(time_interval)
-    assert snaps_producer._time_interval == time_interval
+    assert snaps_producer.time_interval == time_interval
     snaps_producer.setTimeInterval(int(time_interval))
-    assert snaps_producer._time_interval == int(time_interval)
+    assert snaps_producer.time_interval == int(time_interval)
     with pytest.raises(ValueError):
         snaps_producer.setTimeInterval("not an integer or float")
 

--- a/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
@@ -262,7 +262,6 @@ def test_partial_process_fn(
     def partial_process_fn(
         producer: SnapsProducerFrameOnly, frame: dai.ImgFrame, threshold: float
     ):
-        # Your custom logic using extra param `threshold`
         if frame.getWidth() > threshold:
             producer.sendSnap("threshold_snap", frame)
 

--- a/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
@@ -1,0 +1,292 @@
+import time
+from functools import partial
+from typing import Callable
+from unittest.mock import MagicMock
+
+import depthai as dai
+import numpy as np
+import pytest
+
+from depthai_nodes.node import SnapsProducer, SnapsProducerFrameOnly
+from tests.utils import LOG_INTERVAL, OutputMock, create_img_detection, create_img_frame
+
+HEIGHT, WIDTH = 100, 100
+FRAME = np.random.randint(0, 255, (HEIGHT, WIDTH, 3), dtype=np.uint8)
+
+
+@pytest.fixture(scope="session")
+def duration(request):
+    d = request.config.getoption("--duration")
+    if d is None:
+        return 1e-6
+    return d
+
+
+@pytest.fixture
+def snaps_producer_frame_only():
+    producer = SnapsProducerFrameOnly()
+    producer._logger = MagicMock()
+    return producer
+
+
+@pytest.fixture
+def snaps_producer():
+    producer = SnapsProducer()
+    producer._logger = MagicMock()
+    return producer
+
+
+@pytest.fixture
+def simple_process_fn_frame_only():
+    def filter_detections_frame_only(producer, frame):
+        producer.sendSnap(name="test", frame=frame)
+
+    return filter_detections_frame_only
+
+
+@pytest.fixture
+def simple_process_fn():
+    def filter_detections(producer, frame, msg):
+        producer.sendSnap(name="test", frame=frame)
+
+    return filter_detections
+
+
+def test_building_frame_only(snaps_producer_frame_only: SnapsProducerFrameOnly):
+    snaps_producer_frame_only.build(OutputMock())
+
+
+def test_building(snaps_producer: SnapsProducer):
+    snaps_producer.build(OutputMock(), OutputMock())
+
+
+def test_parameter_setting_frame_only(
+    snaps_producer_frame_only: SnapsProducerFrameOnly,
+    recwarn,
+    token: str = "test_token",
+    url: str = "test_url",
+    time_interval: float = 1.0,
+    process_fn: Callable = simple_process_fn_frame_only,
+):
+    # token
+    snaps_producer_frame_only.setToken(token)
+    assert not recwarn.list, "Unexpected warnings raised on .setToken"
+    with pytest.raises(ValueError):
+        snaps_producer_frame_only.setToken(1)
+
+    # url
+    snaps_producer_frame_only.setUrl(url)
+    assert not recwarn.list, "Unexpected warnings raised on .setUrl"
+    with pytest.raises(ValueError):
+        snaps_producer_frame_only.setUrl(1)
+
+    # time_interval
+    snaps_producer_frame_only.setTimeInterval(time_interval)
+    assert snaps_producer_frame_only._time_interval == time_interval
+    snaps_producer_frame_only.setTimeInterval(int(time_interval))
+    assert snaps_producer_frame_only._time_interval == int(time_interval)
+    with pytest.raises(ValueError):
+        snaps_producer_frame_only.setTimeInterval("not an integer or float")
+
+    # process_fn
+    snaps_producer_frame_only.setProcessFn(process_fn)
+    with pytest.raises(ValueError):
+        snaps_producer_frame_only.setProcessFn("not a function")
+    with pytest.raises(ValueError):
+        snaps_producer_frame_only.setProcessFn(None)
+
+
+def test_parameter_setting(
+    snaps_producer: SnapsProducer,
+    recwarn,
+    token: str = "test_token",
+    url: str = "test_url",
+    time_interval: float = 1.0,
+    process_fn: Callable = simple_process_fn,
+):
+    # token
+    snaps_producer.setToken(token)
+    assert not recwarn.list, "Unexpected warnings raised on .setToken"
+    with pytest.raises(ValueError):
+        snaps_producer.setToken(1)
+
+    # url
+    snaps_producer.setUrl(url)
+    assert not recwarn.list, "Unexpected warnings raised on .setUrl"
+    with pytest.raises(ValueError):
+        snaps_producer.setUrl(1)
+
+    # time_interval
+    snaps_producer.setTimeInterval(time_interval)
+    assert snaps_producer._time_interval == time_interval
+    snaps_producer.setTimeInterval(int(time_interval))
+    assert snaps_producer._time_interval == int(time_interval)
+    with pytest.raises(ValueError):
+        snaps_producer.setTimeInterval("not an integer or float")
+
+    # process_fn
+    snaps_producer.setProcessFn(process_fn)
+    with pytest.raises(ValueError):
+        snaps_producer.setProcessFn("not a function")
+    with pytest.raises(ValueError):
+        snaps_producer.setProcessFn(None)
+
+
+def test_processing_frame_only(
+    snaps_producer_frame_only: SnapsProducerFrameOnly,
+    duration: float,
+    caplog,
+):
+    o_snaps = OutputMock()
+    snaps_producer_frame_only.build(o_snaps, time_interval=0)
+    q_snaps = o_snaps.createOutputQueue()
+
+    start_time = time.time()
+    last_log_time = time.time()
+    while time.time() - start_time < duration:
+        if time.time() - last_log_time > LOG_INTERVAL:
+            print(
+                f"Test running... {time.time() - start_time:.1f}s elapsed, {duration - time.time() + start_time:.1f}s remaining"
+            )
+            last_log_time = time.time()
+
+        frame = create_img_frame(FRAME)
+        q_snaps.send(frame)
+
+        with caplog.at_level("INFO"):
+            snaps_producer_frame_only.process(q_snaps.get())
+
+        snaps_producer_frame_only._logger.info.assert_called_with("Snap `frame` sent")
+
+
+def test_processing_frame_only_custom_process_fn(
+    snaps_producer_frame_only: SnapsProducerFrameOnly,
+    simple_process_fn_frame_only: Callable,
+    duration: float,
+    caplog,
+):
+    o_snaps = OutputMock()
+    snaps_producer_frame_only.build(
+        o_snaps, time_interval=0, process_fn=simple_process_fn_frame_only
+    )
+    q_snaps = o_snaps.createOutputQueue()
+
+    start_time = time.time()
+    last_log_time = time.time()
+    while time.time() - start_time < duration:
+        if time.time() - last_log_time > LOG_INTERVAL:
+            print(
+                f"Test running... {time.time() - start_time:.1f}s elapsed, {duration - time.time() + start_time:.1f}s remaining"
+            )
+            last_log_time = time.time()
+
+        frame = create_img_frame(FRAME)
+        q_snaps.send(frame)
+
+        with caplog.at_level("INFO"):
+            snaps_producer_frame_only.process(q_snaps.get())
+
+        snaps_producer_frame_only._logger.info.assert_called_with("Snap `test` sent")
+
+
+def test_processing(
+    snaps_producer: SnapsProducer,
+    duration: float,
+    caplog,
+):
+    o_snaps_frame = OutputMock()
+    o_snaps_msg = OutputMock()
+    snaps_producer.build(o_snaps_frame, o_snaps_msg, time_interval=0)
+    q_snaps_frame = o_snaps_frame.createOutputQueue()
+    q_snaps_msg = o_snaps_msg.createOutputQueue()
+
+    start_time = time.time()
+    last_log_time = time.time()
+    while time.time() - start_time < duration:
+        if time.time() - last_log_time > LOG_INTERVAL:
+            print(
+                f"Test running... {time.time() - start_time:.1f}s elapsed, {duration - time.time() + start_time:.1f}s remaining"
+            )
+            last_log_time = time.time()
+
+        frame = create_img_frame(FRAME)
+        q_snaps_frame.send(frame)
+        detection = create_img_detection()
+        q_snaps_msg.send(detection)
+
+        with caplog.at_level("INFO"):
+            snaps_producer.process(q_snaps_frame.get(), q_snaps_msg.get())
+
+        snaps_producer._logger.info.assert_called_with("Snap `frame` sent")
+
+
+def test_processing_custom_process_fn(
+    snaps_producer: SnapsProducer,
+    simple_process_fn: Callable,
+    duration: float,
+    caplog,
+):
+    o_snaps_frame = OutputMock()
+    o_snaps_msg = OutputMock()
+    snaps_producer.build(
+        o_snaps_frame, o_snaps_msg, time_interval=0, process_fn=simple_process_fn
+    )
+    q_snaps_frame = o_snaps_frame.createOutputQueue()
+    q_snaps_msg = o_snaps_msg.createOutputQueue()
+
+    start_time = time.time()
+    last_log_time = time.time()
+    while time.time() - start_time < duration:
+        if time.time() - last_log_time > LOG_INTERVAL:
+            print(
+                f"Test running... {time.time() - start_time:.1f}s elapsed, {duration - time.time() + start_time:.1f}s remaining"
+            )
+            last_log_time = time.time()
+
+        frame = create_img_frame(FRAME)
+        q_snaps_frame.send(frame)
+        detection = create_img_detection()
+        q_snaps_msg.send(detection)
+
+        with caplog.at_level("INFO"):
+            snaps_producer.process(q_snaps_frame.get(), q_snaps_msg.get())
+
+        snaps_producer._logger.info.assert_called_with("Snap `test` sent")
+
+
+def test_partial_process_fn(
+    snaps_producer_frame_only: SnapsProducerFrameOnly,
+    duration: float,
+    caplog,
+):
+    def partial_process_fn(
+        producer: SnapsProducerFrameOnly, frame: dai.ImgFrame, threshold: float
+    ):
+        # Your custom logic using extra param `threshold`
+        if frame.getWidth() > threshold:
+            producer.sendSnap("threshold_snap", frame)
+
+    o_snaps = OutputMock()
+    snaps_producer_frame_only.build(
+        o_snaps, time_interval=0, process_fn=partial(partial_process_fn, threshold=1)
+    )
+    q_snaps = o_snaps.createOutputQueue()
+
+    start_time = time.time()
+    last_log_time = time.time()
+    while time.time() - start_time < duration:
+        if time.time() - last_log_time > LOG_INTERVAL:
+            print(
+                f"Test running... {time.time() - start_time:.1f}s elapsed, {duration - time.time() + start_time:.1f}s remaining"
+            )
+            last_log_time = time.time()
+
+        frame = create_img_frame(FRAME)
+        q_snaps.send(frame)
+
+        with caplog.at_level("INFO"):
+            snaps_producer_frame_only.process(q_snaps.get())
+
+        snaps_producer_frame_only._logger.info.assert_called_with(
+            "Snap `threshold_snap` sent"
+        )

--- a/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
@@ -25,7 +25,6 @@ def duration(request):
 @pytest.fixture
 def snaps_producer_frame_only():
     producer = SnapsProducerFrameOnly()
-    producer.setToken("test token")
     producer._logger = MagicMock()
     return producer
 
@@ -33,7 +32,6 @@ def snaps_producer_frame_only():
 @pytest.fixture
 def snaps_producer():
     producer = SnapsProducer()
-    producer.setToken("test token")
     producer._logger = MagicMock()
     return producer
 

--- a/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_snaps_producer_node.py
@@ -25,6 +25,7 @@ def duration(request):
 @pytest.fixture
 def snaps_producer_frame_only():
     producer = SnapsProducerFrameOnly()
+    producer.setToken("test token")
     producer._logger = MagicMock()
     return producer
 
@@ -32,6 +33,7 @@ def snaps_producer_frame_only():
 @pytest.fixture
 def snaps_producer():
     producer = SnapsProducer()
+    producer.setToken("test token")
     producer._logger = MagicMock()
     return producer
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Added `SnapsProducerFrameOnly` (LMK if you have a better name suggestion) and `SnapsProducer` nodes that abstract sending snaps to the backend. It allows either out of the box sending of frames depending on the time interval (default) or making custom processing functions so it can be extended for particular use case.

Example usage with custom processing function:
```python
def filter_detections_frame_only(producer, frame):
        producer.sendSnap(name="test", frame=frame)

snaps_producer = pipeline.create(SnapsProducerFrameOnly).build(
        frame=nn_with_parser.passthrough,
        process_fn=filter_detections_frame_only,
        time_interval=5,
)
```

Example with `partial` to pass in extra parameters:
```python
def partial_process_fn(
    producer: SnapsProducerFrameOnly, frame: dai.ImgFrame, threshold: float
):
    if frame.getWidth() > threshold:
        producer.sendSnap("threshold_snap", frame)

snaps_producer = pipeline.create(SnapsProducerFrameOnly).build(
        frame=nn_with_parser.passthrough,
        process_fn=partial(partial_process_fn, threshold=200)
)
```

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable