### PR TITLE
[FIX] Float confidence

### DIFF
--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -60,7 +60,7 @@ class ImgDetectionExtended(dai.Buffer):
             self._rotated_rect.angle,
         )
         new_obj.rotated_rect = copy.deepcopy(rectangle)
-        new_obj.confidence = float(copy.deepcopy(self.confidence))
+        new_obj.confidence = copy.deepcopy(self.confidence)
         new_obj.label = copy.deepcopy(self.label)
         new_obj.label_name = copy.deepcopy(self.label_name)
         new_obj.keypoints = self._keypoints.copy()
@@ -110,7 +110,7 @@ class ImgDetectionExtended(dai.Buffer):
         if value < -0.1 or value > 1.1:
             raise ValueError("Confidence must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0, min(1, value))
+            value = max(0.0, min(1.0, value))
             self._logger.info("Confidence value was clipped to [0, 1].")
 
         self._confidence = value

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -60,7 +60,7 @@ class ImgDetectionExtended(dai.Buffer):
             self._rotated_rect.angle,
         )
         new_obj.rotated_rect = copy.deepcopy(rectangle)
-        new_obj.confidence = copy.deepcopy(self.confidence)
+        new_obj.confidence = float(copy.deepcopy(self.confidence))
         new_obj.label = copy.deepcopy(self.label)
         new_obj.label_name = copy.deepcopy(self.label_name)
         new_obj.keypoints = self._keypoints.copy()

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -110,7 +110,7 @@ class ImgDetectionExtended(dai.Buffer):
         if value < -0.1 or value > 1.1:
             raise ValueError("Confidence must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0.0, min(1.0, value))
+            value = float(max(0.0, min(1.0, value)))
             self._logger.info("Confidence value was clipped to [0, 1].")
 
         self._confidence = value

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -71,7 +71,7 @@ class Keypoint(dai.Buffer):
         if value < -0.1 or value > 1.1:
             raise ValueError("x must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0, min(1, value))
+            value = max(0.0, min(1.0, value))
             self._logger.info("x value was clipped to [0, 1].")
         self._x = value
 
@@ -98,7 +98,7 @@ class Keypoint(dai.Buffer):
         if value < -0.1 or value > 1.1:
             raise ValueError("y must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0, min(1, value))
+            value = max(0.0, min(1.0, value))
             self._logger.info("y value was clipped to [0, 1].")
         self._y = value
 
@@ -146,7 +146,7 @@ class Keypoint(dai.Buffer):
         if (value < -0.1 or value > 1.1) and value != -1.0:
             raise ValueError("Confidence must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0, min(1, value))
+            value = max(0.0, min(1.0, value))
             self._logger.info("Confidence value was clipped to [0, 1].")
         self._confidence = value
 

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -68,10 +68,8 @@ class Keypoint(dai.Buffer):
         """
         if not isinstance(value, float):
             raise TypeError("x must be a float.")
-        if value < -0.1 or value > 1.1:
-            raise ValueError("x must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0.0, min(1.0, value))
+            value = float(max(0.0, min(1.0, value)))
             self._logger.info("x value was clipped to [0, 1].")
         self._x = value
 
@@ -95,10 +93,8 @@ class Keypoint(dai.Buffer):
         """
         if not isinstance(value, float):
             raise TypeError("y must be a float.")
-        if value < -0.1 or value > 1.1:
-            raise ValueError("y must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0.0, min(1.0, value))
+            value = float(max(0.0, min(1.0, value)))
             self._logger.info("y value was clipped to [0, 1].")
         self._y = value
 
@@ -146,7 +142,7 @@ class Keypoint(dai.Buffer):
         if (value < -0.1 or value > 1.1) and value != -1.0:
             raise ValueError("Confidence must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0.0, min(1.0, value))
+            value = float(max(0.0, min(1.0, value)))
             self._logger.info("Confidence value was clipped to [0, 1].")
         self._confidence = value
 

--- a/depthai_nodes/message/lines.py
+++ b/depthai_nodes/message/lines.py
@@ -4,6 +4,7 @@ from typing import List
 import depthai as dai
 
 from depthai_nodes import PRIMARY_COLOR
+from depthai_nodes.logging import get_logger
 
 from .utils import (
     copy_message,
@@ -29,6 +30,7 @@ class Line(dai.Buffer):
         self._start_point: dai.Point2f = None
         self._end_point: dai.Point2f = None
         self._confidence: float = None
+        self._logger = get_logger(__name__)
 
     def copy(self):
         """Creates a new instance of the Line class and copies the attributes.
@@ -103,12 +105,17 @@ class Line(dai.Buffer):
 
         @param value: Confidence of the line.
         @type value: float
-        @raise TypeError: If value is not of type float.
+        @raise TypeError: If value is not a float.
+        @raise ValueError: If value is not between 0 and 1.
         """
         if not isinstance(value, float):
-            raise TypeError(
-                f"Confidence must be of type float, instead got {type(value)}."
-            )
+            raise TypeError("Confidence must be a float.")
+        if value < -0.1 or value > 1.1:
+            raise ValueError("Confidence must be between 0 and 1.")
+        if not (0 <= value <= 1):
+            value = max(0.0, min(1.0, value))
+            self._logger.info("Confidence value was clipped to [0, 1].")
+
         self._confidence = value
 
 

--- a/depthai_nodes/message/lines.py
+++ b/depthai_nodes/message/lines.py
@@ -113,7 +113,7 @@ class Line(dai.Buffer):
         if value < -0.1 or value > 1.1:
             raise ValueError("Confidence must be between 0 and 1.")
         if not (0 <= value <= 1):
-            value = max(0.0, min(1.0, value))
+            value = float(max(0.0, min(1.0, value)))
             self._logger.info("Confidence value was clipped to [0, 1].")
 
         self._confidence = value

--- a/tests/unittests/test_messages/test_img_detections_msg.py
+++ b/tests/unittests/test_messages/test_img_detections_msg.py
@@ -46,6 +46,10 @@ def test_img_detection_extended_set_confidence(
     img_detection_extended.confidence = 0.9
     assert img_detection_extended.confidence == 0.9
 
+    img_detection_extended.confidence = 1.05
+    assert img_detection_extended.confidence == 1.0
+    assert isinstance(img_detection_extended.confidence, float)
+
     with pytest.raises(TypeError):
         img_detection_extended.confidence = "not a float"
 

--- a/tests/unittests/test_messages/test_keypoints_msg.py
+++ b/tests/unittests/test_messages/test_keypoints_msg.py
@@ -25,22 +25,32 @@ def test_keypoint_set_x(keypoint: Keypoint):
     keypoint.x = 0.5
     assert keypoint.x == 0.5
 
+    keypoint.x = 1.15
+    assert keypoint.x == 1.0
+    assert isinstance(keypoint.x, float)
+
+    keypoint.x = -0.15
+    assert keypoint.x == 0.0
+    assert isinstance(keypoint.x, float)
+
     with pytest.raises(TypeError):
         keypoint.x = "not a float"
-
-    with pytest.raises(ValueError):
-        keypoint.x = 1.5
 
 
 def test_keypoint_set_y(keypoint: Keypoint):
     keypoint.y = 0.5
     assert keypoint.y == 0.5
 
+    keypoint.y = 1.15
+    assert keypoint.y == 1.0
+    assert isinstance(keypoint.y, float)
+
+    keypoint.y = -0.15
+    assert keypoint.y == 0.0
+    assert isinstance(keypoint.y, float)
+
     with pytest.raises(TypeError):
         keypoint.y = "not a float"
-
-    with pytest.raises(ValueError):
-        keypoint.y = 1.5
 
 
 def test_keypoint_set_z(keypoint: Keypoint):
@@ -54,6 +64,14 @@ def test_keypoint_set_z(keypoint: Keypoint):
 def test_keypoint_set_confidence(keypoint: Keypoint):
     keypoint.confidence = 0.9
     assert keypoint.confidence == 0.9
+
+    keypoint.confidence = 1.05
+    assert keypoint.confidence == 1.0
+    assert isinstance(keypoint.confidence, float)
+
+    keypoint.confidence = -0.05
+    assert keypoint.confidence == 0.0
+    assert isinstance(keypoint.confidence, float)
 
     with pytest.raises(TypeError):
         keypoint.confidence = "not a float"

--- a/tests/unittests/test_messages/test_lines_msg.py
+++ b/tests/unittests/test_messages/test_lines_msg.py
@@ -45,8 +45,19 @@ def test_line_set_confidence(line: Line):
     line.confidence = 0.9
     assert line.confidence == 0.9
 
+    line.confidence = 1.05
+    assert line.confidence == 1.0
+    assert isinstance(line.confidence, float)
+
+    line.confidence = -0.05
+    assert line.confidence == 0.0
+    assert isinstance(line.confidence, float)
+
     with pytest.raises(TypeError):
         line.confidence = "not a float"
+
+    with pytest.raises(ValueError):
+        line.confidence = 1.5
 
 
 def test_lines_initialization(lines: Lines):


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
A special case happens in confidence setter when confidence is above 1 and below 1.1. It clips the confidence to min(0, max(1, conf)) which can later throw an error as 0 and 1 are not floats.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable