### PR TITLE
E2E tests: Add option to select only one platform.

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -26,6 +26,10 @@ on:
         description: 'Version of depthai to install. Default: 3.0.0rc3'
         required: true
         default: '3.0.0rc3'
+      platform:
+        description: 'Platform to use for testing. By default both RVC2 and RVC4 are used but you can use only one by passing only `rvc2` or `rvc4`(use lowercase).'
+        default: "all"
+        required: false
   push:
     branches:
       - main
@@ -47,7 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [rvc2, rvc4]
+        platform: ${{ fromJSON(github.event_name == 'workflow_dispatch' && (github.event.inputs.platform == 'all' && '["rvc2", "rvc4"]' || format('["{0}"]', github.event.inputs.platform)) || '["rvc2", "rvc4"]') }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Purpose
We have static matrix with [rvc2, rvc4], so if we want to run only one platform two jobs are picked up and both performing the same job.

## Specification
Adding parameter to select both, rvc2, rvc4 option and then dynamically creating matrix for it. It fixes BOM tests.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable