### PR TITLE
Remove need for cls_scores = scores.max(axis=-1) as ReduceMax resides on the model side for YOLO26

### DIFF
--- a/depthai_nodes/node/parser_generator.py
+++ b/depthai_nodes/node/parser_generator.py
@@ -30,6 +30,7 @@ class ParserGenerator(dai.node.ThreadedHostNode):
         YOLOSubtype.V8,
         YOLOSubtype.V9,
         YOLOSubtype.V10,
+        YOLOSubtype.V26,
         YOLOSubtype.P,
         YOLOSubtype.GOLD,
     ]

--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -384,9 +384,9 @@ def _apply_conf_and_topk(
     cls_ids = cls_ids[topk_idx]
     aux_kept = aux_kept[topk_idx] if aux_kept is not None else None
 
-    results = np.concatenate(
-        [boxes, conf[:, None], cls_ids[:, None]], axis=1
-    ).astype(np.float32)
+    results = np.concatenate([boxes, conf[:, None], cls_ids[:, None]], axis=1).astype(
+        np.float32
+    )
 
     return results, aux_kept
 

--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -331,65 +331,6 @@ def parse_kpts(
     return kps
 
 
-def _apply_conf_and_topk(
-    boxes: np.ndarray,
-    scores: np.ndarray,
-    conf_threshold: float,
-    max_det: int,
-    auxiliary: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray, Optional[np.ndarray]]:
-    """Apply confidence threshold and top-k filtering.
-
-    @param boxes: Bounding boxes array (A, 4).
-    @type boxes: np.ndarray
-    @param scores: Class scores array (A, nc).
-    @type scores: np.ndarray
-    @param conf_threshold: Confidence threshold.
-    @type conf_threshold: float
-    @param max_det: Maximum number of detections.
-    @type max_det: int
-    @param auxiliary: generic parameter for task-specific data (mask coefficients for
-        segmentation and keypoints for pose) to be filtered according to the detections
-    @type auxiliary: Optional[np.ndarray]
-    @return: Tuple of (results array (K, 6), filtered auxiliary or None).
-    @rtype: Tuple[np.ndarray, Optional[np.ndarray]]
-    """
-    cls_ids = scores.argmax(axis=-1).astype(np.float32)
-    cls_scores = scores.max(axis=-1)
-    keep = cls_scores >= conf_threshold
-
-    if not np.any(keep):
-        aux_shape = (0,) + auxiliary.shape[1:] if auxiliary is not None else None
-        return np.zeros((0, 6), dtype=np.float32), (
-            np.zeros(aux_shape, dtype=np.float32) if aux_shape else None
-        )
-
-    keep_indices = np.where(keep)[0]
-    boxes = boxes[keep]
-    cls_scores = cls_scores[keep]
-    cls_ids = cls_ids[keep]
-    aux_kept = auxiliary[keep_indices] if auxiliary is not None else None
-
-    k = min(max_det, cls_scores.shape[0])
-    if cls_scores.shape[0] > k:
-        topk_idx = np.argpartition(-cls_scores, k - 1)[:k]
-        order = np.argsort(-cls_scores[topk_idx])
-        topk_idx = topk_idx[order]
-    else:
-        topk_idx = np.argsort(-cls_scores)
-
-    boxes = boxes[topk_idx]
-    cls_scores = cls_scores[topk_idx]
-    cls_ids = cls_ids[topk_idx]
-    aux_kept = aux_kept[topk_idx] if aux_kept is not None else None
-
-    results = np.concatenate(
-        [boxes, cls_scores[:, None], cls_ids[:, None]], axis=1
-    ).astype(np.float32)
-
-    return results, aux_kept
-
-
 def decode_yolo26(
     raw: np.ndarray,
     conf_threshold: float,
@@ -398,11 +339,13 @@ def decode_yolo26(
 ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
     """Decode YOLO26 output for detection, segmentation, or pose.
 
-    YOLO26 end2end output is already decoded (xyxy in pixels) but needs topk and conf
-    thresholding. Optionally filters an auxiliary tensor (mask coefficients or
-    keypoints) with the detections
+    YOLO26 end2end output is already decoded (xyxy in pixels) with a pre-computed
+    confidence score (ReduceMax over class scores). Needs topk and conf thresholding.
+    Optionally filters an auxiliary tensor (mask coefficients or keypoints) with the
+    detections.
 
-    @param raw: Raw detection tensor (N, A, 4+nc).
+    @param raw: Raw detection tensor (N, A, 5+nc) where columns are
+        [x1, y1, x2, y2, conf, cls_0, ..., cls_nc-1].
     @type raw: np.ndarray
     @param conf_threshold: Confidence threshold.
     @type conf_threshold: float
@@ -414,15 +357,44 @@ def decode_yolo26(
     @return: Tuple of (detection results (K, 6), kept auxiliary data (K, M) or None).
     @rtype: Tuple[np.ndarray, Optional[np.ndarray]]
     """
-    det_results = raw[0]  # (A, 4+nc)
+    det_results = raw[0]  # (A, 5+nc)
     extra = extra_raw[0] if extra_raw is not None else None
 
     boxes = det_results[:, :4]
-    scores = det_results[:, 4:]
-    results, kept_extra = _apply_conf_and_topk(
-        boxes, scores, conf_threshold, max_det, extra
-    )
-    return results, kept_extra
+    conf = det_results[:, 4]  # pre-computed ReduceMax confidence
+    cls_ids = det_results[:, 5:].argmax(axis=-1).astype(np.float32)
+
+    keep = conf >= conf_threshold
+    if not np.any(keep):
+        aux_shape = (0,) + extra.shape[1:] if extra is not None else None
+        return np.zeros((0, 6), dtype=np.float32), (
+            np.zeros(aux_shape, dtype=np.float32) if aux_shape else None
+        )
+
+    keep_indices = np.where(keep)[0]
+    boxes = boxes[keep]
+    conf = conf[keep]
+    cls_ids = cls_ids[keep]
+    aux_kept = extra[keep_indices] if extra is not None else None
+
+    k = min(max_det, conf.shape[0])
+    if conf.shape[0] > k:
+        topk_idx = np.argpartition(-conf, k - 1)[:k]
+        order = np.argsort(-conf[topk_idx])
+        topk_idx = topk_idx[order]
+    else:
+        topk_idx = np.argsort(-conf)
+
+    boxes = boxes[topk_idx]
+    conf = conf[topk_idx]
+    cls_ids = cls_ids[topk_idx]
+    aux_kept = aux_kept[topk_idx] if aux_kept is not None else None
+
+    results = np.concatenate(
+        [boxes, conf[:, None], cls_ids[:, None]], axis=1
+    ).astype(np.float32)
+
+    return results, aux_kept
 
 
 def decode_yolo_output(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-depthai>=3.3.0
+depthai>=3.6.1
 opencv-python-headless~=4.10.0
 numpy>=1.22

--- a/tests/unittests/test_messages/test_copy_message.py
+++ b/tests/unittests/test_messages/test_copy_message.py
@@ -9,6 +9,7 @@ from tests.utils.messages import creators as message_creators
 
 ATTRS_TO_IGNORE = [
     "Type",  # dai.ImgFrame attribute
+    "Fsync",  # dai.ImgFrame attribute
 ]
 
 


### PR DESCRIPTION
## Purpose
Also change expected names for yolo26 fields in the NNArchive

Depends on pruned models from https://github.com/luxonis/tools/pull/206

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
