### PR TITLE
Fix: Add transformations to ApplyColormap node

### DIFF
--- a/depthai_nodes/message/map.py
+++ b/depthai_nodes/message/map.py
@@ -123,6 +123,14 @@ class Map2D(dai.Buffer):
         """
         self.transformation = transformation
 
+    def getTransformation(self) -> dai.ImgTransformation:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self.transformation
+
     def getVisualizationMessage(self) -> dai.ImgFrame:
         """Returns default visualization message for 2D maps in the form of a
         colormapped image."""

--- a/depthai_nodes/message/segmentation.py
+++ b/depthai_nodes/message/segmentation.py
@@ -104,6 +104,14 @@ class SegmentationMask(dai.Buffer):
         """
         self.transformation = transformation
 
+    def getTransformation(self) -> dai.ImgTransformation:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self.transformation
+
     def getVisualizationMessage(self) -> dai.ImgFrame:
         """Returns the default visualization message for segmentation masks."""
         img_frame = dai.ImgFrame()

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -160,8 +160,11 @@ class ApplyColormap(BaseHostNode):
             color_arr,
             self._img_frame_type,
         )
+
         frame.setTimestamp(msg.getTimestamp())
         frame.setSequenceNum(msg.getSequenceNum())
+        frame.setTransformation(msg.getTransformation())
+        frame.setTimestampDevice(msg.getTimestampDevice())
 
         self._logger.debug("ImgFrame message created")
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
ApplyColormap node did not propagate image transformations from its input to the output. This could cause crashes and wrong behaviour in other (depthai) nodes that rely on transformation.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable