### PR TITLE
fix: ImgDetectionsBridge label setting

### DIFF
--- a/depthai_nodes/node/img_detections_bridge.py
+++ b/depthai_nodes/node/img_detections_bridge.py
@@ -144,7 +144,8 @@ class ImgDetectionsBridge(BaseHostNode):
         detections_transformed = []
         for detection in img_det_ext.detections:
             detection_transformed = dai.ImgDetection()
-            detection_transformed.label = detection.label
+            if detection.label >= 0:
+                detection_transformed.label = detection.label
             detection_transformed.confidence = detection.confidence
             if not self._ignore_angle and detection.rotated_rect.angle != 0:
                 raise NotImplementedError(


### PR DESCRIPTION
## Purpose
Fixing a bug in `ImgDetectionsBridge`.

## Specification
While transforming `ImgDetectionsExtended` to `dai.ImgDetections`, we try setting the detection label. This is successful in most cases but fails if the label is equal to `-1` (valid for `ImgDetectionsExtended` but not for `dai.ImgDetections`). Adds a quick fix for this - don't set the label if smaller than `0` (this is not the greatest fix as the label of the newly created object is set to the default value of `0` but at least we don't get a fail).

## Dependencies & Potential Impact
None

## Deployment Plan
None

## Testing & Validation
Tested by running `depthai-experiments`.