### PR TITLE
Add `preserve_background` argument to the `ImgFrameOverlay` node 

### DIFF
--- a/depthai_nodes/node/img_frame_overlay.py
+++ b/depthai_nodes/node/img_frame_overlay.py
@@ -20,7 +20,7 @@ class ImgFrameOverlay(BaseHostNode):
         The weight of the background frame in the overlay. By default, the weight is 0.5
             which means that both frames are represented equally in the overlay.
     preserve_background: bool
-        If True, zero areas in the foreground frame do not darken the background during overlay. Default is False.
+        If True, zero areas in the foreground frame are ignored in the output overlay frame. Default is False.
     out : dai.ImgFrame
         The output message for the overlay frame.
     """
@@ -49,8 +49,8 @@ class ImgFrameOverlay(BaseHostNode):
     def setPreserveBackground(self, preserve_background: bool) -> None:
         """Sets the preserve_background flag.
 
-        @param preserve_background: If True, zero areas in the foreground frame do not
-            darken the background.
+        @param preserve_background: If True, zero areas in the foreground frame are
+            ignored in the output overlay frame.
         @type preserve_background: bool
         """
         if not isinstance(preserve_background, bool):
@@ -72,8 +72,8 @@ class ImgFrameOverlay(BaseHostNode):
         @type frame2: dai.Node.Output
         @param alpha: The weight of the background frame in the overlay.
         @type alpha: float
-        @param preserve_background: If True, zero areas in the foreground frame do not
-            darken the background.
+        @param preserve_background: If True, zero areas in the foreground frame are
+            ignored in the output overlay frame.
         @type preserve_background: bool
         @return: The node object with the background and foreground streams overlaid.
         @rtype: ImgFrameOverlay


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Add `preserve_background` option to prevent darkening of the background when overlaying an RGB image with a segmentation mask.

Previously, when overlaying a foreground mask over a background image using `ImgFrameOverlay`, zero areas in the foreground would darken the background due to the default alpha blending. This update introduces a new flag `preserve_background` to handle this scenario properly.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
New parameter: `preserve_background: bool`

If True, zero-valued areas in the foreground frame are ignored during the overlay, preventing unwanted darkening of the background.

Default is False for backward compatibility.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable