### PR TITLE
FIX: Add checks if ImgTransformations is None + propagate device timestamp

### DIFF
--- a/depthai_nodes/message/classification.py
+++ b/depthai_nodes/message/classification.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List
+from typing import List, Optional
 
 import depthai as dai
 import numpy as np
@@ -27,7 +27,7 @@ class Classifications(dai.Buffer):
         dai.Buffer.__init__(self)
         self._classes: List[str] = []
         self._scores: NDArray[np.float32] = np.array([])
-        self._transformation: dai.ImgTransformation | None = None
+        self._transformation: Optional[dai.ImgTransformation] = None
 
     def copy(self):
         """Creates a new instance of the Classifications class and copies the
@@ -116,7 +116,7 @@ class Classifications(dai.Buffer):
         return self._scores[0]
 
     @property
-    def transformation(self) -> dai.ImgTransformation | None:
+    def transformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -125,7 +125,7 @@ class Classifications(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation | None):
+    def transformation(self, value: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -134,13 +134,13 @@ class Classifications(dai.Buffer):
         """
 
         if value is not None:
-            if not isinstance(value, dai.ImgTransformation | None):
+            if not isinstance(value, dai.ImgTransformation):
                 raise TypeError(
                     f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation | None):
+    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -149,7 +149,7 @@ class Classifications(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation | None:
+    def getTransformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/classification.py
+++ b/depthai_nodes/message/classification.py
@@ -27,7 +27,7 @@ class Classifications(dai.Buffer):
         dai.Buffer.__init__(self)
         self._classes: List[str] = []
         self._scores: NDArray[np.float32] = np.array([])
-        self._transformation: dai.ImgTransformation = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Classifications class and copies the
@@ -116,7 +116,7 @@ class Classifications(dai.Buffer):
         return self._scores[0]
 
     @property
-    def transformation(self) -> dai.ImgTransformation:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -125,7 +125,7 @@ class Classifications(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -134,13 +134,13 @@ class Classifications(dai.Buffer):
         """
 
         if value is not None:
-            if not isinstance(value, dai.ImgTransformation):
+            if not isinstance(value, dai.ImgTransformation | None):
                 raise TypeError(
                     f"Transformation must be a dai.ImgTransformation object, instead got {type(value)}."
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -149,12 +149,23 @@ class Classifications(dai.Buffer):
         """
         self.transformation = transformation
 
+    def getTransformation(self) -> dai.ImgTransformation | None:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self.transformation
+
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Returns default visualization message for classification.
 
         The message adds the top five classes and their scores to the right side of the
         image.
         """
+        if self.transformation is None:
+            raise ValueError("Transformation must be set to get visualization message.")
+
         w, h = self.transformation.getSize()
         annotation_sizes = AnnotationSizes(w, h)
         x_offset = 2 / w

--- a/depthai_nodes/message/clusters.py
+++ b/depthai_nodes/message/clusters.py
@@ -99,7 +99,7 @@ class Clusters(dai.Buffer):
         """Initializes the Clusters object."""
         super().__init__()
         self._clusters: List[Cluster] = []
-        self._transformation: dai.ImgTransformation = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Clusters class and copies the attributes.
@@ -140,7 +140,7 @@ class Clusters(dai.Buffer):
         self._clusters = value
 
     @property
-    def transformation(self) -> dai.ImgTransformation:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -149,7 +149,7 @@ class Clusters(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -164,7 +164,7 @@ class Clusters(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -172,6 +172,14 @@ class Clusters(dai.Buffer):
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
         self.transformation = transformation
+
+    def getTransformation(self) -> dai.ImgTransformation | None:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self.transformation
 
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Creates a default visualization message for clusters and colors each one
@@ -198,4 +206,6 @@ class Clusters(dai.Buffer):
 
         img_annotations.annotations.append(annotation)
         img_annotations.setTimestamp(self.getTimestamp())
+        img_annotations.setSequenceNum(self.getSequenceNum())
+        img_annotations.setTimestampDevice(self.getTimestampDevice())
         return img_annotations

--- a/depthai_nodes/message/clusters.py
+++ b/depthai_nodes/message/clusters.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List
+from typing import List, Optional
 
 import cv2
 import depthai as dai
@@ -99,7 +99,7 @@ class Clusters(dai.Buffer):
         """Initializes the Clusters object."""
         super().__init__()
         self._clusters: List[Cluster] = []
-        self._transformation: dai.ImgTransformation | None = None
+        self._transformation: Optional[dai.ImgTransformation] = None
 
     def copy(self):
         """Creates a new instance of the Clusters class and copies the attributes.
@@ -140,7 +140,7 @@ class Clusters(dai.Buffer):
         self._clusters = value
 
     @property
-    def transformation(self) -> dai.ImgTransformation | None:
+    def transformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -149,7 +149,7 @@ class Clusters(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation | None):
+    def transformation(self, value: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -164,7 +164,7 @@ class Clusters(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation | None):
+    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -173,7 +173,7 @@ class Clusters(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation | None:
+    def getTransformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import depthai as dai
 import numpy as np
@@ -207,7 +207,7 @@ class ImgDetectionsExtended(dai.Buffer):
         super().__init__()
         self._detections: List[ImgDetectionExtended] = []
         self._masks: SegmentationMask = SegmentationMask()
-        self._transformation: dai.ImgTransformation | None = None
+        self._transformation: Optional[dai.ImgTransformation] = None
 
     def copy(self):
         """Creates a new instance of the ImgDetectionsExtended class and copies the
@@ -287,7 +287,7 @@ class ImgDetectionsExtended(dai.Buffer):
             raise TypeError("Mask must be a numpy array or a SegmentationMask object.")
 
     @property
-    def transformation(self) -> dai.ImgTransformation | None:
+    def transformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -296,7 +296,7 @@ class ImgDetectionsExtended(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation | None):
+    def transformation(self, value: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -310,7 +310,7 @@ class ImgDetectionsExtended(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation | None):
+    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -321,7 +321,7 @@ class ImgDetectionsExtended(dai.Buffer):
             assert isinstance(transformation, dai.ImgTransformation)
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation | None:
+    def getTransformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/img_detections.py
+++ b/depthai_nodes/message/img_detections.py
@@ -207,7 +207,7 @@ class ImgDetectionsExtended(dai.Buffer):
         super().__init__()
         self._detections: List[ImgDetectionExtended] = []
         self._masks: SegmentationMask = SegmentationMask()
-        self._transformation: dai.ImgTransformation = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the ImgDetectionsExtended class and copies the
@@ -219,7 +219,6 @@ class ImgDetectionsExtended(dai.Buffer):
         new_obj = ImgDetectionsExtended()
         new_obj.detections = [det.copy() for det in self.detections]
         new_obj.masks = self._masks.copy()
-        new_obj.transformation = self.transformation
         new_obj.setSequenceNum(self.getSequenceNum())
         new_obj.setTimestamp(self.getTimestamp())
         new_obj.setTimestampDevice(self.getTimestampDevice())
@@ -288,7 +287,7 @@ class ImgDetectionsExtended(dai.Buffer):
             raise TypeError("Mask must be a numpy array or a SegmentationMask object.")
 
     @property
-    def transformation(self) -> dai.ImgTransformation:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -297,7 +296,7 @@ class ImgDetectionsExtended(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -311,7 +310,7 @@ class ImgDetectionsExtended(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -322,7 +321,7 @@ class ImgDetectionsExtended(dai.Buffer):
             assert isinstance(transformation, dai.ImgTransformation)
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -331,6 +330,9 @@ class ImgDetectionsExtended(dai.Buffer):
         return self.transformation
 
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
+        if self.transformation is None:
+            raise ValueError("Transformation must be set to get visualization message.")
+
         w, h = self.transformation.getSize()
         annotation_builder = AnnotationHelper()
         detection_drawer = DetectionDrawer(annotation_builder, (w, h))

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -187,7 +187,7 @@ class Keypoints(dai.Buffer):
         super().__init__()
         self._keypoints: List[Keypoint] = []
         self._edges: List[Tuple[int, int]] = []
-        self._transformation: dai.ImgTransformation = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Keypoints class and copies the attributes.
@@ -258,7 +258,7 @@ class Keypoints(dai.Buffer):
         self._edges = value
 
     @property
-    def transformation(self) -> dai.ImgTransformation:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -267,7 +267,7 @@ class Keypoints(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -282,7 +282,7 @@ class Keypoints(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -290,6 +290,14 @@ class Keypoints(dai.Buffer):
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
         self.transformation = transformation
+
+    def getTransformation(self) -> dai.ImgTransformation | None:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self.transformation
 
     def getPoints2f(self) -> dai.VectorPoint2f:
         """Returns the keypoints in the form of a dai.VectorPoint2f object."""

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import depthai as dai
 
@@ -187,7 +187,7 @@ class Keypoints(dai.Buffer):
         super().__init__()
         self._keypoints: List[Keypoint] = []
         self._edges: List[Tuple[int, int]] = []
-        self._transformation: dai.ImgTransformation | None = None
+        self._transformation: Optional[dai.ImgTransformation] = None
 
     def copy(self):
         """Creates a new instance of the Keypoints class and copies the attributes.
@@ -258,7 +258,7 @@ class Keypoints(dai.Buffer):
         self._edges = value
 
     @property
-    def transformation(self) -> dai.ImgTransformation | None:
+    def transformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -267,7 +267,7 @@ class Keypoints(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation | None):
+    def transformation(self, value: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -282,7 +282,7 @@ class Keypoints(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation | None):
+    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -291,7 +291,7 @@ class Keypoints(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation | None:
+    def getTransformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/lines.py
+++ b/depthai_nodes/message/lines.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List
+from typing import List, Optional
 
 import depthai as dai
 
@@ -135,7 +135,7 @@ class Lines(dai.Buffer):
         """Initializes the Lines object."""
         super().__init__()
         self._lines: List[Line] = []
-        self._transformation: dai.ImgTransformation | None = None
+        self._transformation: Optional[dai.ImgTransformation] = None
 
     def copy(self):
         """Creates a new instance of the Lines class and copies the attributes.
@@ -176,7 +176,7 @@ class Lines(dai.Buffer):
         self._lines = value
 
     @property
-    def transformation(self) -> dai.ImgTransformation | None:
+    def transformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -185,7 +185,7 @@ class Lines(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation | None):
+    def transformation(self, value: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -200,7 +200,7 @@ class Lines(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation | None):
+    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -208,6 +208,14 @@ class Lines(dai.Buffer):
         @raise TypeError: If value is not a dai.ImgTransformation object.
         """
         self.transformation = transformation
+
+    def getTransformation(self) -> Optional[dai.ImgTransformation]:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self._transformation
 
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Returns default visualization message for lines.

--- a/depthai_nodes/message/lines.py
+++ b/depthai_nodes/message/lines.py
@@ -135,7 +135,7 @@ class Lines(dai.Buffer):
         """Initializes the Lines object."""
         super().__init__()
         self._lines: List[Line] = []
-        self._transformation: dai.ImgTransformation = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Lines class and copies the attributes.
@@ -176,7 +176,7 @@ class Lines(dai.Buffer):
         self._lines = value
 
     @property
-    def transformation(self) -> dai.ImgTransformation:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -185,7 +185,7 @@ class Lines(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -200,7 +200,7 @@ class Lines(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.

--- a/depthai_nodes/message/map.py
+++ b/depthai_nodes/message/map.py
@@ -123,6 +123,14 @@ class Map2D(dai.Buffer):
         """
         self.transformation = transformation
 
+    def getTransformation(self) -> dai.ImgTransformation:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self.transformation
+
     def getVisualizationMessage(self) -> dai.ImgFrame:
         """Returns default visualization message for 2D maps in the form of a
         colormapped image."""

--- a/depthai_nodes/message/map.py
+++ b/depthai_nodes/message/map.py
@@ -27,7 +27,7 @@ class Map2D(dai.Buffer):
         self._map: NDArray[np.float32] = np.array([])
         self._width: int = None
         self._height: int = None
-        self._transformation: dai.ImgTransformation = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Map2D class and copies the attributes.
@@ -90,7 +90,7 @@ class Map2D(dai.Buffer):
         return self._height
 
     @property
-    def transformation(self) -> dai.ImgTransformation:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -99,7 +99,7 @@ class Map2D(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -123,7 +123,7 @@ class Map2D(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -137,8 +137,9 @@ class Map2D(dai.Buffer):
         img_frame = dai.ImgFrame()
         img_frame.setTimestamp(self.getTimestamp())
         img_frame.setTimestampDevice(self.getTimestampDevice())
-        img_frame.setTransformation(self.transformation)
         img_frame.setSequenceNum(self.getSequenceNum())
+        if self.transformation is not None:
+            img_frame.setTransformation(self.transformation)
         mask = self._map.copy()
         if np.any(mask < 1):
             mask = mask * 255

--- a/depthai_nodes/message/map.py
+++ b/depthai_nodes/message/map.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Optional
 
 import cv2
 import depthai as dai
@@ -27,7 +28,7 @@ class Map2D(dai.Buffer):
         self._map: NDArray[np.float32] = np.array([])
         self._width: int = None
         self._height: int = None
-        self._transformation: dai.ImgTransformation | None = None
+        self._transformation: Optional[dai.ImgTransformation] = None
 
     def copy(self):
         """Creates a new instance of the Map2D class and copies the attributes.
@@ -90,7 +91,7 @@ class Map2D(dai.Buffer):
         return self._height
 
     @property
-    def transformation(self) -> dai.ImgTransformation | None:
+    def transformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -99,7 +100,7 @@ class Map2D(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation | None):
+    def transformation(self, value: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -123,7 +124,7 @@ class Map2D(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation | None:
+    def getTransformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/prediction.py
+++ b/depthai_nodes/message/prediction.py
@@ -70,7 +70,7 @@ class Predictions(dai.Buffer):
         """Initializes the Predictions object."""
         super().__init__()
         self._predictions: List[Prediction] = []
-        self._transformation: dai.ImgTransformation = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Predictions class and copies the attributes.
@@ -122,7 +122,7 @@ class Predictions(dai.Buffer):
         return self._predictions[0].prediction
 
     @property
-    def transformation(self) -> dai.ImgTransformation:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -131,7 +131,7 @@ class Predictions(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -146,7 +146,7 @@ class Predictions(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -155,11 +155,21 @@ class Predictions(dai.Buffer):
         """
         self.transformation = transformation
 
+    def getTransformation(self) -> dai.ImgTransformation | None:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self.transformation
+
     def getVisualizationMessage(self) -> dai.ImgAnnotations:
         """Returns the visualization message for the predictions.
 
         The message adds text representing the predictions to the right of the image.
         """
+        if self.transformation is None:
+            raise ValueError("Transformation must be set to get visualization message.")
         w, h = self.transformation.getSize()
         annotation_helper = AnnotationHelper()
         annotation_sizes = AnnotationSizes(w, h)

--- a/depthai_nodes/message/prediction.py
+++ b/depthai_nodes/message/prediction.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List
+from typing import List, Optional
 
 import depthai as dai
 
@@ -70,7 +70,7 @@ class Predictions(dai.Buffer):
         """Initializes the Predictions object."""
         super().__init__()
         self._predictions: List[Prediction] = []
-        self._transformation: dai.ImgTransformation | None = None
+        self._transformation: Optional[dai.ImgTransformation] = None
 
     def copy(self):
         """Creates a new instance of the Predictions class and copies the attributes.
@@ -122,7 +122,7 @@ class Predictions(dai.Buffer):
         return self._predictions[0].prediction
 
     @property
-    def transformation(self) -> dai.ImgTransformation | None:
+    def transformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -131,7 +131,7 @@ class Predictions(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation | None):
+    def transformation(self, value: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -146,7 +146,7 @@ class Predictions(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation | None):
+    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -155,7 +155,7 @@ class Predictions(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation | None:
+    def getTransformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/segmentation.py
+++ b/depthai_nodes/message/segmentation.py
@@ -23,7 +23,7 @@ class SegmentationMask(dai.Buffer):
         """Initializes the SegmentationMask object."""
         super().__init__()
         self._mask: NDArray[np.int16] = np.empty(0, dtype=np.int16)
-        self._transformation: dai.ImgTransformation = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the SegmentationMask class and copies the
@@ -37,7 +37,7 @@ class SegmentationMask(dai.Buffer):
         new_obj.setSequenceNum(self.getSequenceNum())
         new_obj.setTimestamp(self.getTimestamp())
         new_obj.setTimestampDevice(self.getTimestampDevice())
-        new_obj.setTransformation(self.transformation)
+        new_obj.setTransformation(self.getTransformation())
         return new_obj
 
     @property
@@ -71,7 +71,7 @@ class SegmentationMask(dai.Buffer):
         self._mask = value
 
     @property
-    def transformation(self) -> dai.ImgTransformation:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -80,7 +80,7 @@ class SegmentationMask(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -95,7 +95,7 @@ class SegmentationMask(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -104,7 +104,7 @@ class SegmentationMask(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/segmentation.py
+++ b/depthai_nodes/message/segmentation.py
@@ -104,6 +104,14 @@ class SegmentationMask(dai.Buffer):
         """
         self.transformation = transformation
 
+    def getTransformation(self) -> dai.ImgTransformation:
+        """Returns the Image Transformation object.
+
+        @return: The Image Transformation object.
+        @rtype: dai.ImgTransformation
+        """
+        return self.transformation
+
     def getVisualizationMessage(self) -> dai.ImgFrame:
         """Returns the default visualization message for segmentation masks."""
         img_frame = dai.ImgFrame()

--- a/depthai_nodes/message/segmentation.py
+++ b/depthai_nodes/message/segmentation.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Optional
 
 import cv2
 import depthai as dai
@@ -23,7 +24,7 @@ class SegmentationMask(dai.Buffer):
         """Initializes the SegmentationMask object."""
         super().__init__()
         self._mask: NDArray[np.int16] = np.empty(0, dtype=np.int16)
-        self._transformation: dai.ImgTransformation | None = None
+        self._transformation: Optional[dai.ImgTransformation] = None
 
     def copy(self):
         """Creates a new instance of the SegmentationMask class and copies the
@@ -71,7 +72,7 @@ class SegmentationMask(dai.Buffer):
         self._mask = value
 
     @property
-    def transformation(self) -> dai.ImgTransformation | None:
+    def transformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -80,7 +81,7 @@ class SegmentationMask(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: dai.ImgTransformation | None):
+    def transformation(self, value: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -95,7 +96,7 @@ class SegmentationMask(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: dai.ImgTransformation | None):
+    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -104,7 +105,7 @@ class SegmentationMask(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> dai.ImgTransformation | None:
+    def getTransformation(self) -> Optional[dai.ImgTransformation]:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -160,8 +160,11 @@ class ApplyColormap(BaseHostNode):
             color_arr,
             self._img_frame_type,
         )
+
         frame.setTimestamp(msg.getTimestamp())
         frame.setSequenceNum(msg.getSequenceNum())
+        frame.setTransformation(msg.getTransformation())
+        frame.setTimestampDevice(msg.getTimestampDevice())
 
         self._logger.debug("ImgFrame message created")
 

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -163,8 +163,10 @@ class ApplyColormap(BaseHostNode):
 
         frame.setTimestamp(msg.getTimestamp())
         frame.setSequenceNum(msg.getSequenceNum())
-        frame.setTransformation(msg.getTransformation())
         frame.setTimestampDevice(msg.getTimestampDevice())
+        transformation = msg.getTransformation()
+        if transformation is not None:
+            frame.setTransformation(transformation)
 
         self._logger.debug("ImgFrame message created")
 

--- a/depthai_nodes/node/depth_merger.py
+++ b/depthai_nodes/node/depth_merger.py
@@ -148,6 +148,10 @@ class DepthMerger(BaseHostNode):
         ]
         new_dets.setSequenceNum(detections.getSequenceNum())
         new_dets.setTimestamp(detections.getTimestamp())
+        new_dets.setTimestampDevice(detections.getTimestampDevice())
+        transformation = detections.getTransformation()
+        if transformation is not None:
+            new_dets.setTransformation(transformation)
         return new_dets
 
     def _get_index(self, relative_coord: float, dimension_len: int) -> int:

--- a/depthai_nodes/node/img_detections_bridge.py
+++ b/depthai_nodes/node/img_detections_bridge.py
@@ -101,7 +101,10 @@ class ImgDetectionsBridge(BaseHostNode):
 
         msg_transformed.setTimestamp(msg.getTimestamp())
         msg_transformed.setSequenceNum(msg.getSequenceNum())
-        msg_transformed.setTransformation(msg.getTransformation())
+        msg_transformed.setTimestampDevice(msg.getTimestampDevice())
+        transformation = msg.getTransformation()
+        if transformation is not None:
+            msg_transformed.setTransformation(transformation)
 
         self._logger.debug("Detection message created")
 

--- a/depthai_nodes/node/img_detections_filter.py
+++ b/depthai_nodes/node/img_detections_filter.py
@@ -148,6 +148,14 @@ class ImgDetectionsFilter(BaseHostNode):
         msg_new = copy_message(
             msg
         )  # we don't want to modify the original message as it might be used by other nodes
+        assert isinstance(
+            msg_new,
+            (
+                dai.ImgDetections,
+                ImgDetectionsExtended,
+                dai.SpatialImgDetections,
+            ),
+        )
 
         filtered_detections = []
         for detection in msg.detections:

--- a/depthai_nodes/node/img_frame_overlay.py
+++ b/depthai_nodes/node/img_frame_overlay.py
@@ -99,6 +99,10 @@ class ImgFrameOverlay(BaseHostNode):
         )
         overlay.setTimestamp(frame1.getTimestamp())
         overlay.setSequenceNum(frame1.getSequenceNum())
+        overlay.setTimestampDevice(frame1.getTimestampDevice())
+        transformation = frame1.getTransformation()
+        if transformation is not None:
+            overlay.setTransformation(transformation)
 
         self._logger.debug("ImgFrame message created")
 

--- a/depthai_nodes/node/parsers/classification.py
+++ b/depthai_nodes/node/parsers/classification.py
@@ -152,9 +152,12 @@ class ClassificationParser(BaseParser):
                 scores = softmax(scores)
 
             msg = create_classification_message(self.classes, scores)
-            msg.setTransformation(output.getTransformation())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                msg.setTransformation(transformation)
             msg.setTimestamp(output.getTimestamp())
             msg.setSequenceNum(output.getSequenceNum())
+            msg.setTimestampDevice(output.getTimestampDevice())
 
             self._logger.debug(f"Created message with {len(msg.classes)} classes")
 

--- a/depthai_nodes/node/parsers/classification_sequence.py
+++ b/depthai_nodes/node/parsers/classification_sequence.py
@@ -191,9 +191,12 @@ class ClassificationSequenceParser(ClassificationParser):
                 ignored_indexes=self.ignored_indexes,
                 concatenate_classes=self.concatenate_classes,
             )
-            msg.setTransformation(output.getTransformation())
             msg.setTimestamp(output.getTimestamp())
             msg.setSequenceNum(output.getSequenceNum())
+            msg.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                msg.setTransformation(transformation)
 
             self._logger.debug(f"Created message with {len(msg.classes)} classes")
 

--- a/depthai_nodes/node/parsers/detection.py
+++ b/depthai_nodes/node/parsers/detection.py
@@ -178,9 +178,12 @@ class DetectionParser(BaseParser):
                 scores = np.array([])
 
             message = create_detection_message(bboxes=bboxes, scores=scores)
-            message.transformation = output.getTransformation()
+            transformation = output.getTransformation()
+            if transformation is not None:
+                message.setTransformation(transformation)
             message.setTimestamp(output.getTimestamp())
             message.setSequenceNum(output.getSequenceNum())
+            message.setTimestampDevice(output.getTimestampDevice())
 
             self._logger.debug(f"Created detections message with {len(bboxes)} objects")
             self.out.send(message)

--- a/depthai_nodes/node/parsers/embeddings.py
+++ b/depthai_nodes/node/parsers/embeddings.py
@@ -76,6 +76,11 @@ class EmbeddingsParser(BaseParser):
                 len(output_names) == 1
             ), "Embeddings head should have only one output layer"
             output.setSequenceNum(output.getSequenceNum())
+            output.setTimestamp(output.getTimestamp())
+            output.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                output.setTransformation(transformation)
 
             self.out.send(output)
 

--- a/depthai_nodes/node/parsers/fastsam.py
+++ b/depthai_nodes/node/parsers/fastsam.py
@@ -375,9 +375,12 @@ class FastSAMParser(BaseParser):
             results_masks = merge_masks(results_masks)
 
             segmentation_message = create_segmentation_message(results_masks)
-            segmentation_message.setTransformation(output.getTransformation())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                segmentation_message.setTransformation(transformation)
             segmentation_message.setTimestamp(output.getTimestamp())
             segmentation_message.setSequenceNum(output.getSequenceNum())
+            segmentation_message.setTimestampDevice(output.getTimestampDevice())
 
             self._logger.debug(
                 f"Created segmentation message with {len(results_masks)} masks"

--- a/depthai_nodes/node/parsers/hrnet.py
+++ b/depthai_nodes/node/parsers/hrnet.py
@@ -142,8 +142,11 @@ class HRNetParser(KeypointParser):
                 label_names=self.label_names,
             )
             keypoints_message.setTimestamp(output.getTimestamp())
-            keypoints_message.setTransformation(output.getTransformation())
             keypoints_message.setSequenceNum(output.getSequenceNum())
+            keypoints_message.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                keypoints_message.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created keypoints message with {len(keypoints)} points"

--- a/depthai_nodes/node/parsers/image_output.py
+++ b/depthai_nodes/node/parsers/image_output.py
@@ -133,9 +133,11 @@ class ImageOutputParser(BaseParser):
                 ),
             )
             image_message.setTimestamp(output.getTimestamp())
-            if output.getTransformation():
-                image_message.setTransformation(output.getTransformation())
             image_message.setSequenceNum(output.getSequenceNum())
+            image_message.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                image_message.setTransformation(transformation)
 
             self._logger.debug(f"Created image message with shape {image.shape}")
 

--- a/depthai_nodes/node/parsers/keypoints.py
+++ b/depthai_nodes/node/parsers/keypoints.py
@@ -238,8 +238,11 @@ class KeypointParser(BaseParser):
                 keypoints, edges=self.edges, label_names=self.label_names
             )
             msg.setTimestamp(output.getTimestamp())
-            msg.setTransformation(output.getTransformation())
             msg.setSequenceNum(output.getSequenceNum())
+            msg.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                msg.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created keypoints message with {len(keypoints)} points"

--- a/depthai_nodes/node/parsers/lane_detection.py
+++ b/depthai_nodes/node/parsers/lane_detection.py
@@ -217,8 +217,11 @@ class LaneDetectionParser(BaseParser):
 
             msg = create_cluster_message(points)
             msg.setTimestamp(output.getTimestamp())
-            msg.setTransformation(output.getTransformation())
             msg.setSequenceNum(output.getSequenceNum())
+            msg.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                msg.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created lane detection message with {len(points)} points"

--- a/depthai_nodes/node/parsers/map_output.py
+++ b/depthai_nodes/node/parsers/map_output.py
@@ -118,8 +118,10 @@ class MapOutputParser(BaseParser):
             )
             map_message.setTimestamp(output.getTimestamp())
             map_message.setTimestampDevice(output.getTimestampDevice())
-            map_message.setTransformation(output.getTransformation())
             map_message.setSequenceNum(output.getSequenceNum())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                map_message.setTransformation(transformation)
 
             self._logger.debug("Created Map message.")
 

--- a/depthai_nodes/node/parsers/mediapipe_palm_detection.py
+++ b/depthai_nodes/node/parsers/mediapipe_palm_detection.py
@@ -223,8 +223,11 @@ class MPPalmDetectionParser(DetectionParser):
                 label_names=label_names,
             )
             detections_msg.setTimestamp(output.getTimestamp())
-            detections_msg.setTransformation(output.getTransformation())
             detections_msg.setSequenceNum(output.getSequenceNum())
+            detections_msg.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                detections_msg.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created detection message with {len(bboxes)} detections"

--- a/depthai_nodes/node/parsers/mlsd.py
+++ b/depthai_nodes/node/parsers/mlsd.py
@@ -187,8 +187,11 @@ class MLSDParser(BaseParser):
 
             message = create_line_detection_message(lines, np.array(scores))
             message.setTimestamp(output.getTimestamp())
-            message.setTransformation(output.getTransformation())
             message.setSequenceNum(output.getSequenceNum())
+            message.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                message.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created line detection message with {len(lines)} lines"

--- a/depthai_nodes/node/parsers/ppdet.py
+++ b/depthai_nodes/node/parsers/ppdet.py
@@ -137,8 +137,11 @@ class PPTextDetectionParser(DetectionParser):
                 bboxes=bboxes, scores=scores, angles=angles
             )
             message.setTimestamp(output.getTimestamp())
-            message.setTransformation(output.getTransformation())
             message.setSequenceNum(output.getSequenceNum())
+            message.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                message.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created text detection message with {len(bboxes)} detections"

--- a/depthai_nodes/node/parsers/regression.py
+++ b/depthai_nodes/node/parsers/regression.py
@@ -98,8 +98,11 @@ class RegressionParser(BaseParser):
 
             regression_message = create_regression_message(predictions=predictions)
             regression_message.setTimestamp(output.getTimestamp())
-            regression_message.setTransformation(output.getTransformation())
+            regression_message.setTimestampDevice(output.getTimestampDevice())
             regression_message.setSequenceNum(output.getSequenceNum())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                regression_message.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created regression message with {len(predictions)} values"

--- a/depthai_nodes/node/parsers/scrfd.py
+++ b/depthai_nodes/node/parsers/scrfd.py
@@ -253,8 +253,11 @@ class SCRFDParser(DetectionParser):
                 keypoints=keypoints,
             )
             message.setTimestamp(output.getTimestamp())
-            message.setTransformation(output.getTransformation())
             message.setSequenceNum(output.getSequenceNum())
+            message.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                message.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created detection message with {len(bboxes)} detections"

--- a/depthai_nodes/node/parsers/segmentation.py
+++ b/depthai_nodes/node/parsers/segmentation.py
@@ -164,8 +164,11 @@ class SegmentationParser(BaseParser):
 
             mask_message = create_segmentation_message(class_map)
             mask_message.setTimestamp(output.getTimestamp())
-            mask_message.setTransformation(output.getTransformation())
             mask_message.setSequenceNum(output.getSequenceNum())
+            mask_message.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                mask_message.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created segmentation message with {class_map.shape[0]} classes"

--- a/depthai_nodes/node/parsers/superanimal_landmarker.py
+++ b/depthai_nodes/node/parsers/superanimal_landmarker.py
@@ -126,8 +126,11 @@ class SuperAnimalParser(KeypointParser):
                 edges=self.edges,
             )
             msg.setTimestamp(output.getTimestamp())
-            msg.setTransformation(output.getTransformation())
             msg.setSequenceNum(output.getSequenceNum())
+            msg.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                msg.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created keypoints message with {len(keypoints)} points"

--- a/depthai_nodes/node/parsers/xfeat.py
+++ b/depthai_nodes/node/parsers/xfeat.py
@@ -552,7 +552,7 @@ class XFeatStereoParser(XFeatBaseParser):
             matched_points = create_tracked_features_message(mkpts0, mkpts1)
             matched_points.setTimestamp(target_output.getTimestamp())
             matched_points.setSequenceNum(reference_output.getSequenceNum())
-
+            matched_points.setTimestampDevice(target_output.getTimestampDevice())
             self._logger.debug("Keypoints found, sending TrackedFeatures message")
             self.out.send(matched_points)
             self._logger.debug("TrackedFeatures message sent")

--- a/depthai_nodes/node/parsers/yolo.py
+++ b/depthai_nodes/node/parsers/yolo.py
@@ -523,8 +523,11 @@ class YOLOExtendedParser(BaseParser):
                 )
 
             detections_message.setTimestamp(output.getTimestamp())
-            detections_message.setTransformation(output.getTransformation())
+            detections_message.setTimestampDevice(output.getTimestampDevice())
             detections_message.setSequenceNum(output.getSequenceNum())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                detections_message.setTransformation(transformation)
 
             self._logger.debug(
                 f"Created detection message with {len(bboxes)} detections"

--- a/depthai_nodes/node/parsers/yunet.py
+++ b/depthai_nodes/node/parsers/yunet.py
@@ -307,7 +307,10 @@ class YuNetParser(DetectionParser):
                     label_names=[],
                 )
                 detections_message.setTimestamp(output.getTimestamp())
-                detections_message.setTransformation(output.getTransformation())
+                detections_message.setTimestampDevice(output.getTimestampDevice())
+                transformation = output.getTransformation()
+                if transformation is not None:
+                    detections_message.setTransformation(transformation)
                 detections_message.setSequenceNum(output.getSequenceNum())
                 self.out.send(detections_message)
                 continue
@@ -354,8 +357,11 @@ class YuNetParser(DetectionParser):
             )
 
             detections_message.setTimestamp(output.getTimestamp())
-            detections_message.setTransformation(output.getTransformation())
             detections_message.setSequenceNum(output.getSequenceNum())
+            detections_message.setTimestampDevice(output.getTimestampDevice())
+            transformation = output.getTransformation()
+            if transformation is not None:
+                detections_message.setTransformation(transformation)
 
             self._logger.debug(f"Created detections message with {len(bboxes)} faces")
 

--- a/depthai_nodes/node/tiles_patcher.py
+++ b/depthai_nodes/node/tiles_patcher.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List
+from typing import List, Optional
 
 import depthai as dai
 
@@ -218,7 +218,7 @@ class TilesPatcher(BaseHostNode):
         self,
         timestamp: datetime.timedelta,
         device_timestamp: datetime.timedelta,
-        transformation: dai.ImgTransformation | None,
+        transformation: Optional[dai.ImgTransformation],
         sequence_num: int,
     ) -> None:
         """Send the final combined bounding boxes as output when all tiles for a frame

--- a/depthai_nodes/node/tiling.py
+++ b/depthai_nodes/node/tiling.py
@@ -120,7 +120,7 @@ class Tiling(BaseHostNode):
             self._logger.debug(f"Message {index} sent successfully")
 
     def _crop_to_nn_shape(
-        self, frame: np.ndarray, scaled_width, scaled_height
+        self, frame: np.ndarray, scaled_width: int, scaled_height: int
     ) -> np.ndarray:
         """Crops and resizes the input tile to fit the neural network's input shape.
         Adds padding if necessary to preserve aspect ratio.
@@ -150,7 +150,12 @@ class Tiling(BaseHostNode):
         return frame_padded
 
     def _create_img_frame(
-        self, tile: np.ndarray, frame, tile_index, scaled_width, scaled_height
+        self,
+        tile: np.ndarray,
+        frame: dai.ImgFrame,
+        tile_index: int,
+        scaled_width: int,
+        scaled_height: int,
     ) -> dai.ImgFrame:
         """Creates an ImgFrame from the cropped tile and prepares it for input into the
         neural network. This ImgFrame contains the tiled image in a planar format ready
@@ -185,10 +190,15 @@ class Tiling(BaseHostNode):
         img_frame.setTimestampDevice(frame.getTimestampDevice())
         img_frame.setInstanceNum(frame.getInstanceNum())
         img_frame.setSequenceNum(tile_index)
+        transformation = frame.getTransformation()
+        if transformation is not None:
+            img_frame.setTransformation(transformation)
 
         return img_frame
 
-    def _calculate_tiles(self, grid_size, img_shape, overlap):
+    def _calculate_tiles(
+        self, grid_size: Tuple, img_shape: Tuple, overlap: float
+    ) -> np.ndarray:
         """Calculates the dimensions (x, y) of each tile given the grid size, image
         shape, and overlap.
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
In certain circumstances, ImgTransformations can be set to None and would cause a crash due to the definition of setTransformation in depthai. This PR Adds if checks for cases when ImgTransformations are None.

In addition, this PR adds propagation of the deviceTimestamp via setDeviceTimestamp to all message types in depthai-nodes.
 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable