### PR TITLE
Apply objectness-based filtering only when real objectness scores are present

### DIFF
--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -393,7 +393,7 @@ def decode_yolo_output(
 
     # 2. Concatenate all kept candidates at once
     output = np.concatenate(filtered_outputs, axis=0)
-    if not np.all(output[:, 4] == np.max(output[:, 4])) and output.shape[0] > max_nms:
+    if not np.unique(output[:, 4]).size == 1 and output.shape[0] > max_nms:
         idx = np.argsort(output[:, 4])[::-1][:max_nms]  # sort by objectness
         output = output[idx]
 

--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -393,7 +393,7 @@ def decode_yolo_output(
 
     # 2. Concatenate all kept candidates at once
     output = np.concatenate(filtered_outputs, axis=0)
-    if output.shape[0] > max_nms:
+    if not np.all(output[:, 4] == np.max(output[:, 4])) and output.shape[0] > max_nms:
         idx = np.argsort(output[:, 4])[::-1][:max_nms]  # sort by objectness
         output = output[idx]
 


### PR DESCRIPTION
## Purpose
In some YOLO variants the “objectness” score is not meaningful (e.g. all ones). Filtering by objectness before non-maximum suppression can therefore discard valid, high-confidence detections. This change ensures we only apply objectness-based filtering when the model actually produces different objectness scores.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->

- Only if not all objectness values are identical and the total number of detections exceeds `max_nms` do we sort and trim by objectness.
- Otherwise we fall back to the previous behavior of applying NMS on all detections regardless of objectness.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable