### PR TITLE
Parser optimizations.

### DIFF
--- a/depthai_nodes/node/parsers/scrfd.py
+++ b/depthai_nodes/node/parsers/scrfd.py
@@ -6,7 +6,7 @@ import numpy as np
 from depthai_nodes.message.creators import create_detection_message
 from depthai_nodes.node.parsers.detection import DetectionParser
 from depthai_nodes.node.parsers.utils import xyxy_to_xywh
-from depthai_nodes.node.parsers.utils.scrfd import decode_scrfd
+from depthai_nodes.node.parsers.utils.scrfd import compute_anchor_centers, decode_scrfd
 
 
 class SCRFDParser(DetectionParser):
@@ -72,7 +72,7 @@ class SCRFDParser(DetectionParser):
         self.num_anchors = num_anchors
         self.input_size = input_size
         self.label_names = ["Face"]
-        self._cached_anchors = self.compute_anchor_centers(
+        self._cached_anchors = compute_anchor_centers(
             self.feat_stride_fpn, self.input_size, self.num_anchors
         )
         self._logger.debug(
@@ -158,7 +158,7 @@ class SCRFDParser(DetectionParser):
         self.output_layer_names = output_layers
         self.feat_stride_fpn = head_config.get("feat_stride_fpn", self.feat_stride_fpn)
         self.num_anchors = head_config.get("num_anchors", self.num_anchors)
-        self._cached_anchors = self.compute_anchor_centers(
+        self._cached_anchors = compute_anchor_centers(
             self.feat_stride_fpn, self.input_size, self.num_anchors
         )
 
@@ -263,33 +263,3 @@ class SCRFDParser(DetectionParser):
             self.out.send(message)
 
             self._logger.debug("Detection message sent successfully")
-
-    def compute_anchor_centers(
-        self, strides: List[int], input_size: Tuple[int, int], num_anchors: int
-    ) -> Dict[int, np.ndarray]:
-        """Compute the anchor centers for a given list of strides, input size, and
-        number of anchors.
-
-        @param strides: List of strides.
-        @type strides: List[int]
-        @param input_size: Input size.
-        @type input_size: Tuple[int, int]
-        @param num_anchors: Number of anchors.
-        @type num_anchors: int
-        @return: Dictionary of anchor centers.
-        @rtype: Dict[int, np.ndarray]
-        """
-        anchor_centers_dict = {}
-        for stride in strides:
-            height = input_size[0] // stride
-            width = input_size[1] // stride
-            anchor_centers = np.stack(np.mgrid[:height, :width][::-1], axis=-1).astype(
-                np.float32
-            )
-            anchor_centers = (anchor_centers * stride).reshape((-1, 2))
-            if num_anchors > 1:
-                anchor_centers = np.stack(
-                    [anchor_centers] * num_anchors, axis=1
-                ).reshape((-1, 2))
-            anchor_centers_dict[stride] = anchor_centers
-        return anchor_centers_dict

--- a/depthai_nodes/node/parsers/utils/fastsam.py
+++ b/depthai_nodes/node/parsers/utils/fastsam.py
@@ -5,8 +5,7 @@ import numpy as np
 
 from depthai_nodes.node.parsers.utils import sigmoid
 from depthai_nodes.node.parsers.utils.yolo import (
-    non_max_suppression,
-    parse_yolo_outputs,
+    decode_yolo_output,
 )
 
 
@@ -249,16 +248,13 @@ def decode_fastsam_output(
     @return: NMS output
     @rtype: np.ndarray
     """
-    output = parse_yolo_outputs(
-        outputs=outputs, strides=strides, num_outputs=6, anchors=anchors, kpts=None
-    )
-    output_nms = non_max_suppression(
-        output,
+    output_nms = decode_yolo_output(
+        yolo_outputs=outputs,
+        strides=strides,
+        anchors=anchors,
+        kpts=None,
         conf_thres=conf_thres,
-        iou_thres=iou_thres,
-        num_classes=num_classes,
-        kpts_mode=False,
-    )[0]
+    )
 
     full_box = np.zeros(output_nms.shape[1])
     full_box[2], full_box[3], full_box[4], full_box[6:] = (

--- a/depthai_nodes/node/parsers/utils/fastsam.py
+++ b/depthai_nodes/node/parsers/utils/fastsam.py
@@ -254,6 +254,8 @@ def decode_fastsam_output(
         anchors=anchors,
         kpts=None,
         conf_thres=conf_thres,
+        iou_thres=iou_thres,
+        num_classes=num_classes,
     )
 
     full_box = np.zeros(output_nms.shape[1])

--- a/depthai_nodes/node/parsers/utils/medipipe.py
+++ b/depthai_nodes/node/parsers/utils/medipipe.py
@@ -378,9 +378,8 @@ def normalize_radians(angle):
     return angle - 2 * math.pi * math.floor((angle + math.pi) / (2 * math.pi))
 
 
-def generate_anchors_and_decode(bboxes, scores, threshold=0.5, scale=192):
+def decode(bboxes, scores, anchors, threshold=0.5, scale=192):
     """Generate anchors and decode bounding boxes for mediapipe hand detection model."""
-    anchors = generate_handtracker_anchors(scale, scale)
     decoded_bboxes = decode_bboxes(threshold, scores, bboxes, anchors, scale=scale)
     detections_to_rect(decoded_bboxes)
     rect_transformation(decoded_bboxes, scale, scale, no_shift=True)

--- a/depthai_nodes/node/parsers/utils/ppdet.py
+++ b/depthai_nodes/node/parsers/utils/ppdet.py
@@ -101,91 +101,6 @@ def _unclip(
     return box
 
 
-# def parse_paddle_detection_outputs(
-#     predictions: np.ndarray,
-#     mask_threshold: float = 0.25,
-#     bbox_threshold: float = 0.5,
-#     max_detections: int = 100,
-#     width: Optional[int] = None,
-#     height: Optional[int] = None,
-# ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-#     """Parse the output of a PaddlePaddle Text Detection model from a mask of text
-#     probabilities into rotated bounding boxes with additional corners saved as
-#     keypoints.
-
-#     @param predictions: The output of a PaddlePaddle Text Detection model.
-#     @type predictions: np.ndarray
-#     @param mask_threshold: The threshold for the mask.
-#     @type mask_threshold: float
-#     @param bbox_threshold: The threshold for bounding boxes.
-#     @type bbox_threshold: float
-#     @param max_detections: The maximum number of candidate bounding boxes.
-#     @type max_detections: int
-#     @return: A touple containing the rotated bounding boxes, corners and scores.
-#     @rtype: Touple[np.ndarray, np.ndarray, np.ndarray]
-#     """
-
-#     if len(predictions.shape) == 4:
-#         if predictions.shape[0] == 1 and predictions.shape[1] == 1:
-#             predictions = predictions[0, 0]
-#         elif predictions.shape[0] == 1 and predictions.shape[3] == 1:
-#             predictions = predictions[0, :, :, 0]
-#         else:
-#             raise ValueError(
-#                 f"Predictions should be either (1, 1, H, W) or (1, H, W, 1), got {predictions.shape}."
-#             )
-#     else:
-#         raise ValueError(
-#             f"Predictions should be 4D array of shape (1, 1, H, W) or (1, H, W, 1), got {predictions.shape}."
-#         )
-
-#     mask = predictions > mask_threshold
-#     kernel = np.ones((5, 5), np.uint8)
-#     mask = cv2.dilate(mask.astype(np.uint8), kernel, iterations=1)
-
-#     outs = cv2.findContours(
-#         (mask * 255).astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE
-#     )
-
-#     if len(outs) == 3:
-#         _, contours, _ = outs[0], outs[1], outs[2]
-#     elif len(outs) == 2:
-#         contours, _ = outs[0], outs[1]
-#     contours = sorted(contours, key=cv2.contourArea, reverse=True)
-
-#     num_contours = min(len(contours), max_detections)
-
-#     boxes = []
-#     scores = []
-#     angles = []
-#     for contour in contours[:num_contours]:
-#         box, corners = _get_mini_boxes(contour)
-#         if min(box[2], box[3]) < 8:
-#             continue
-
-#         score = _box_score(predictions, corners.reshape(-1, 2))
-#         if score < bbox_threshold:
-#             continue
-
-#         box = _unclip(box)
-#         boxes.append(box[:4])
-#         scores.append(score)
-#         angles.append(box[4])
-
-#     boxes = np.array(boxes)
-#     if boxes.size > 0:
-#         boxes[:, 0] /= width
-#         boxes[:, 1] /= height
-#         boxes[:, 2] /= width
-#         boxes[:, 3] /= height
-
-#     boxes = np.clip(boxes, 0.0, 1.0)
-#     angles = np.array(angles)
-#     angles = np.round(angles, 0)
-
-#     return boxes, angles, np.array(scores)
-
-
 def parse_paddle_detection_outputs(
     predictions: np.ndarray,
     mask_threshold: float = 0.25,
@@ -206,6 +121,10 @@ def parse_paddle_detection_outputs(
     @type bbox_threshold: float
     @param max_detections: The maximum number of candidate bounding boxes.
     @type max_detections: int
+    @param width: The width of the image.
+    @type width: Optional[int]
+    @param height: The height of the image.
+    @type height: Optional[int]
     @return: A touple containing the rotated bounding boxes, corners and scores.
     @rtype: Touple[np.ndarray, np.ndarray, np.ndarray]
     """
@@ -230,13 +149,9 @@ def parse_paddle_detection_outputs(
     if height is None:
         height = H
 
-    # Binary mask, already np.uint8
     mask = (predictions > mask_threshold).astype(np.uint8)
-    mask = cv2.dilate(
-        mask, np.ones((3, 3), np.uint8), iterations=1
-    )  # Smaller kernel is usually enough
+    mask = cv2.dilate(mask, np.ones((3, 3), np.uint8), iterations=1)
 
-    # Find contours - OpenCV 3/4 API compatibility
     contours, _ = cv2.findContours(mask, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
     # Pre-filter small contours (skip sorting all small blobs)
     contours = [c for c in contours if cv2.contourArea(c) > 8]
@@ -246,7 +161,6 @@ def parse_paddle_detection_outputs(
         contour_areas = np.array([cv2.contourArea(c) for c in contours])
         top_indices = np.argpartition(-contour_areas, max_detections)[:max_detections]
         contours = [contours[i] for i in top_indices]
-    # else just use all
 
     boxes, angles, scores = [], [], []
     for contour in contours:
@@ -257,7 +171,6 @@ def parse_paddle_detection_outputs(
         if score < bbox_threshold:
             continue
         box = _unclip(box)
-        # Save (x, y, w, h)
         boxes.append([box[0] / width, box[1] / height, box[2] / width, box[3] / height])
         angles.append(round(box[4], 0))
         scores.append(score)

--- a/depthai_nodes/node/parsers/utils/ppdet.py
+++ b/depthai_nodes/node/parsers/utils/ppdet.py
@@ -143,12 +143,6 @@ def parse_paddle_detection_outputs(
             f"Predictions should be 4D array of shape (1, 1, H, W) or (1, H, W, 1), got {predictions.shape}."
         )
 
-    H, W = predictions.shape
-    if width is None:
-        width = W
-    if height is None:
-        height = H
-
     mask = (predictions > mask_threshold).astype(np.uint8)
     mask = cv2.dilate(mask, np.ones((3, 3), np.uint8), iterations=1)
 

--- a/depthai_nodes/node/parsers/utils/scrfd.py
+++ b/depthai_nodes/node/parsers/utils/scrfd.py
@@ -1,6 +1,39 @@
+from typing import Dict, List, Tuple
+
 import numpy as np
 
 from depthai_nodes.node.parsers.utils.nms import nms
+
+
+def compute_anchor_centers(
+    strides: List[int], input_size: Tuple[int, int], num_anchors: int
+) -> Dict[int, np.ndarray]:
+    """Compute the anchor centers for a given list of strides, input size, and number of
+    anchors.
+
+    @param strides: List of strides.
+    @type strides: List[int]
+    @param input_size: Input size.
+    @type input_size: Tuple[int, int]
+    @param num_anchors: Number of anchors.
+    @type num_anchors: int
+    @return: Dictionary of anchor centers.
+    @rtype: Dict[int, np.ndarray]
+    """
+    anchor_centers_dict = {}
+    for stride in strides:
+        height = input_size[0] // stride
+        width = input_size[1] // stride
+        anchor_centers = np.stack(np.mgrid[:height, :width][::-1], axis=-1).astype(
+            np.float32
+        )
+        anchor_centers = (anchor_centers * stride).reshape((-1, 2))
+        if num_anchors > 1:
+            anchor_centers = np.stack([anchor_centers] * num_anchors, axis=1).reshape(
+                (-1, 2)
+            )
+        anchor_centers_dict[stride] = anchor_centers
+    return anchor_centers_dict
 
 
 def distance2bbox(points, distance, max_shape=None):

--- a/depthai_nodes/node/parsers/utils/scrfd.py
+++ b/depthai_nodes/node/parsers/utils/scrfd.py
@@ -62,6 +62,7 @@ def decode_scrfd(
     num_anchors,
     score_threshold,
     nms_threshold,
+    anchors,
 ):
     """Decode the detection results of SCRFD.
 
@@ -81,6 +82,8 @@ def decode_scrfd(
     @type score_threshold: float
     @param nms_threshold: Non-maximum suppression threshold.
     @type nms_threshold: float
+    @param anchors: Dictionary of anchors.
+    @type anchors: dict[int, np.ndarray]
     @return: Bounding boxes, confidence scores, and keypoints of detected objects.
     @rtype: tuple[np.ndarray, np.ndarray, np.ndarray]
     """
@@ -96,14 +99,7 @@ def decode_scrfd(
         height = input_size[0] // stride
         width = input_size[1] // stride
 
-        anchor_centers = np.stack(np.mgrid[:height, :width][::-1], axis=-1).astype(
-            np.float32
-        )
-        anchor_centers = (anchor_centers * stride).reshape((-1, 2))
-        if num_anchors > 1:
-            anchor_centers = np.stack([anchor_centers] * num_anchors, axis=1).reshape(
-                (-1, 2)
-            )
+        anchor_centers = anchors[stride]
 
         pos_inds = np.where(scores >= score_threshold)[0]
         bboxes = distance2bbox(anchor_centers, bbox_preds)

--- a/depthai_nodes/node/parsers/utils/xfeat.py
+++ b/depthai_nodes/node/parsers/utils/xfeat.py
@@ -222,6 +222,8 @@ def detect_and_compute(
     @type feats: np.ndarray
     @param kpts: Keypoints.
     @type kpts: np.ndarray
+    @param heatmaps: Heatmaps.
+    @type heatmaps: np.ndarray
     @param resize_rate_w: Resize rate for width.
     @type resize_rate_w: float
     @param resize_rate_h: Resize rate for height.

--- a/depthai_nodes/node/parsers/utils/yunet.py
+++ b/depthai_nodes/node/parsers/utils/yunet.py
@@ -1,6 +1,4 @@
-from itertools import (
-    product,  # NOTE: you can use manual_product function instead of itertools.product
-)
+from itertools import product
 from typing import List, Optional, Tuple
 
 import numpy as np


### PR DESCRIPTION
## Purpose
Some of the parsers are not the optimal.

## Specification
- `YuNetParser` - cached anchors,  unnecessary np.where (replaced with np.clip), general vectorization
- `YOLOExtendedParser` - decoding speed up and pre-filtering before the NMS
- `PPDetParser` - 1. Dilation kernel reduced: Faster, less small blobs, 2. Small areas filtered before sorting: Reduces number of contours to sort/loop. 3. Top-N selection uses np.argpartition: O(N) not O(N log N) as with full sort. 4. Direct construction of output arrays: Minimizes list->array conversion overhead. 5. Less shape shuffling, no unnecessary np.reshape.
- `MLSDParser` - Explicit python loop removed and replaced with numpy; usage of batched gather
- `SCRFDParser` - Caching anchors
- `MPPalmDetectionParser` - Caching anchor
- `FastSAMParser` - yolo part decoding speed up

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable