### PR TITLE
Remove Python 3.8 Type Annotations

### DIFF
--- a/depthai_nodes/constants.py
+++ b/depthai_nodes/constants.py
@@ -1,15 +1,11 @@
 import depthai as dai
 
-PRIMARY_COLOR = dai.Color(
-    float(21 / 255), float(127 / 255), float(88 / 255), float(1.0)
-)
+PRIMARY_COLOR = dai.Color(float(21 / 255), float(127 / 255), float(88 / 255), 1.0)
 TRANSPARENT_PRIMARY_COLOR = dai.Color(
-    float(21 / 255), float(127 / 255), float(88 / 255), float(0.2)
+    float(21 / 255), float(127 / 255), float(88 / 255), 0.2
 )
-SECONDARY_COLOR = dai.Color(
-    float(240 / 255), float(240 / 255), float(240 / 255), float(1.0)
-)
-FONT_COLOR = dai.Color(float(255 / 255), float(255 / 255), float(255 / 255), float(1.0))
+SECONDARY_COLOR = dai.Color(float(240 / 255), float(240 / 255), float(240 / 255), 1.0)
+FONT_COLOR = dai.Color(float(255 / 255), float(255 / 255), float(255 / 255), 1.0)
 FONT_SIZE_PER_HEIGHT = 1 / 30
 SMALLER_FONT_SIZE_PER_HEIGHT = FONT_SIZE_PER_HEIGHT / 2
 FONT_BACKGROUND_COLOR = dai.Color(0.0, 0.0, 0.0, 0.0)

--- a/depthai_nodes/logging.py
+++ b/depthai_nodes/logging.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from enum import Enum
-from typing import Optional
 
 
 class LogLevel(Enum):
@@ -12,14 +11,14 @@ class LogLevel(Enum):
     WARN = "WARN"
 
 
-def get_logger(name: Optional[str] = None) -> logging.Logger:
+def get_logger(name: str | None = None) -> logging.Logger:
     logger = logging.getLogger("depthai-nodes")
     if name:
         logger = logger.getChild(name)
     return logger
 
 
-def setup_logging(level: Optional[str] = None, file: Optional[str] = None):
+def setup_logging(level: str | None = None, file: str | None = None):
     """Globally configures logging for depthai_nodes package.
 
     @type level: str or None
@@ -57,7 +56,7 @@ def setup_logging(level: Optional[str] = None, file: Optional[str] = None):
     logger.info(f"Using log level: {used_level}")
 
 
-def get_log_level(level_str: Optional[str]) -> Optional[LogLevel]:
+def get_log_level(level_str: str | None) -> LogLevel | None:
     try:
         if level_str is None:
             return None

--- a/depthai_nodes/message/classification.py
+++ b/depthai_nodes/message/classification.py
@@ -1,5 +1,4 @@
 import copy
-from typing import List, Optional
 
 import depthai as dai
 import numpy as np
@@ -25,9 +24,9 @@ class Classifications(dai.Buffer):
     def __init__(self):
         """Initializes the Classifications object."""
         dai.Buffer.__init__(self)
-        self._classes: List[str] = []
+        self._classes: list[str] = []
         self._scores: NDArray[np.float32] = np.array([])
-        self._transformation: Optional[dai.ImgTransformation] = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Classifications class and copies the
@@ -46,24 +45,24 @@ class Classifications(dai.Buffer):
         return new_obj
 
     @property
-    def classes(self) -> List:
+    def classes(self) -> list:
         """Returns the list of classes.
 
         @return: List of classes.
-        @rtype: List[str]
+        @rtype: list[str]
         """
         return self._classes
 
     @classes.setter
-    def classes(self, value: List[str]):
+    def classes(self, value: list[str]):
         """Sets the classes.
 
         @param value: A list of class names.
-        @type value: List[str]
+        @type value: list[str]
         @raise TypeError: If value is not a list.
         @raise ValueError: If each element is not of type string.
         """
-        if not isinstance(value, List):
+        if not isinstance(value, list):
             raise TypeError(f"Classes must be a list, instead got {type(value)}.")
         if not all(isinstance(class_name, str) for class_name in value):
             raise ValueError("Classes must be a list of strings.")
@@ -116,7 +115,7 @@ class Classifications(dai.Buffer):
         return self._scores[0]
 
     @property
-    def transformation(self) -> Optional[dai.ImgTransformation]:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -125,7 +124,7 @@ class Classifications(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: Optional[dai.ImgTransformation]):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -140,7 +139,7 @@ class Classifications(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -149,7 +148,7 @@ class Classifications(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> Optional[dai.ImgTransformation]:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/clusters.py
+++ b/depthai_nodes/message/clusters.py
@@ -1,5 +1,4 @@
 import copy
-from typing import List, Optional
 
 import cv2
 import depthai as dai
@@ -17,7 +16,7 @@ class Cluster(dai.Buffer):
     ----------
     label : int
         Label of the cluster.
-    points : List[dai.Point2f]
+    points : list[dai.Point2f]
         List of points in the cluster.
     """
 
@@ -25,7 +24,7 @@ class Cluster(dai.Buffer):
         """Initializes the Cluster object."""
         super().__init__()
         self._label: int = None
-        self._points: List[dai.Point2f] = []
+        self._points: list[dai.Point2f] = []
 
     def copy(self):
         """Creates a new instance of the Cluster class and copies the attributes.
@@ -60,24 +59,24 @@ class Cluster(dai.Buffer):
         self._label = value
 
     @property
-    def points(self) -> List[dai.Point2f]:
+    def points(self) -> list[dai.Point2f]:
         """Returns the points in the cluster.
 
         @return: List of points in the cluster.
-        @rtype: List[dai.Point2f]
+        @rtype: list[dai.Point2f
         """
         return self._points
 
     @points.setter
-    def points(self, value: List[dai.Point2f]):
+    def points(self, value: list[dai.Point2f]):
         """Sets the points in the cluster.
 
         @param value: List of points in the cluster.
-        @type value: List[dai.Point2f]
+        @type value: list[dai.Point2f]
         @raise TypeError: If value is not a list.
         @raise TypeError: If each element is not of type dai.Point2f.
         """
-        if not isinstance(value, List):
+        if not isinstance(value, list):
             raise TypeError(f"Points must be a list, instead got {type(value)}.")
         if not all(isinstance(point, dai.Point2f) for point in value):
             raise ValueError("Points must be a list of dai.Point2f objects")
@@ -89,7 +88,7 @@ class Clusters(dai.Buffer):
 
     Attributes
     ----------
-    clusters : List[Cluster]
+    clusters : list[Cluster]
         List of clusters.
     transformation : dai.ImgTransformation
         Image transformation object.
@@ -98,8 +97,8 @@ class Clusters(dai.Buffer):
     def __init__(self):
         """Initializes the Clusters object."""
         super().__init__()
-        self._clusters: List[Cluster] = []
-        self._transformation: Optional[dai.ImgTransformation] = None
+        self._clusters: list[Cluster] = []
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Clusters class and copies the attributes.
@@ -116,31 +115,31 @@ class Clusters(dai.Buffer):
         return new_obj
 
     @property
-    def clusters(self) -> List[Cluster]:
+    def clusters(self) -> list[Cluster]:
         """Returns the clusters.
 
         @return: List of clusters.
-        @rtype: List[Cluster]
+        @rtype: list[Cluster]
         """
         return self._clusters
 
     @clusters.setter
-    def clusters(self, value: List[Cluster]):
+    def clusters(self, value: list[Cluster]):
         """Sets the clusters.
 
         @param value: List of clusters.
-        @type value: List[Cluster]
+        @type value: list[Cluster]
         @raise TypeError: If value is not a list.
         @raise ValueError: If each element is not of type Cluster.
         """
-        if not isinstance(value, List):
+        if not isinstance(value, list):
             raise TypeError("Clusters must be a list.")
         if not all(isinstance(cluster, Cluster) for cluster in value):
             raise ValueError("Clusters must be a list of Cluster objects.")
         self._clusters = value
 
     @property
-    def transformation(self) -> Optional[dai.ImgTransformation]:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -149,7 +148,7 @@ class Clusters(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: Optional[dai.ImgTransformation]):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -164,7 +163,7 @@ class Clusters(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -173,7 +172,7 @@ class Clusters(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> Optional[dai.ImgTransformation]:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/collection.py
+++ b/depthai_nodes/message/collection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generic, List, Optional, Type, TypeVar
+from typing import Generic, TypeVar
 
 import depthai as dai
 
@@ -15,22 +15,22 @@ class Collection(dai.Buffer, Generic[T]):
       from the first item when the collection becomes non-empty.
     """
 
-    def __init__(self, items: List[T]):
+    def __init__(self, items: list[T]):
         super().__init__()
-        self._item_cls: Optional[Type[T]] = type(items[0]) if items else None
-        self.items: List[T] = items
+        self._item_cls: type[T] | None = type(items[0]) if items else None
+        self.items: list[T] = items
 
     @property
-    def item_cls(self) -> Optional[Type[T]]:
+    def item_cls(self) -> type[T] | None:
         """The inferred runtime type for items, once known."""
         return self._item_cls
 
     @property
-    def items(self) -> List[T]:
+    def items(self) -> list[T]:
         return self._items
 
     @items.setter
-    def items(self, value: List[T]) -> None:
+    def items(self, value: list[T]) -> None:
         if not isinstance(value, list):
             raise TypeError(f"items must be a list, got {type(value)}")
 
@@ -55,11 +55,11 @@ class Collection(dai.Buffer, Generic[T]):
             )
         self._items.append(item)
 
-    def extend(self, items: List[T]) -> None:
+    def extend(self, items: list[T]) -> None:
         # Reuse setter validation
         self.items = [*self._items, *items]
 
-    def copy(self) -> "Collection":
+    def copy(self) -> Collection:
         new_list = []
         for item in self.items:
             new_list.append(item.copy())

--- a/depthai_nodes/message/creators/classification.py
+++ b/depthai_nodes/message/creators/classification.py
@@ -1,19 +1,16 @@
-from typing import List, Optional, Union
-
 import numpy as np
 
 from depthai_nodes import Classifications
 
 
 def create_classification_message(
-    classes: List[str], scores: Union[np.ndarray, List]
+    classes: list[str], scores: np.ndarray | list
 ) -> Classifications:
     """Create a message for classification. The message contains the class names and
     their respective scores, sorted in descending order of scores.
 
     @param classes: A list containing class names.
-    @type classes: List[str]
-    @param scores: A numpy array of shape (n_classes,) containing the probability score of each class.
+    @type classes: list[str]    @param scores: A numpy array of shape (n_classes,) containing the probability score of each class.
     @type scores: np.ndarray
 
     @return: A message with attributes `classes` and `scores`. `classes` is a list of classes, sorted in descending order of scores. `scores` is a list of the corresponding scores.
@@ -87,9 +84,9 @@ def create_classification_message(
 
 
 def create_classification_sequence_message(
-    classes: List[str],
-    scores: Union[np.ndarray, List],
-    ignored_indexes: Optional[List[int]] = None,
+    classes: list[str],
+    scores: np.ndarray | list,
+    ignored_indexes: list[int] | None = None,
     remove_duplicates: bool = False,
     concatenate_classes: bool = False,
 ) -> Classifications:
@@ -99,12 +96,10 @@ def create_classification_sequence_message(
     sequence.
 
     @param classes: A list of class names, with length 'n_classes'.
-    @type classes: List
-    @param scores: A numpy array of shape (sequence_length, n_classes) containing the (row-wise) probability distributions over the classes.
+    @type classes: list    @param scores: A numpy array of shape (sequence_length, n_classes) containing the (row-wise) probability distributions over the classes.
     @type scores: np.ndarray
     @param ignored_indexes: A list of indexes to ignore during classification generation (e.g., background class, padding class). Defaults to None.
-    @type ignored_indexes: Optional[List[int]]
-    @param remove_duplicates: If True, removes consecutive duplicates from the sequence. Defaults to False.
+    @type ignored_indexes: list[int] | None    @param remove_duplicates: If True, removes consecutive duplicates from the sequence. Defaults to False.
     @type remove_duplicates: bool
     @param concatenate_classes: If True, concatenates consecutive classes based on the space character. Defaults to False.
     @type concatenate_classes: bool
@@ -118,10 +113,10 @@ def create_classification_sequence_message(
     @raises ValueError: If 'ignored_indexes' in not None or a list of valid indexes within the range [0, n_classes - 1].
     """
 
-    if not isinstance(classes, List):
+    if not isinstance(classes, list):
         raise ValueError(f"Classes should be a list, got {type(classes)}.")
 
-    if isinstance(scores, List):
+    if isinstance(scores, list):
         scores = np.array(scores)
 
     if len(scores.shape) != 2:
@@ -143,7 +138,7 @@ def create_classification_sequence_message(
     scores = scores.astype(np.float32)
 
     if ignored_indexes is not None:
-        if not isinstance(ignored_indexes, List):
+        if not isinstance(ignored_indexes, list):
             raise ValueError(
                 f"Ignored indexes should be a list, got {type(ignored_indexes)}."
             )
@@ -165,7 +160,7 @@ def create_classification_sequence_message(
     if ignored_indexes is not None:
         selection &= np.array([index not in ignored_indexes for index in indexes])
 
-    class_list: List[str] = [classes[i] for i in indexes[selection]]
+    class_list: list[str] = [classes[i] for i in indexes[selection]]
     score_list = np.max(scores, axis=1)[selection]
 
     if (

--- a/depthai_nodes/message/creators/clusters.py
+++ b/depthai_nodes/message/creators/clusters.py
@@ -1,16 +1,14 @@
-from typing import List, Union
-
 import depthai as dai
 
 from depthai_nodes import Cluster, Clusters
 
 
-def create_cluster_message(clusters: List[List[List[Union[float, int]]]]) -> Clusters:
+def create_cluster_message(clusters: list[list[list[float | int]]]) -> Clusters:
     """Create a DepthAI message for clusters.
 
     @param clusters: List of clusters. Each cluster is a list of points with x and y
         coordinates.
-    @type clusters: List[List[List[Union[float, int]]]]
+    @type clusters: list[list[list[float | int]]]
     @return: Clusters message containing the detected clusters.
     @rtype: Clusters
     @raise TypeError: If the clusters are not a list.

--- a/depthai_nodes/message/creators/detection.py
+++ b/depthai_nodes/message/creators/detection.py
@@ -1,13 +1,11 @@
-from typing import List, Optional, Tuple
-
 import depthai as dai
 import numpy as np
 
 
 def _create_keypoints(
     keypoints: np.ndarray,
-    scores: np.ndarray = None,
-    keypoint_label_names: Optional[List[str]] = None,
+    scores: np.ndarray | None = None,
+    keypoint_label_names: list[str] | None = None,
 ) -> list[dai.Keypoint]:
     if not isinstance(keypoints, (np.ndarray, list)):
         raise ValueError(
@@ -23,9 +21,7 @@ def _create_keypoints(
 
         if len(keypoints) != len(scores):
             raise ValueError(
-                "Keypoints and scores should have the same length. Got {} keypoints and {} scores.".format(
-                    len(keypoints), len(scores)
-                )
+                f"Keypoints and scores should have the same length. Got {len(keypoints)} keypoints and {len(scores)} scores."
             )
 
         if not all(isinstance(score, (float, np.floating)) for score in scores):
@@ -90,14 +86,14 @@ def _create_keypoints(
 def create_detection_message(
     bboxes: np.ndarray,
     scores: np.ndarray,
-    angles: np.ndarray = None,
-    labels: np.ndarray = None,
-    label_names: Optional[List[str]] = None,
-    keypoints: np.ndarray = None,
-    keypoints_scores: np.ndarray = None,
-    keypoint_label_names: Optional[List[str]] = None,
-    keypoint_edges: Optional[List[Tuple[int, int]]] = None,
-    masks: np.ndarray = None,
+    angles: np.ndarray | None = None,
+    labels: np.ndarray | None = None,
+    label_names: list[str] | None = None,
+    keypoints: np.ndarray | None = None,
+    keypoints_scores: np.ndarray | None = None,
+    keypoint_label_names: list[str] | None = None,
+    keypoint_edges: list[tuple[int, int]] | None = None,
+    masks: np.ndarray | None = None,
 ) -> dai.ImgDetections:
     """Create a DepthAI message for object detection. The message contains the bounding
     boxes in X_center, Y_center, Width, Height format with optional angles, labels and
@@ -109,25 +105,25 @@ def create_detection_message(
     @param scores: Confidence scores of the detected objects of shape (N,).
     @type scores: np.ndarray
     @param angles: Angles of detected objects expressed in degrees. Defaults to None.
-    @type angles: Optional[np.ndarray]
+    @type angles: np.ndarray | None
     @param labels: Labels of detected objects of shape (N,). Defaults to None.
-    @type labels: Optional[np.ndarray]
+    @type labels: np.ndarray | None
     @param label_names: Names of the labels (classes)
-    @type label_names: Optional[List[str]]
+    @type label_names: list[str] | None
     @param keypoints: Keypoints of detected objects of shape (N, n_keypoints, dim) where
         dim is 2 or 3. Defaults to None.
-    @type keypoints: Optional[np.array]
+    @type keypoints: np.array | None
     @param keypoints_scores: Confidence scores of detected keypoints of shape (N,
         n_keypoints). Defaults to None.
-    @type keypoints_scores: Optional[np.ndarray]
+    @type keypoints_scores: np.ndarray | None
     @param keypoint_label_names: Labels of keypoints. Defaults to None.
-    @type keypoint_label_names: Optional[List[str]]
+    @type keypoint_label_names: list[str] | None
     @param keypoint_edges: Connection pairs of keypoints. Defaults to None. Example:
         [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint 1,
         keypoint 1 is connected to keypoint 2, etc.
-    @type keypoint_edges: Optional[List[Tuple[int, int]]]
+    @type keypoint_edges: list[tuple[int, int]] | None
     @param masks: Masks of detected objects of shape (H, W). Defaults to None.
-    @type masks: Optional[np.ndarray]
+    @type masks: np.ndarray | None
     @return: Message containing the bounding boxes, labels, confidence scores, and
         keypoints of detected objects.
     @rtype: dai.ImgDetections

--- a/depthai_nodes/message/creators/keypoints.py
+++ b/depthai_nodes/message/creators/keypoints.py
@@ -1,5 +1,3 @@
-from typing import List, Optional, Tuple, Union
-
 import depthai as dai
 import numpy as np
 
@@ -7,11 +5,11 @@ from depthai_nodes.message.keypoints import Keypoints
 
 
 def create_keypoints_message(
-    keypoints: Union[np.ndarray, List[List[float]]],
-    scores: Union[np.ndarray, List[float], None] = None,
-    confidence_threshold: Optional[float] = None,
-    label_names: Optional[List[str]] = None,
-    edges: Optional[List[Tuple[int, int]]] = None,
+    keypoints: np.ndarray | list[list[float]],
+    scores: np.ndarray | list[float] | None = None,
+    confidence_threshold: float | None = None,
+    label_names: list[str] | None = None,
+    edges: list[tuple[int, int]] | None = None,
 ) -> Keypoints:
     """Create a native DepthAI keypoints message."""
 
@@ -28,9 +26,7 @@ def create_keypoints_message(
 
         if len(keypoints) != len(scores):
             raise ValueError(
-                "Keypoints and scores should have the same length. Got {} keypoints and {} scores.".format(
-                    len(keypoints), len(scores)
-                )
+                f"Keypoints and scores should have the same length. Got {len(keypoints)} keypoints and {len(scores)} scores."
             )
 
         if not all(isinstance(score, (float, np.floating)) for score in scores):

--- a/depthai_nodes/message/creators/regression.py
+++ b/depthai_nodes/message/creators/regression.py
@@ -1,13 +1,11 @@
-from typing import List
-
 from depthai_nodes import Prediction, Predictions
 
 
-def create_regression_message(predictions: List[float]) -> Predictions:
+def create_regression_message(predictions: list[float]) -> Predictions:
     """Create a DepthAI message for prediction models.
 
     @param predictions: Predicted value(s).
-    @type predictions: List[float]
+    @type predictions: list[float]
     @return: Predictions message containing the predicted value(s).
     @rtype: Predictions
     @raise ValueError: If predictions is not a list.
@@ -27,7 +25,7 @@ def create_regression_message(predictions: List[float]) -> Predictions:
     for prediction in predictions:
         prediction_object = Prediction()
         prediction_object.prediction = prediction
-        prediction_objects_list.append((prediction_object))
+        prediction_objects_list.append(prediction_object)
 
     predictions_message = Predictions()
     predictions_message.predictions = prediction_objects_list

--- a/depthai_nodes/message/gathered_data.py
+++ b/depthai_nodes/message/gathered_data.py
@@ -1,4 +1,4 @@
-from typing import Generic, List, TypeVar
+from typing import Generic, TypeVar
 
 import depthai as dai
 
@@ -15,11 +15,11 @@ class GatheredData(Collection[TGathered], Generic[TReference, TGathered]):
     ----------
     reference_data: TReference
         Data that is used to determine how many of TGathered to gather.
-    items: List[TGathered]
+    items: list[TGathered]
         List of gathered data.
     """
 
-    def __init__(self, reference_data: TReference, items: List[TGathered]) -> None:
+    def __init__(self, reference_data: TReference, items: list[TGathered]) -> None:
         """Initializes the GatheredData object."""
         super().__init__(items=items)
         self.reference_data = reference_data

--- a/depthai_nodes/message/keypoints.py
+++ b/depthai_nodes/message/keypoints.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Optional
 
 import depthai as dai
 
@@ -13,7 +12,7 @@ class Keypoints(dai.Buffer):
     def __init__(self):
         super().__init__()
         self._keypoints_list = dai.KeypointsList()
-        self._transformation: Optional[dai.ImgTransformation] = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         new_obj = Keypoints()
@@ -40,21 +39,21 @@ class Keypoints(dai.Buffer):
         self._keypoints_list = value
 
     @property
-    def transformation(self) -> Optional[dai.ImgTransformation]:
+    def transformation(self) -> dai.ImgTransformation | None:
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: Optional[dai.ImgTransformation]):
+    def transformation(self, value: dai.ImgTransformation | None):
         if value is not None and not isinstance(value, dai.ImgTransformation):
             raise TypeError(
                 f"Transformation must be a dai.ImgTransformation object, got {type(value)}."
             )
         self._transformation = value
 
-    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         self.transformation = transformation
 
-    def getTransformation(self) -> Optional[dai.ImgTransformation]:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         return self.transformation
 
     def getKeypoints(self) -> list[dai.Keypoint]:

--- a/depthai_nodes/message/lines.py
+++ b/depthai_nodes/message/lines.py
@@ -1,5 +1,4 @@
 import copy
-from typing import List, Optional
 
 import depthai as dai
 
@@ -125,7 +124,7 @@ class Lines(dai.Buffer):
 
     Attributes
     ----------
-    lines : List[Line]
+    lines : list[Line]
         List of detected lines.
     transformation : dai.ImgTransformation
         Image transformation object.
@@ -134,8 +133,8 @@ class Lines(dai.Buffer):
     def __init__(self):
         """Initializes the Lines object."""
         super().__init__()
-        self._lines: List[Line] = []
-        self._transformation: Optional[dai.ImgTransformation] = None
+        self._lines: list[Line] = []
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Lines class and copies the attributes.
@@ -152,31 +151,31 @@ class Lines(dai.Buffer):
         return new_obj
 
     @property
-    def lines(self) -> List[Line]:
+    def lines(self) -> list[Line]:
         """Returns the lines.
 
         @return: List of lines.
-        @rtype: List[Line]
+        @rtype: list[Line]
         """
         return self._lines
 
     @lines.setter
-    def lines(self, value: List[Line]):
+    def lines(self, value: list[Line]):
         """Sets the lines.
 
         @param value: List of lines.
-        @type value: List[Line]
+        @type value: list[Line]
         @raise TypeError: If value is not a list.
         @raise TypeError: If each element is not of type Line.
         """
-        if not isinstance(value, List):
+        if not isinstance(value, list):
             raise TypeError(f"lines must be a list, instead got {type(value)}.")
         if not all(isinstance(item, Line) for item in value):
             raise ValueError("Lines must be a list of Line objects.")
         self._lines = value
 
     @property
-    def transformation(self) -> Optional[dai.ImgTransformation]:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -185,7 +184,7 @@ class Lines(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: Optional[dai.ImgTransformation]):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -200,7 +199,7 @@ class Lines(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -209,7 +208,7 @@ class Lines(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> Optional[dai.ImgTransformation]:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/map.py
+++ b/depthai_nodes/message/map.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Optional
 
 import cv2
 import depthai as dai
@@ -28,7 +27,7 @@ class Map2D(dai.Buffer):
         self._map: NDArray[np.float32] = np.array([])
         self._width: int = None
         self._height: int = None
-        self._transformation: Optional[dai.ImgTransformation] = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Map2D class and copies the attributes.
@@ -91,7 +90,7 @@ class Map2D(dai.Buffer):
         return self._height
 
     @property
-    def transformation(self) -> Optional[dai.ImgTransformation]:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -100,7 +99,7 @@ class Map2D(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: Optional[dai.ImgTransformation]):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -124,7 +123,7 @@ class Map2D(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> Optional[dai.ImgTransformation]:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/prediction.py
+++ b/depthai_nodes/message/prediction.py
@@ -1,5 +1,4 @@
 import copy
-from typing import List, Optional
 
 import depthai as dai
 
@@ -60,7 +59,7 @@ class Predictions(dai.Buffer):
 
     Attributes
     ----------
-    predictions : List[Prediction]
+    predictions : list[Prediction]
         List of predictions.
     transformation : dai.ImgTransformation
         Image transformation object.
@@ -69,8 +68,8 @@ class Predictions(dai.Buffer):
     def __init__(self):
         """Initializes the Predictions object."""
         super().__init__()
-        self._predictions: List[Prediction] = []
-        self._transformation: Optional[dai.ImgTransformation] = None
+        self._predictions: list[Prediction] = []
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the Predictions class and copies the attributes.
@@ -87,24 +86,24 @@ class Predictions(dai.Buffer):
         return new_obj
 
     @property
-    def predictions(self) -> List[Prediction]:
+    def predictions(self) -> list[Prediction]:
         """Returns the predictions.
 
         @return: List of predictions.
-        @rtype: List[Prediction]
+        @rtype: list[Prediction]
         """
         return self._predictions
 
     @predictions.setter
-    def predictions(self, value: List[Prediction]):
+    def predictions(self, value: list[Prediction]):
         """Sets the predictions.
 
         @param value: List of predicted values.
-        @type value: List[Prediction]
+        @type value: list[Prediction]
         @raise TypeError: If value is not a list.
         @raise ValueError: If each element is not of type Prediction.
         """
-        if not isinstance(value, List):
+        if not isinstance(value, list):
             raise TypeError(
                 f"Predictions must be of type list, instead got {type(value)}."
             )
@@ -122,7 +121,7 @@ class Predictions(dai.Buffer):
         return self._predictions[0].prediction
 
     @property
-    def transformation(self) -> Optional[dai.ImgTransformation]:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -131,7 +130,7 @@ class Predictions(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: Optional[dai.ImgTransformation]):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -146,7 +145,7 @@ class Predictions(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -155,7 +154,7 @@ class Predictions(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> Optional[dai.ImgTransformation]:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/segmentation.py
+++ b/depthai_nodes/message/segmentation.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Optional
 
 import cv2
 import depthai as dai
@@ -24,7 +23,7 @@ class SegmentationMask(dai.Buffer):
         """Initializes the SegmentationMask object."""
         super().__init__()
         self._mask: NDArray[np.int16] = np.empty(0, dtype=np.int16)
-        self._transformation: Optional[dai.ImgTransformation] = None
+        self._transformation: dai.ImgTransformation | None = None
 
     def copy(self):
         """Creates a new instance of the SegmentationMask class and copies the
@@ -67,12 +66,12 @@ class SegmentationMask(dai.Buffer):
             raise ValueError("Mask must be 2D or empty.")
         if value.dtype != np.int16:
             raise ValueError("Mask must be an array of int16.")
-        if np.any((value < -1)):
+        if np.any(value < -1):
             raise ValueError("Mask must be an array of integers larger or equal to -1.")
         self._mask = value
 
     @property
-    def transformation(self) -> Optional[dai.ImgTransformation]:
+    def transformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.
@@ -81,7 +80,7 @@ class SegmentationMask(dai.Buffer):
         return self._transformation
 
     @transformation.setter
-    def transformation(self, value: Optional[dai.ImgTransformation]):
+    def transformation(self, value: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param value: The Image Transformation object.
@@ -96,7 +95,7 @@ class SegmentationMask(dai.Buffer):
                 )
         self._transformation = value
 
-    def setTransformation(self, transformation: Optional[dai.ImgTransformation]):
+    def setTransformation(self, transformation: dai.ImgTransformation | None):
         """Sets the Image Transformation object.
 
         @param transformation: The Image Transformation object.
@@ -105,7 +104,7 @@ class SegmentationMask(dai.Buffer):
         """
         self.transformation = transformation
 
-    def getTransformation(self) -> Optional[dai.ImgTransformation]:
+    def getTransformation(self) -> dai.ImgTransformation | None:
         """Returns the Image Transformation object.
 
         @return: The Image Transformation object.

--- a/depthai_nodes/message/snap_data.py
+++ b/depthai_nodes/message/snap_data.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Optional
-
 import depthai as dai
 
 
@@ -12,9 +10,9 @@ class SnapData(dai.Buffer):
         Logical name of the snap.
     file_group : dai.FileGroup
         Object containing the snap image and associated data.
-    tags : List[str]
+    tags : list[str]
         Optional list of tags to include.
-    extras : Dict[str, str]
+    extras : dict[str, str]
         Additional metadata.
     """
 
@@ -22,8 +20,8 @@ class SnapData(dai.Buffer):
         self,
         snap_name: str,
         file_group: dai.FileGroup,
-        tags: Optional[List[str]] = None,
-        extras: Optional[Dict[str, str]] = None,
+        tags: list[str] | None = None,
+        extras: dict[str, str] | None = None,
     ):
         super().__init__()
         self.snap_name = snap_name

--- a/depthai_nodes/message/utils/copy_message.py
+++ b/depthai_nodes/message/utils/copy_message.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Union
 
 import depthai as dai
 
@@ -51,8 +50,8 @@ def _copy(msg: dai.Buffer) -> dai.Buffer:
         return img_frame_copy
 
     def _copy_img_detection(
-        img_det: Union[dai.ImgDetection, dai.SpatialImgDetection],
-    ) -> Union[dai.ImgDetection, dai.SpatialImgDetection]:
+        img_det: dai.ImgDetection | dai.SpatialImgDetection,
+    ) -> dai.ImgDetection | dai.SpatialImgDetection:
         assert isinstance(img_det, (dai.ImgDetection, dai.SpatialImgDetection))
         img_det_copy = _copy_metadata(img_det)
         assert isinstance(img_det_copy, (dai.ImgDetection, dai.SpatialImgDetection))
@@ -68,8 +67,8 @@ def _copy(msg: dai.Buffer) -> dai.Buffer:
         return img_det_copy
 
     def _copy_img_detections(
-        img_dets: Union[dai.ImgDetections, dai.SpatialImgDetections],
-    ) -> Union[dai.ImgDetections, dai.SpatialImgDetections]:
+        img_dets: dai.ImgDetections | dai.SpatialImgDetections,
+    ) -> dai.ImgDetections | dai.SpatialImgDetections:
         assert isinstance(img_dets, (dai.ImgDetections, dai.SpatialImgDetections))
         img_dets_copy = _copy_metadata(img_dets)
         if isinstance(img_dets, dai.ImgDetections):

--- a/depthai_nodes/message/utils/detection_utils.py
+++ b/depthai_nodes/message/utils/detection_utils.py
@@ -1,16 +1,14 @@
-from typing import Union
-
 import depthai as dai
 
 
 def compute_area(
-    detection: Union[dai.ImgDetection, dai.SpatialImgDetection],
+    detection: dai.ImgDetection | dai.SpatialImgDetection,
 ):
     """Computes the normalized area of a detection bounding box.
 
     @param detection: Detection object to compute the area for. Can be of type
         dai.ImgDetection, or dai.SpatialImgDetection.
-    @type detection: Union[dai.ImgDetection, dai.SpatialImgDetection]
+    @type detection: dai.ImgDetection | dai.SpatialImgDetection
     @return: Normalized area (width * height) of the detection bounding box.
     @rtype: float
     """

--- a/depthai_nodes/node/apply_colormap.py
+++ b/depthai_nodes/node/apply_colormap.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import cv2
 import depthai as dai
 import numpy as np
@@ -18,7 +16,7 @@ class ApplyColormap(BaseHostNode):
 
     Parameters
     ----------
-    colormapValue : Union[int, np.ndarray], optional
+    colormapValue : int | np.ndarray, optional
         OpenCV colormap enum (e.g. cv2.COLORMAP_JET) or a custom OpenCV-compatible
         colormap LUT. Default is cv2.COLORMAP_JET.
     maxValue : int, optional
@@ -38,7 +36,7 @@ class ApplyColormap(BaseHostNode):
 
     def __init__(
         self,
-        colormapValue: Union[int, np.ndarray] = cv2.COLORMAP_JET,
+        colormapValue: int | np.ndarray = cv2.COLORMAP_JET,
         maxValue: int = 0,
     ) -> None:
         super().__init__()
@@ -52,12 +50,12 @@ class ApplyColormap(BaseHostNode):
             f"ApplyColormap initialized with colormap_value={colormapValue}, max_value={maxValue}",
         )
 
-    def setColormap(self, colormapValue: Union[int, np.ndarray]) -> None:
+    def setColormap(self, colormapValue: int | np.ndarray) -> None:
         """Set the color mapping applied to incoming maps.
 
         @param colormapValue: OpenCV colormap enum value or a custom OpenCV-compatible
             LUT.
-        @type colormapValue: Union[int, np.ndarray]
+        @type colormapValue: int | np.ndarray
         """
         self._colormap = self._make_colormap(colormapValue)
         if isinstance(colormapValue, int):
@@ -97,7 +95,7 @@ class ApplyColormap(BaseHostNode):
         self._logger.debug("Message sent successfully")
 
     @staticmethod
-    def _make_colormap(colormap_value: Union[int, np.ndarray]) -> np.ndarray:
+    def _make_colormap(colormap_value: int | np.ndarray) -> np.ndarray:
         if isinstance(colormap_value, int):
             colormap = cv2.applyColorMap(np.arange(256, dtype=np.uint8), colormap_value)
             colormap[0] = [0, 0, 0]  # Set zero values to black

--- a/depthai_nodes/node/apply_depth_colormap.py
+++ b/depthai_nodes/node/apply_depth_colormap.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Union
-
 import cv2
 import depthai as dai
 import numpy as np
@@ -18,7 +16,7 @@ class ApplyDepthColormap(BaseHostNode):
 
     Parameters
     ----------
-    colormapValue : Union[int, np.ndarray], optional
+    colormapValue : int | np.ndarray, optional
         OpenCV colormap enum (e.g. cv2.COLORMAP_JET) or a custom OpenCV-compatible
         colormap LUT. Default is cv2.COLORMAP_JET.
     pLow : float, optional
@@ -39,7 +37,7 @@ class ApplyDepthColormap(BaseHostNode):
 
     def __init__(
         self,
-        colormapValue: Union[int, np.ndarray] = cv2.COLORMAP_JET,
+        colormapValue: int | np.ndarray = cv2.COLORMAP_JET,
         pLow: float = 2.0,
         pHigh: float = 98.0,
     ) -> None:
@@ -56,12 +54,12 @@ class ApplyDepthColormap(BaseHostNode):
             self._p_high,
         )
 
-    def setColormap(self, colormapValue: Union[int, np.ndarray]) -> None:
+    def setColormap(self, colormapValue: int | np.ndarray) -> None:
         """Set the color mapping applied to depth images.
 
         @param colormapValue: OpenCV colormap enum value or a custom OpenCV-compatible
             LUT.
-        @type colormapValue: Union[int, np.ndarray]
+        @type colormapValue: int | np.ndarray
         """
         self._colormap = self._make_colormap(colormapValue)
         if isinstance(colormapValue, int):
@@ -121,7 +119,7 @@ class ApplyDepthColormap(BaseHostNode):
         self._logger.debug("Message sent successfully")
 
     @staticmethod
-    def _validate_percentile_range(low: float, high: float) -> Tuple[float, float]:
+    def _validate_percentile_range(low: float, high: float) -> tuple[float, float]:
         low = float(low)
         high = float(high)
         if not (0.0 <= low < high <= 100.0):
@@ -129,7 +127,7 @@ class ApplyDepthColormap(BaseHostNode):
         return low, high
 
     @staticmethod
-    def _make_colormap(colormap_value: Union[int, np.ndarray]) -> np.ndarray:
+    def _make_colormap(colormap_value: int | np.ndarray) -> np.ndarray:
         if isinstance(colormap_value, int):
             colormap = cv2.applyColorMap(np.arange(256, dtype=np.uint8), colormap_value)
             return colormap
@@ -157,7 +155,7 @@ class ApplyDepthColormap(BaseHostNode):
 
     def _compute_normalization_bounds(
         self, valid_depth_values: np.ndarray
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         low = float(np.percentile(valid_depth_values, self._p_low))
         high = float(np.percentile(valid_depth_values, self._p_high))
         return low, high

--- a/depthai_nodes/node/depth_merger.py
+++ b/depthai_nodes/node/depth_merger.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import depthai as dai
 
 from depthai_nodes.node.base_host_node import BaseHostNode
@@ -83,7 +81,7 @@ class DepthMerger(BaseHostNode):
 
     def _transform(
         self, message_2d: dai.Buffer, depth: dai.ImgFrame
-    ) -> Union[dai.SpatialImgDetections, dai.SpatialImgDetection]:
+    ) -> dai.SpatialImgDetections | dai.SpatialImgDetection:
         """Transforms 2D detections into spatial detections based on the depth frame."""
         if isinstance(message_2d, dai.ImgDetection):
             return self._detection_to_spatial(message_2d, depth)

--- a/depthai_nodes/node/extended_neural_network.py
+++ b/depthai_nodes/node/extended_neural_network.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import depthai as dai
 
 from depthai_nodes.node.base_threaded_host_node import BaseThreadedHostNode
@@ -79,11 +77,11 @@ class ExtendedNeuralNetwork(BaseThreadedHostNode):
                 "ExtendedNeuralNetwork node is currently not supported on RVC2."
             )
         self._has_camera_node_as_input = False
-        self._nn: Optional[ParsingNeuralNetwork] = None
-        self._coordinates_mapper: Optional[CoordinatesMapper] = None
+        self._nn: ParsingNeuralNetwork | None = None
+        self._coordinates_mapper: CoordinatesMapper | None = None
 
     @property
-    def out(self) -> Optional[dai.Node.Output]:
+    def out(self) -> dai.Node.Output | None:
         """Return the primary parsed output stream."""
         if not self._nn:
             return None
@@ -93,7 +91,7 @@ class ExtendedNeuralNetwork(BaseThreadedHostNode):
             return self._coordinates_mapper.out
 
     @property
-    def outputs(self) -> Optional[dai.Node.Output]:
+    def outputs(self) -> dai.Node.Output | None:
         """Return the multi-head output stream when available."""
         if not self._nn:
             return None
@@ -103,7 +101,7 @@ class ExtendedNeuralNetwork(BaseThreadedHostNode):
             return self._coordinates_mapper.out
 
     @property
-    def passthrough(self) -> Optional[dai.Node.Output]:
+    def passthrough(self) -> dai.Node.Output | None:
         """Return the passthrough stream from the underlying NN node."""
         if not self._nn:
             return None
@@ -112,7 +110,7 @@ class ExtendedNeuralNetwork(BaseThreadedHostNode):
     def build(
         self,
         inputImage: dai.node.Camera | dai.Node.Output,
-        nnSource: Union[dai.NNModelDescription, dai.NNArchive, str],
+        nnSource: dai.NNModelDescription | dai.NNArchive | str,
         resizeMode: dai.ImageManipConfig.ResizeMode = dai.ImageManipConfig.ResizeMode.CENTER_CROP,
     ) -> "ExtendedNeuralNetwork":
         """Build the internal inference pipeline.
@@ -121,7 +119,7 @@ class ExtendedNeuralNetwork(BaseThreadedHostNode):
             the camera; generic outputs are resized via an internal ImageManip.
         @type inputImage: dai.node.Camera | dai.Node.Output
         @param nnSource: HubAI model slug, dai.NNModelDescription, or dai.NNArchive.
-        @type nnSource: Union[dai.NNModelDescription, dai.NNArchive, str]
+        @type nnSource: dai.NNModelDescription | dai.NNArchive | str
         @param resizeMode: Resize strategy used when adapting frames to the network
             input shape.
         @type resizeMode: dai.ImageManipConfig.ResizeMode

--- a/depthai_nodes/node/frame_cropper.py
+++ b/depthai_nodes/node/frame_cropper.py
@@ -1,5 +1,4 @@
 from string import Template
-from typing import Optional, Tuple
 
 import depthai as dai
 
@@ -126,16 +125,16 @@ class FrameCropper(BaseThreadedHostNode):
         super().__init__()
         self._cropper_image_manip = self._pipeline.create(dai.node.ImageManip)
         self._version_selected = False
-        self._output_size: Optional[Tuple[int, int]] = None  # width, height
+        self._output_size: tuple[int, int] | None = None  # width, height
 
         # when fromImgDetections is used script node can work on ImgDetections directly
-        self._script: Optional[dai.node.Script] = None
-        self._input_img_detections: Optional[dai.Node.Output] = None
-        self._padding: Optional[float] = None
-        self._resize_mode: Optional[dai.ImageManipConfig.ResizeMode] = None
+        self._script: dai.node.Script | None = None
+        self._input_img_detections: dai.Node.Output | None = None
+        self._padding: float | None = None
+        self._resize_mode: dai.ImageManipConfig.ResizeMode | None = None
 
         # when fromManipConfigs is used, script node receives MessageGroup of precomputed configs
-        self._input_manip_configs: Optional[dai.Node.Output] = None
+        self._input_manip_configs: dai.Node.Output | None = None
         self._wait_for_cfg = False
         self._logger.debug("FrameCropper initialized")
 
@@ -147,7 +146,7 @@ class FrameCropper(BaseThreadedHostNode):
     def fromImgDetections(
         self,
         inputImgDetections: dai.Node.Output,
-        outputSize: Tuple[int, int],
+        outputSize: tuple[int, int],
         resizeMode: dai.ImageManipConfig.ResizeMode = dai.ImageManipConfig.ResizeMode.CENTER_CROP,
         padding: float = 0.0,
     ) -> "FrameCropper":

--- a/depthai_nodes/node/gather_data.py
+++ b/depthai_nodes/node/gather_data.py
@@ -1,11 +1,8 @@
 import time
+from collections.abc import Callable
 from queue import PriorityQueue
 from typing import (
-    Callable,
-    Dict,
     Generic,
-    List,
-    Optional,
     Protocol,
     TypeVar,
     runtime_checkable,
@@ -20,7 +17,7 @@ from depthai_nodes.logging import get_logger
 @runtime_checkable
 class HasDetections(Protocol):
     @property
-    def detections(self) -> List:
+    def detections(self) -> list:
         """Return the detections used to derive the default wait count."""
         ...
 
@@ -89,10 +86,10 @@ class GatherData(dai.node.ThreadedHostNode, Generic[TReference, TGathered]):
     def __init__(self) -> None:
         """Initializes the GatherData node."""
         super().__init__()
-        self._camera_fps: Optional[int] = None
-        self._unmatched_data: List[TGathered] = []
-        self._data_by_reference_ts: Dict[float, List[TGathered]] = {}
-        self._reference_data: Dict[float, TReference] = {}
+        self._camera_fps: int | None = None
+        self._unmatched_data: list[TGathered] = []
+        self._data_by_reference_ts: dict[float, list[TGathered]] = {}
+        self._reference_data: dict[float, TReference] = {}
         self._ready_timestamps = PriorityQueue()
         self._wait_count_fn = self._default_wait_count_fn
 
@@ -128,7 +125,7 @@ class GatherData(dai.node.ThreadedHostNode, Generic[TReference, TGathered]):
         cameraFps: int,
         inputData: dai.Node.Output,
         inputReference: dai.Node.Output,
-        waitCountFn: Optional[Callable[[TReference], int]] = None,
+        waitCountFn: Callable[[TReference], int] | None = None,
     ) -> "GatherData[TReference, TGathered]":
         """Connect the data and reference streams used for gathering.
 
@@ -142,7 +139,7 @@ class GatherData(dai.node.ThreadedHostNode, Generic[TReference, TGathered]):
         @param waitCountFn: Optional callback returning the number of data messages
             expected for a given reference. If omitted, defaults to
             len(reference.detections).
-        @type waitCountFn: Optional[Callable[[TReference], int]]
+        @type waitCountFn: Callable[[TReference], int] | None
         @return: The configured node instance.
         @rtype: GatherData[TReference, TGathered]
         """
@@ -220,7 +217,7 @@ class GatherData(dai.node.ThreadedHostNode, Generic[TReference, TGathered]):
     def _get_total_seconds_ts(self, buffer_like: dai.Buffer) -> float:
         return buffer_like.getTimestamp().total_seconds()
 
-    def _get_matching_reference_ts(self, data_ts: float) -> Optional[float]:
+    def _get_matching_reference_ts(self, data_ts: float) -> float | None:
         for reference_ts in self._reference_data.keys():
             if self._timestamps_in_tolerance(reference_ts, data_ts):
                 return reference_ts
@@ -238,7 +235,7 @@ class GatherData(dai.node.ThreadedHostNode, Generic[TReference, TGathered]):
         self._ready_timestamps.put(timestamp)
 
     def _try_match_data(self, reference_ts: float) -> None:
-        matched_data: List[TGathered] = []
+        matched_data: list[TGathered] = []
         for data in self._unmatched_data:
             data_ts = self._get_total_seconds_ts(data)
             if self._timestamps_in_tolerance(reference_ts, data_ts):
@@ -270,7 +267,7 @@ class GatherData(dai.node.ThreadedHostNode, Generic[TReference, TGathered]):
     def _get_wait_count(self, reference: TReference) -> int:
         return self._wait_count_fn(reference)
 
-    def _pop_ready_data(self) -> Optional[GatheredData]:
+    def _pop_ready_data(self) -> GatheredData | None:
         if self._ready_timestamps.empty():
             return None
 

--- a/depthai_nodes/node/host_spatials_calc.py
+++ b/depthai_nodes/node/host_spatials_calc.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List
+from collections.abc import Callable
 
 import depthai as dai
 import numpy as np
@@ -49,9 +49,7 @@ class HostSpatialsCalc:
                 thresholdLow = int(thresholdLow)
             else:
                 raise TypeError(
-                    "Threshold has to be an integer or float! Got {}".format(
-                        type(thresholdLow)
-                    )
+                    f"Threshold has to be an integer or float! Got {type(thresholdLow)}"
                 )
         self.thresh_low = thresholdLow
 
@@ -66,9 +64,7 @@ class HostSpatialsCalc:
                 thresholdHigh = int(thresholdHigh)
             else:
                 raise TypeError(
-                    "Threshold has to be an integer or float! Got {}".format(
-                        type(thresholdHigh)
-                    )
+                    f"Threshold has to be an integer or float! Got {type(thresholdHigh)}"
                 )
         self.thresh_high = thresholdHigh
 
@@ -79,27 +75,27 @@ class HostSpatialsCalc:
                 delta = int(delta)
             else:
                 raise TypeError(
-                    "Delta has to be an integer or float! Got {}".format(type(delta))
+                    f"Delta has to be an integer or float! Got {type(delta)}"
                 )
         self.delta = delta
 
     def calcSpatials(
         self,
         depthData: dai.ImgFrame,
-        roi: List[int],
+        roi: list[int],
         averagingMethod: Callable = np.mean,
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """Calculate spatial coordinates from the depth frame within the ROI.
 
         @param depthData: Depth frame used for coordinate estimation.
         @type depthData: dai.ImgFrame
         @param roi: Region of interest or point.
-        @type roi: List[int]
+        @type roi: list[int]
         @param averagingMethod: Callable used to reduce valid depth values inside the
             ROI.
         @type averagingMethod: Callable
         @return: Spatial coordinates in camera space.
-        @rtype: Dict[str, float]
+        @rtype: dict[str, float]
         """
         depthFrame = depthData.getFrame()
 
@@ -146,7 +142,7 @@ class HostSpatialsCalc:
         }
         return spatials
 
-    def _check_input(self, roi: List[int], frame: np.ndarray) -> List[int]:
+    def _check_input(self, roi: list[int], frame: np.ndarray) -> list[int]:
         if len(roi) == 4:
             return roi
         if len(roi) != 2:

--- a/depthai_nodes/node/img_detections_filter.py
+++ b/depthai_nodes/node/img_detections_filter.py
@@ -1,6 +1,5 @@
 import warnings
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
 
 import depthai as dai
 import numpy as np
@@ -12,16 +11,16 @@ from depthai_nodes.node.utils.nms import nms_detections
 
 @dataclass
 class _FilterCfg:
-    labels_to_keep: Optional[List[int]] = None
-    labels_to_reject: Optional[List[int]] = None
-    min_confidence: Optional[float] = None
-    min_area: Optional[float] = None
+    labels_to_keep: list[int] | None = None
+    labels_to_reject: list[int] | None = None
+    min_confidence: float | None = None
+    min_area: float | None = None
     nms_disabled: bool = True
     nms_conf_thresh: float = 0.3
     nms_iou_thresh: float = 0.4
     sort_desc: bool = True
     sort_disabled: bool = True
-    first_k: Optional[int] = None
+    first_k: int | None = None
 
 
 class ImgDetectionsFilter(BaseHostNode):
@@ -60,7 +59,7 @@ class ImgDetectionsFilter(BaseHostNode):
         )
         self._logger.debug("ImgDetectionsFilter initialized")
 
-    def setLabels(self, labels: List[int], keep: bool) -> None:
+    def setLabels(self, labels: list[int], keep: bool) -> None:
         """Deprecated wrapper for configuring label inclusion or exclusion."""
         warnings.warn(
             "setLabels() is deprecated; use keepLabels() or rejectLabels() instead.",
@@ -169,7 +168,7 @@ class ImgDetectionsFilter(BaseHostNode):
         self._cfg.sort_disabled = True
         return self
 
-    def takeFirstK(self, k: Optional[int]):
+    def takeFirstK(self, k: int | None):
         """Keep only the first ``k`` detections after filtering and sorting."""
         self._cfg.first_k = k
         return self
@@ -211,10 +210,10 @@ class ImgDetectionsFilter(BaseHostNode):
 
     def _filter_step(
         self,
-        detections: List[dai.ImgDetection | dai.SpatialImgDetection],
-    ) -> Tuple[List[dai.ImgDetection | dai.SpatialImgDetection], List[int]]:
+        detections: list[dai.ImgDetection | dai.SpatialImgDetection],
+    ) -> tuple[list[dai.ImgDetection | dai.SpatialImgDetection], list[int]]:
         filtered_detections = []
-        filtered_out_ixs: List[int] = []
+        filtered_out_ixs: list[int] = []
         for ix, detection in enumerate(detections):
             if self._cfg.labels_to_keep is not None:
                 if detection.label not in self._cfg.labels_to_keep:
@@ -241,8 +240,8 @@ class ImgDetectionsFilter(BaseHostNode):
         return filtered_detections, filtered_out_ixs
 
     def _nms_step(
-        self, detections: List[dai.ImgDetection | dai.SpatialImgDetection]
-    ) -> List[dai.ImgDetection | dai.SpatialImgDetection]:
+        self, detections: list[dai.ImgDetection | dai.SpatialImgDetection]
+    ) -> list[dai.ImgDetection | dai.SpatialImgDetection]:
         if self._cfg.nms_disabled:
             return detections
         return nms_detections(
@@ -252,8 +251,8 @@ class ImgDetectionsFilter(BaseHostNode):
         )
 
     def _sorting_step(
-        self, detections: List[dai.ImgDetection | dai.SpatialImgDetection]
-    ) -> List[dai.ImgDetection | dai.SpatialImgDetection]:
+        self, detections: list[dai.ImgDetection | dai.SpatialImgDetection]
+    ) -> list[dai.ImgDetection | dai.SpatialImgDetection]:
         if not self._cfg.sort_disabled:
             sorted_detections = sorted(
                 detections, key=lambda x: x.confidence, reverse=self._cfg.sort_desc
@@ -262,7 +261,7 @@ class ImgDetectionsFilter(BaseHostNode):
         return detections
 
     @staticmethod
-    def _update_segmentation_mask(msg_new, filtered_out_ixs: List[int]):
+    def _update_segmentation_mask(msg_new, filtered_out_ixs: list[int]):
         mask = msg_new.getCvSegmentationMask()
         if mask is not None:
             mask = np.where(np.isin(mask, filtered_out_ixs), 255, mask)

--- a/depthai_nodes/node/img_frame_overlay.py
+++ b/depthai_nodes/node/img_frame_overlay.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import cv2
 import depthai as dai
 
@@ -61,8 +59,8 @@ class ImgFrameOverlay(BaseHostNode):
         self,
         frame1: dai.Node.Output,
         frame2: dai.Node.Output,
-        alpha: Optional[float] = None,
-        preserveBackground: Optional[bool] = None,
+        alpha: float | None = None,
+        preserveBackground: bool | None = None,
     ) -> "ImgFrameOverlay":
         """Connect the input streams and optionally update overlay settings.
 
@@ -71,10 +69,10 @@ class ImgFrameOverlay(BaseHostNode):
         @param frame2: Upstream output producing the foreground frame.
         @type frame2: dai.Node.Output
         @param alpha: Optional blend weight for the background frame.
-        @type alpha: Optional[float]
+        @type alpha: float | None
         @param preserveBackground: Optional override for whether zero-valued foreground
             pixels preserve the background frame.
-        @type preserveBackground: Optional[bool]
+        @type preserveBackground: bool | None
         @return: The configured node instance.
         @rtype: ImgFrameOverlay
         """

--- a/depthai_nodes/node/message_collector.py
+++ b/depthai_nodes/node/message_collector.py
@@ -1,6 +1,5 @@
 from typing import (
     Generic,
-    Optional,
     TypeVar,
 )
 
@@ -43,7 +42,7 @@ class MessageCollector(dai.node.ThreadedHostNode, Generic[TCollected]):
     def __init__(self) -> None:
         """Initializes the GatherData node."""
         super().__init__()
-        self._camera_fps: Optional[int] = None
+        self._camera_fps: int | None = None
 
         self._data_input = self.createInput()
         self._out = self.createOutput()

--- a/depthai_nodes/node/parser_generator.py
+++ b/depthai_nodes/node/parser_generator.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Optional
-
 import depthai as dai
 
 from depthai_nodes.logging import get_logger
@@ -38,24 +36,24 @@ class ParserGenerator(dai.node.ThreadedHostNode):
     def build(
         self,
         nnArchive: dai.NNArchive,
-        headIndex: Optional[int] = None,
+        headIndex: int | None = None,
         hostOnly: bool = False,
-    ) -> Dict:
+    ) -> dict:
         """Instantiate parser nodes for the supplied model archive.
 
         @param nnArchive: Model archive describing the parser configuration.
         @type nnArchive: dai.NNArchive
         @param headIndex: Optional model head index to instantiate. If omitted, parsers
             are created for all heads.
-        @type headIndex: Optional[int]
+        @type headIndex: int | None
         @param hostOnly: If True, prefer host-side parser implementations where
             available.
         @type hostOnly: bool
         @return: Mapping of model head index to parser node.
-        @rtype: Dict
+        @rtype: dict
         """
 
-        heads: List = nnArchive.getConfig().model.heads  # type: ignore
+        heads: list = nnArchive.getConfig().model.heads  # type: ignore
 
         indexes = range(len(heads))
 

--- a/depthai_nodes/node/parsers/base_parser.py
+++ b/depthai_nodes/node/parsers/base_parser.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 import depthai as dai
 
@@ -54,12 +54,12 @@ class BaseParser(dai.node.ThreadedHostNode, metaclass=BaseMeta):
         self._out = node
 
     @abstractmethod
-    def build(self, head_config: Dict[str, Any]) -> "BaseParser":
+    def build(self, head_config: dict[str, Any]) -> "BaseParser":
         """Configures the parser based on the specified head configuration.
 
         @param head_config: A dictionary containing configuration details relevant to
             the parser, including parameters and settings required for output parsing.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: BaseParser
         """

--- a/depthai_nodes/node/parsers/classification.py
+++ b/depthai_nodes/node/parsers/classification.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -17,7 +17,7 @@ class ClassificationParser(BaseParser):
     ----------
     output_layer_name: str
         Name of the output layer relevant to the parser.
-    classes : List[str]
+    classes : list[str]
         List of class names to be used for linking with their respective scores.
         Expected to be in the same order as Neural Network's output. If not provided, the message will only return sorted scores.
     is_softmax : bool = True
@@ -33,7 +33,7 @@ class ClassificationParser(BaseParser):
     def __init__(
         self,
         output_layer_name: str = "",
-        classes: List[str] = None,
+        classes: list[str] = None,
         is_softmax: bool = True,
     ) -> None:
         """Initializes the parser node.
@@ -43,7 +43,7 @@ class ClassificationParser(BaseParser):
         @param classes: List of class names to be used for linking with their respective
             scores. Expected to be in the same order as Neural Network's output. If not
             provided, the message will only return sorted scores.
-        @type classes: List[str]
+        @type classes: list[str]
         @param is_softmax: If False, the scores are converted to probabilities using
             softmax function.
         @type is_softmax: bool
@@ -68,12 +68,12 @@ class ClassificationParser(BaseParser):
         self.output_layer_name = output_layer_name
         self._logger.debug(f"Output layer name set to '{self.output_layer_name}'")
 
-    def setClasses(self, classes: List[str]) -> None:
+    def setClasses(self, classes: list[str]) -> None:
         """Sets the class names for the classification model.
 
         @param classes: List of class names to be used for linking with their respective
             scores.
-        @type classes: List[str]
+        @type classes: list[str]
         """
         if not isinstance(classes, list):
             raise ValueError("classes must be a list.")
@@ -98,12 +98,12 @@ class ClassificationParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "ClassificationParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: ClassificationParser
         """

--- a/depthai_nodes/node/parsers/classification_sequence.py
+++ b/depthai_nodes/node/parsers/classification_sequence.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -20,11 +20,11 @@ class ClassificationSequenceParser(ClassificationParser):
     ----------
     output_layer_name: str
         Name of the output layer relevant to the parser.
-    classes: List[str]
+    classes: list[str]
         List of available classes for the model.
     is_softmax: bool
         If False, the scores are converted to probabilities using softmax function.
-    ignored_indexes: List[int]
+    ignored_indexes: list[int]
         List of indexes to ignore during classification generation (e.g., background class, blank space).
     remove_duplicates: bool
         If True, removes consecutive duplicates from the sequence.
@@ -42,9 +42,9 @@ class ClassificationSequenceParser(ClassificationParser):
     def __init__(
         self,
         output_layer_name: str = "",
-        classes: List[str] = None,
+        classes: list[str] = None,
         is_softmax: bool = True,
-        ignored_indexes: List[int] = None,
+        ignored_indexes: list[int] = None,
         remove_duplicates: bool = False,
         concatenate_classes: bool = False,
     ) -> None:
@@ -53,10 +53,10 @@ class ClassificationSequenceParser(ClassificationParser):
         @param output_layer_name: Name of the output layer relevant to the parser.
         @type output_layer_name: str
         @param classes: List of available classes for the model.
-        @type classes: List[str]
+        @type classes: list[str]
         @param ignored_indexes: List of indexes to ignore during classification
             generation (e.g., background class, blank space).
-        @type ignored_indexes: List[int]
+        @type ignored_indexes: list[int]
         @param is_softmax: If False, the scores are converted to probabilities using
             softmax function.
         @type is_softmax: bool
@@ -90,12 +90,12 @@ class ClassificationSequenceParser(ClassificationParser):
         self.remove_duplicates = remove_duplicates
         self._logger.debug(f"Remove duplicates set to {remove_duplicates}")
 
-    def setIgnoredIndexes(self, ignored_indexes: List[int]) -> None:
+    def setIgnoredIndexes(self, ignored_indexes: list[int]) -> None:
         """Sets the ignored_indexes for the classification sequence model.
 
         @param ignored_indexes: A list of indexes to ignore during classification
             generation.
-        @type ignored_indexes: List[int]
+        @type ignored_indexes: list[int]
         """
         if not isinstance(ignored_indexes, list):
             raise ValueError("Ignored indexes must be a list.")
@@ -116,13 +116,12 @@ class ClassificationSequenceParser(ClassificationParser):
         self.concatenate_classes = concatenate_classes
         self._logger.debug(f"Concatenate classes set to {concatenate_classes}")
 
-    def build(self, head_config: Dict[str, Any]) -> "ClassificationSequenceParser":
+    def build(self, head_config: dict[str, Any]) -> "ClassificationSequenceParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser. The required keys are `classes`, `n_classes`, and `is_softmax`.
         In addition to these, there are three optional keys that are mostly used for text processing: `ignored_indexes`, `remove_duplicates` and `concatenate_classes`.
-        @type head_config: Dict[str, Any]
-
+        @type head_config: dict[str, Any]
         @return: Returns the instantiated parser with the correct configuration.
         @rtype: ClassificationParser
         """

--- a/depthai_nodes/node/parsers/detection.py
+++ b/depthai_nodes/node/parsers/detection.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 import depthai as dai
 import numpy as np
 
@@ -30,8 +28,8 @@ class DetectionParser(BaseParser):
         Non-maximum suppression threshold.
     max_det : int
         Maximum number of detections to keep.
-    label_names : List[str]
-        List of label names for detected objects.
+    label_names : list[str]
+    List of label names for detected objects.
 
     Output Message/s
         -------
@@ -46,7 +44,7 @@ class DetectionParser(BaseParser):
         conf_threshold: float = 0.5,
         iou_threshold: float = 0.5,
         max_det: int = 100,
-        label_names: Optional[List[str]] = None,
+        label_names: list[str] | None = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -99,11 +97,11 @@ class DetectionParser(BaseParser):
         self.max_det = max_det
         self._logger.debug(f"Maximum detections updated to {max_det}")
 
-    def setLabelNames(self, label_names: List[str]) -> None:
+    def setLabelNames(self, label_names: list[str]) -> None:
         """Sets the label names for detected objects.
 
         @param label_names: List of label names for detected objects.
-        @type label_names: List[str]
+        @type label_names: list[str]
         """
         if not isinstance(label_names, list):
             raise ValueError("Label names must be a list.")
@@ -116,7 +114,7 @@ class DetectionParser(BaseParser):
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: DetectionParser
         """

--- a/depthai_nodes/node/parsers/embeddings.py
+++ b/depthai_nodes/node/parsers/embeddings.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import depthai as dai
 
@@ -40,11 +40,11 @@ class EmbeddingsParser(BaseParser):
         self.output_layer_name = output_layer_name
         self._logger.debug(f"Output layer name set to {self.output_layer_name}")
 
-    def build(self, head_config: Dict[str, Any]) -> "EmbeddingsParser":
+    def build(self, head_config: dict[str, Any]) -> "EmbeddingsParser":
         """Sets the head configuration for the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: EmbeddingsParser
         """

--- a/depthai_nodes/node/parsers/fastsam.py
+++ b/depthai_nodes/node/parsers/fastsam.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -31,15 +31,15 @@ class FastSAMParser(BaseParser):
         Mask confidence threshold.
     prompt : str
         Prompt type.
-    points : Tuple[int, int]
+    points : tuple[int, int]
         Points.
     point_label : int
         Point label.
-    bbox : Tuple[int, int, int, int]
+    bbox : tuple[int, int, int, int]
         Bounding box.
-    yolo_outputs : List[str]
+    yolo_outputs : list[str]
         Names of the YOLO outputs.
-    mask_outputs : List[str]
+    mask_outputs : list[str]
         Names of the mask outputs.
     protos_output : str
         Name of the protos output.
@@ -61,11 +61,11 @@ class FastSAMParser(BaseParser):
         iou_threshold: float = 0.5,
         mask_conf: float = 0.5,
         prompt: str = "everything",
-        points: Optional[Tuple[int, int]] = None,
-        point_label: Optional[int] = None,
-        bbox: Optional[Tuple[int, int, int, int]] = None,
-        yolo_outputs: List[str] = None,
-        mask_outputs: List[str] = None,
+        points: tuple[int, int] | None = None,
+        point_label: int | None = None,
+        bbox: tuple[int, int, int, int] | None = None,
+        yolo_outputs: list[str] = None,
+        mask_outputs: list[str] = None,
         protos_output: str = "protos_output",
     ) -> None:
         """Initializes the parser node.
@@ -81,15 +81,15 @@ class FastSAMParser(BaseParser):
         @param prompt: The prompt type
         @type prompt: str
         @param points: The points
-        @type points: Optional[Tuple[int, int]]
+        @type points: tuple[int, int] | None
         @param point_label: The point label
-        @type point_label: Optional[int]
+        @type point_label: int | None
         @param bbox: The bounding box
-        @type bbox: Optional[Tuple[int, int, int, int]]
+        @type bbox: tuple[int, int, int, int] | None
         @param yolo_outputs: The YOLO outputs
-        @type yolo_outputs: List[str]
+        @type yolo_outputs: list[str]
         @param mask_outputs: The mask outputs
-        @type mask_outputs: List[str]
+        @type mask_outputs: list[str]
         @param protos_output: The protos output
         @type protos_output: str
         """
@@ -182,11 +182,11 @@ class FastSAMParser(BaseParser):
         self.prompt = prompt
         self._logger.debug(f"Prompt set to '{self.prompt}'")
 
-    def setPoints(self, points: Tuple[int, int]) -> None:
+    def setPoints(self, points: tuple[int, int]) -> None:
         """Sets the points.
 
         @param points: The points
-        @type points: Tuple[int, int]
+        @type points: tuple[int, int]
         """
         if not isinstance(points, tuple):
             raise ValueError("Points must be a tuple.")
@@ -208,11 +208,11 @@ class FastSAMParser(BaseParser):
         self.point_label = point_label
         self._logger.debug(f"Point label set to {self.point_label}")
 
-    def setBoundingBox(self, bbox: Tuple[int, int, int, int]) -> None:
+    def setBoundingBox(self, bbox: tuple[int, int, int, int]) -> None:
         """Sets the bounding box.
 
         @param bbox: The bounding box
-        @type bbox: Tuple[int, int, int, int]
+        @type bbox: tuple[int, int, int, int]
         """
         if not isinstance(bbox, tuple):
             raise ValueError("Bounding box must be a tuple.")
@@ -223,11 +223,11 @@ class FastSAMParser(BaseParser):
         self.bbox = bbox
         self._logger.debug(f"Bounding box set to {self.bbox}")
 
-    def setYoloOutputs(self, yolo_outputs: List[str]) -> None:
+    def setYoloOutputs(self, yolo_outputs: list[str]) -> None:
         """Sets the YOLO outputs.
 
         @param yolo_outputs: The YOLO outputs
-        @type yolo_outputs: List[str]
+        @type yolo_outputs: list[str]
         """
         if not isinstance(yolo_outputs, list):
             raise ValueError("YOLO outputs must be a list.")
@@ -236,11 +236,11 @@ class FastSAMParser(BaseParser):
         self.yolo_outputs = yolo_outputs
         self._logger.debug(f"YOLO outputs set to {self.yolo_outputs}")
 
-    def setMaskOutputs(self, mask_outputs: List[str]) -> None:
+    def setMaskOutputs(self, mask_outputs: list[str]) -> None:
         """Sets the mask outputs.
 
         @param mask_outputs: The mask outputs
-        @type mask_outputs: List[str]
+        @type mask_outputs: list[str]
         """
         if not isinstance(mask_outputs, list):
             raise ValueError("Mask outputs must be a list.")
@@ -260,11 +260,11 @@ class FastSAMParser(BaseParser):
         self.protos_output = protos_output
         self._logger.debug(f"Protos output set to '{self.protos_output}'")
 
-    def build(self, head_config: Dict[str, Any]) -> "FastSAMParser":
+    def build(self, head_config: dict[str, Any]) -> "FastSAMParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: FastSAMParser
         """

--- a/depthai_nodes/node/parsers/hrnet.py
+++ b/depthai_nodes/node/parsers/hrnet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -16,9 +16,9 @@ class HRNetParser(KeypointParser):
         Name of the output layer relevant to the parser.
     score_threshold : float
         Confidence score threshold for detected keypoints.
-    label_names: Optional[List[str]]
+    label_names: list[str] | None
         Label names for the keypoints.
-    edges: Optional[List[Tuple[int, int]]]
+    edges: list[tuple[int, int]] | None
         Keypoint connection pairs for visualizing the skeleton. Example:
             [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
             1, keypoint 1 is connected to keypoint 2, etc.
@@ -34,8 +34,8 @@ class HRNetParser(KeypointParser):
         self,
         output_layer_name: str = "",
         score_threshold: float = 0.5,
-        label_names: Optional[List[str]] = None,
-        edges: Optional[List[Tuple[int, int]]] = None,
+        label_names: list[str] | None = None,
+        edges: list[tuple[int, int]] | None = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -44,11 +44,11 @@ class HRNetParser(KeypointParser):
         @param score_threshold: Confidence score threshold for detected keypoints.
         @type score_threshold: float
         @param label_names: Label names for the keypoints.
-        @type label_names: Optional[List[str]]
+        @type label_names: list[str] | None
         @param edges: Keypoint connection pairs for visualizing the skeleton. Example:
             [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
             1, keypoint 1 is connected to keypoint 2, etc.
-        @type edges: Optional[List[Tuple[int, int]]]
+        @type edges: list[tuple[int, int]] | None
         """
         super().__init__(
             output_layer_name,
@@ -73,12 +73,12 @@ class HRNetParser(KeypointParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "HRNetParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: HRNetParser
         """

--- a/depthai_nodes/node/parsers/image_output.py
+++ b/depthai_nodes/node/parsers/image_output.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import depthai as dai
 
@@ -70,12 +70,12 @@ class ImageOutputParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "ImageOutputParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: ImageOutputParser
         """

--- a/depthai_nodes/node/parsers/keypoints.py
+++ b/depthai_nodes/node/parsers/keypoints.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -22,9 +22,9 @@ class KeypointParser(BaseParser):
         Number of keypoints the model detects.
     score_threshold : float
         Confidence score threshold for detected keypoints.
-    label_names : List[str]
+    label_names : list[str]
         Label names for the keypoints.
-    edges : List[Tuple[int, int]]
+    edges : list[tuple[int, int]]
         Keypoint connection pairs for visualizing the skeleton. Example: [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is connected to keypoint 2, etc.
 
     Output Message/s
@@ -48,8 +48,8 @@ class KeypointParser(BaseParser):
         scale_factor: float = 1.0,
         n_keypoints: int = None,
         score_threshold: float = None,
-        label_names: Optional[List[str]] = None,
-        edges: Optional[List[List[int]]] = None,
+        label_names: list[str] | None = None,
+        edges: list[list[int]] | None = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -60,11 +60,11 @@ class KeypointParser(BaseParser):
         @param n_keypoints: Number of keypoints.
         @type n_keypoints: int
         @param label_names: Label names for the keypoints.
-        @type label_names: Optional[List[str]]
+        @type label_names: list[str] | None
         @param edges: Keypoint connection pairs for visualizing the skeleton. Example:
             [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
             1, keypoint 1 is connected to keypoint 2, etc.
-        @type edges: Optional[List[Tuple[int, int]]]
+        @type edges: list[tuple[int, int]] | None
         """
         super().__init__()
         self.output_layer_name = output_layer_name
@@ -133,11 +133,11 @@ class KeypointParser(BaseParser):
         self.score_threshold = threshold
         self._logger.debug(f"Score threshold set to {self.score_threshold}")
 
-    def setLabelNames(self, label_names: List[str]) -> None:
+    def setLabelNames(self, label_names: list[str]) -> None:
         """Sets the label names for the keypoints.
 
         @param label_names: List of label names for the keypoints.
-        @type label_names: List[str]
+        @type label_names: list[str]
         """
         if not isinstance(label_names, list):
             raise ValueError("Label names must be a list.")
@@ -146,13 +146,13 @@ class KeypointParser(BaseParser):
         self.label_names = label_names
         self._logger.debug(f"Label names set to {self.label_names}")
 
-    def setEdges(self, edges: List[Tuple[int, int]]) -> None:
+    def setEdges(self, edges: list[tuple[int, int]]) -> None:
         """Sets the edges for the keypoints.
 
         @param edges: List of edges for the keypoints. Example: [(0,1), (1,2), (2,3),
             (3,0)] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is
             connected to keypoint 2, etc.
-        @type edges: List[Tuple[int, int]]
+        @type edges: list[tuple[int, int]]
         """
         if not isinstance(edges, list):
             raise ValueError("Edges must be a list.")
@@ -168,12 +168,12 @@ class KeypointParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "KeypointParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: KeypointParser
         """

--- a/depthai_nodes/node/parsers/lane_detection.py
+++ b/depthai_nodes/node/parsers/lane_detection.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -17,13 +17,13 @@ class LaneDetectionParser(BaseParser):
     ----------
     output_layer_name: str
         Name of the output layer relevant to the parser.
-    row_anchors : List[int]
+    row_anchors : list[int]
         List of row anchors.
     griding_num : int
         Griding number.
     cls_num_per_lane : int
         Number of points per lane.
-    input_size : Tuple[int, int]
+    input_size : tuple[int, int]
         Input size (width,height).
 
     Output Message/s
@@ -41,23 +41,23 @@ class LaneDetectionParser(BaseParser):
     def __init__(
         self,
         output_layer_name: str = "",
-        row_anchors: List[int] = None,
+        row_anchors: list[int] = None,
         griding_num: int = None,
         cls_num_per_lane: int = None,
-        input_size: Tuple[int, int] = None,
+        input_size: tuple[int, int] = None,
     ) -> None:
         """Initializes the lane detection parser node.
 
         @param output_layer_name: Name of the output layer relevant to the parser.
         @type output_layer_name: str
         @param row_anchors: List of row anchors.
-        @type row_anchors: List[int]
+        @type row_anchors: list[int]
         @param griding_num: Griding number.
         @type griding_num: int
         @param cls_num_per_lane: Number of points per lane.
         @type cls_num_per_lane: int
         @param input_size: Input size (width,height).
-        @type input_size: Tuple[int, int]
+        @type input_size: tuple[int, int]
         """
         super().__init__()
         self.output_layer_name = output_layer_name
@@ -81,11 +81,11 @@ class LaneDetectionParser(BaseParser):
         self.output_layer_name = output_layer_name
         self._logger.debug(f"Output layer name set to '{self.output_layer_name}'")
 
-    def setRowAnchors(self, row_anchors: List[int]) -> None:
+    def setRowAnchors(self, row_anchors: list[int]) -> None:
         """Set the row anchors for the lane detection model.
 
         @param row_anchors: List of row anchors.
-        @type row_anchors: List[int]
+        @type row_anchors: list[int]
         """
         if not isinstance(row_anchors, list):
             raise ValueError("Row anchors must be a list.")
@@ -116,11 +116,11 @@ class LaneDetectionParser(BaseParser):
         self.cls_num_per_lane = cls_num_per_lane
         self._logger.debug(f"Number of points per lane set to {self.cls_num_per_lane}")
 
-    def setInputSize(self, input_size: Tuple[int, int]) -> None:
+    def setInputSize(self, input_size: tuple[int, int]) -> None:
         """Set the input size for the lane detection model.
 
         @param input_size: Input size (width,height).
-        @type input_size: Tuple[int, int]
+        @type input_size: tuple[int, int]
         """
         if not isinstance(input_size, tuple):
             raise ValueError("Input size must be a tuple.")
@@ -133,12 +133,12 @@ class LaneDetectionParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "LaneDetectionParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: LaneDetectionParser
         """

--- a/depthai_nodes/node/parsers/map_output.py
+++ b/depthai_nodes/node/parsers/map_output.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import depthai as dai
 
@@ -67,12 +67,12 @@ class MapOutputParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "MapOutputParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: MapOutputParser
         """

--- a/depthai_nodes/node/parsers/mediapipe_palm_detection.py
+++ b/depthai_nodes/node/parsers/mediapipe_palm_detection.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 import cv2
 import depthai as dai
@@ -19,8 +19,8 @@ class MPPalmDetectionParser(DetectionParser):
 
     Attributes
     ----------
-    output_layer_names: List[str]
-        Names of the output layers relevant to the parser.
+    output_layer_names: list[str]
+    Names of the output layers relevant to the parser.
     conf_threshold : float
         Confidence score threshold for detected hands.
     iou_threshold : float
@@ -44,7 +44,7 @@ class MPPalmDetectionParser(DetectionParser):
 
     def __init__(
         self,
-        output_layer_names: List[str] = None,
+        output_layer_names: list[str] = None,
         conf_threshold: float = 0.5,
         iou_threshold: float = 0.5,
         max_det: int = 100,
@@ -53,7 +53,7 @@ class MPPalmDetectionParser(DetectionParser):
         """Initializes the parser node.
 
         @param output_layer_names: Names of the output layers relevant to the parser.
-        @type output_layer_names: List[str]
+        @type output_layer_names: list[str]
         @param conf_threshold: Confidence score threshold for detected hands.
         @type conf_threshold: float
         @param iou_threshold: Non-maximum suppression threshold.
@@ -77,12 +77,12 @@ class MPPalmDetectionParser(DetectionParser):
             f"MPPalmDetectionParser initialized with output_layer_names={output_layer_names}, conf_threshold={conf_threshold}, iou_threshold={iou_threshold}, max_det={max_det}, scale={scale}"
         )
 
-    def setOutputLayerNames(self, output_layer_names: List[str]) -> None:
+    def setOutputLayerNames(self, output_layer_names: list[str]) -> None:
         """Sets the output layer name(s) for the parser.
 
         @param output_layer_names: The name of the output layer(s) from which the scores
             are extracted.
-        @type output_layer_names: List[str]
+        @type output_layer_names: list[str]
         """
         if not isinstance(output_layer_names, list):
             raise ValueError("Output layer name must be a list.")
@@ -108,12 +108,12 @@ class MPPalmDetectionParser(DetectionParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "MPPalmDetectionParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: MPPalmDetectionParser
         """

--- a/depthai_nodes/node/parsers/mlsd.py
+++ b/depthai_nodes/node/parsers/mlsd.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -118,12 +118,12 @@ class MLSDParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "MLSDParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: MLSDParser
         """

--- a/depthai_nodes/node/parsers/ppdet.py
+++ b/depthai_nodes/node/parsers/ppdet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -80,11 +80,11 @@ class PPTextDetectionParser(DetectionParser):
         self.mask_threshold = mask_threshold
         self._logger.debug(f"Mask threshold set to {self.mask_threshold}")
 
-    def build(self, head_config: Dict[str, Any]) -> "PPTextDetectionParser":
+    def build(self, head_config: dict[str, Any]) -> "PPTextDetectionParser":
         """Configures the parser.
 
         @param config: The head configuration for the parser.
-        @type config: Dict[str, Any]
+        @type config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: PPTextDetectionParser
         """

--- a/depthai_nodes/node/parsers/regression.py
+++ b/depthai_nodes/node/parsers/regression.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -51,12 +51,12 @@ class RegressionParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "RegressionParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: RegressionParser
         """

--- a/depthai_nodes/node/parsers/rf_detr.py
+++ b/depthai_nodes/node/parsers/rf_detr.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -21,9 +21,9 @@ class RFDETRParser(BaseParser):
         Confidence score threshold for detected objects.
     max_det : int
         Maximum number of detections to keep.
-    label_names : Optional[List[str]]
+    label_names : list[str] | None
         List of label names for detected objects.
-    output_layer_names : List[str]
+    output_layer_names : list[str]
         Names of the output layers (boxes, logits, and optionally masks).
 
     Output Message/s
@@ -42,7 +42,7 @@ class RFDETRParser(BaseParser):
         self,
         conf_threshold: float = 0.5,
         max_det: int = 300,
-        label_names: Optional[List[str]] = None,
+        label_names: list[str] | None = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -51,13 +51,13 @@ class RFDETRParser(BaseParser):
         @param max_det: Maximum number of detections to keep.
         @type max_det: int
         @param label_names: List of label names for detected objects.
-        @type label_names: Optional[List[str]]
+        @type label_names: list[str] | None
         """
         super().__init__()
         self.conf_threshold = conf_threshold
         self.max_det = max_det
         self.label_names = label_names
-        self.output_layer_names = []
+        self.output_layer_names: list[str] = []
         self._logger.debug(
             f"RFDETRParser initialized with conf_threshold={conf_threshold}, max_det={max_det}"
         )
@@ -96,11 +96,11 @@ class RFDETRParser(BaseParser):
         self.max_det = max_det
         self._logger.debug(f"Maximum detections updated to {max_det}")
 
-    def setLabelNames(self, label_names: List[str]) -> None:
+    def setLabelNames(self, label_names: list[str]) -> None:
         """Sets the label names for detected objects.
 
         @param label_names: List of label names for detected objects.
-        @type label_names: List[str]
+        @type label_names: list[str]
         """
         if not isinstance(label_names, list):
             raise ValueError("Label names must be a list.")
@@ -109,11 +109,11 @@ class RFDETRParser(BaseParser):
         self.label_names = label_names
         self._logger.debug(f"Label names updated to: {label_names}")
 
-    def setOutputLayerNames(self, output_layer_names: List[str]) -> None:
+    def setOutputLayerNames(self, output_layer_names: list[str]) -> None:
         """Sets the output layer names for the parser.
 
         @param output_layer_names: List of output layer names.
-        @type output_layer_names: List[str]
+        @type output_layer_names: list[str]
         """
         if not isinstance(output_layer_names, list):
             raise ValueError("Output layer names must be a list.")
@@ -122,11 +122,11 @@ class RFDETRParser(BaseParser):
         self.output_layer_names = output_layer_names
         self._logger.debug(f"Output layer names set to {self.output_layer_names}")
 
-    def build(self, head_config: Dict[str, Any]) -> "RFDETRParser":
+    def build(self, head_config: dict[str, Any]) -> "RFDETRParser":
         """Configures the parser based on the head configuration.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: RFDETRParser
         """

--- a/depthai_nodes/node/parsers/scrfd.py
+++ b/depthai_nodes/node/parsers/scrfd.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -14,7 +14,7 @@ class SCRFDParser(DetectionParser):
 
     Attributes
     ----------
-    output_layer_name: List[str]
+    output_layer_name: list[str]
         Names of the output layers relevant to the parser.
     conf_threshold : float
         Confidence score threshold for detected faces.
@@ -38,18 +38,18 @@ class SCRFDParser(DetectionParser):
 
     def __init__(
         self,
-        output_layer_names: List[str] = None,
+        output_layer_names: list[str] = None,
         conf_threshold: float = 0.5,
         iou_threshold: float = 0.5,
         max_det: int = 100,
-        input_size: Tuple[int, int] = (640, 640),
-        feat_stride_fpn: Tuple = (8, 16, 32),
+        input_size: tuple[int, int] = (640, 640),
+        feat_stride_fpn: tuple = (8, 16, 32),
         num_anchors: int = 2,
     ) -> None:
         """Initializes the parser node.
 
         @param output_layer_names: Names of the output layers relevant to the parser.
-        @type output_layer_names: List[str]
+        @type output_layer_names: list[str]
         @param conf_threshold: Confidence score threshold for detected faces.
         @type conf_threshold: float
         @param iou_threshold: Non-maximum suppression threshold.
@@ -79,11 +79,11 @@ class SCRFDParser(DetectionParser):
             f"SCRFDParser initialized with output_layer_names={output_layer_names}, conf_threshold={conf_threshold}, iou_threshold={iou_threshold}, max_det={max_det}, input_size={input_size}, feat_stride_fpn={feat_stride_fpn}, num_anchors={num_anchors}"
         )
 
-    def setOutputLayerNames(self, output_layer_names: List[str]) -> None:
+    def setOutputLayerNames(self, output_layer_names: list[str]) -> None:
         """Sets the output layer name(s) for the parser.
 
         @param output_layer_names: The name of the output layer(s) to be used.
-        @type output_layer_names: List[str]
+        @type output_layer_names: list[str]
         """
         if not isinstance(output_layer_names, list):
             raise ValueError("Output layer names must be a list.")
@@ -92,7 +92,7 @@ class SCRFDParser(DetectionParser):
         self.output_layer_names = output_layer_names
         self._logger.debug(f"Output layer names set to {self.output_layer_names}")
 
-    def setInputSize(self, input_size: Tuple[int, int]) -> None:
+    def setInputSize(self, input_size: tuple[int, int]) -> None:
         """Sets the input size of the model.
 
         @param input_size: Input size of the model.
@@ -105,7 +105,7 @@ class SCRFDParser(DetectionParser):
         self.input_size = input_size
         self._logger.debug(f"Input size set to {self.input_size}")
 
-    def setFeatStrideFPN(self, feat_stride_fpn: List[int]) -> None:
+    def setFeatStrideFPN(self, feat_stride_fpn: list[int]) -> None:
         """Sets the feature stride of the FPN.
 
         @param feat_stride_fpn: Feature stride of the FPN.
@@ -131,12 +131,12 @@ class SCRFDParser(DetectionParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "SCRFDParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: SCRFDParser
         """

--- a/depthai_nodes/node/parsers/segmentation.py
+++ b/depthai_nodes/node/parsers/segmentation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -73,12 +73,12 @@ class SegmentationParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "SegmentationParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: SegmentationParser
         """

--- a/depthai_nodes/node/parsers/superanimal_landmarker.py
+++ b/depthai_nodes/node/parsers/superanimal_landmarker.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -21,9 +21,9 @@ class SuperAnimalParser(KeypointParser):
         Number of keypoints.
     score_threshold : float
         Confidence score threshold for detected keypoints.
-    label_names : List[str]
+    label_names : list[str]
         Label names for the keypoints.
-    edges : List[Tuple[int, int]]
+    edges : list[tuple[int, int]]
         Keypoint connection pairs for visualizing the skeleton. Example: [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is connected to keypoint 2, etc.
 
     Output Message/s
@@ -39,8 +39,8 @@ class SuperAnimalParser(KeypointParser):
         scale_factor: float = 256.0,
         n_keypoints: int = 39,
         score_threshold: float = 0.5,
-        label_names: Optional[List[str]] = None,
-        edges: Optional[List[Tuple[int, int]]] = None,
+        label_names: list[str] | None = None,
+        edges: list[tuple[int, int]] | None = None,
     ) -> None:
         """Initializes the parser node.
 
@@ -53,11 +53,11 @@ class SuperAnimalParser(KeypointParser):
         @param scale_factor: Scale factor to divide the keypoints by.
         @type scale_factor: float
         @param label_names: Label names for the keypoints.
-        @type label_names: Optional[List[str]]
+        @type label_names: list[str] | None
         @param edges: Keypoint connection pairs for visualizing the skeleton. Example:
             [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint
             1, keypoint 1 is connected to keypoint 2, etc.
-        @type edges: Optional[List[Tuple[int, int]]]
+        @type edges: list[tuple[int, int]] | None
         """
         super().__init__(
             output_layer_name,
@@ -73,12 +73,12 @@ class SuperAnimalParser(KeypointParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "SuperAnimalParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: SuperAnimalParser
         """

--- a/depthai_nodes/node/parsers/utils/activations.py
+++ b/depthai_nodes/node/parsers/utils/activations.py
@@ -1,10 +1,8 @@
-from typing import Optional
-
 import numpy as np
 
 
 def softmax(
-    x: np.ndarray, axis: Optional[int] = None, keep_dims: bool = False
+    x: np.ndarray, axis: int | None = None, keep_dims: bool = False
 ) -> np.ndarray:
     """Compute the softmax of an array. The softmax function is defined as: softmax(x) =
     exp(x) / sum(exp(x))

--- a/depthai_nodes/node/parsers/utils/decode_head.py
+++ b/depthai_nodes/node/parsers/utils/decode_head.py
@@ -1,13 +1,13 @@
-from typing import Any, Dict
+from typing import Any
 
 
-def decode_head(head) -> Dict[str, Any]:
+def decode_head(head) -> dict[str, Any]:
     """Decode head object into a dictionary containing configuration details.
 
     @param head: The head object to decode.
     @type head: dai.nn_archive.v1.Head
     @return: A dictionary containing configuration details relevant to the head.
-    @rtype: Dict[str, Any]
+    @rtype: dict[str, Any]
     """
     head_config = {}
     head_config["parser"] = head.parser

--- a/depthai_nodes/node/parsers/utils/fastsam.py
+++ b/depthai_nodes/node/parsers/utils/fastsam.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import cv2
 import numpy as np
@@ -10,7 +10,7 @@ from depthai_nodes.node.parsers.utils.yolo import (
 
 
 def box_prompt(
-    masks: np.ndarray, bbox: Tuple[int, int, int, int], orig_shape: Tuple[int, int]
+    masks: np.ndarray, bbox: tuple[int, int, int, int], orig_shape: tuple[int, int]
 ) -> np.ndarray:
     """Modifies the bounding box properties and calculates IoU between masks and
     bounding box.
@@ -21,9 +21,9 @@ def box_prompt(
     @param masks: The resulting masks of the FastSAM model
     @type masks: np.ndarray
     @param bbox: The prompt bounding box coordinates
-    @type bbox: Tuple[int, int, int, int]
+    @type bbox: tuple[int, int, int, int]
     @param orig_shape: The original shape of the image
-    @type orig_shape: Tuple[int, int] (height, width)
+    @type orig_shape: tuple[int, int](height, width)
     @return: The modified masks
     @rtype: np.ndarray
     """
@@ -58,7 +58,7 @@ def box_prompt(
 
 def format_results(
     bboxes: np.ndarray, masks: np.ndarray, filter: int = 0
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Formats detection results into list of annotations each containing ID,
     segmentation, bounding box, score and area.
 
@@ -71,7 +71,7 @@ def format_results(
     @param filter: The filter value
     @type filter: int
     @return: The formatted annotations
-    @rtype: List[Dict[str, Any]]
+    @rtype: list[dict[str, Any]]
     """
     annotations = []
     n = len(masks) if masks is not None else 0
@@ -92,9 +92,9 @@ def format_results(
 def point_prompt(
     bboxes: np.ndarray,
     masks: np.ndarray,
-    points: List[Tuple[int, int]],
-    pointlabel: List[int],
-    orig_shape: Tuple[int, int],
+    points: list[tuple[int, int]],
+    pointlabel: list[int],
+    orig_shape: tuple[int, int],
 ) -> np.ndarray:
     """Adjusts points on detected masks based on user input and returns the modified
     results.
@@ -107,11 +107,11 @@ def point_prompt(
     @param masks: The masks of the detected objects
     @type masks: np.ndarray
     @param points: The points to adjust
-    @type points: List[Tuple[int, int]]
+    @type points: list[tuple[int, int]]
     @param pointlabel: The point labels
-    @type pointlabel: List[int]
+    @type pointlabel: list[int]
     @param orig_shape: The original shape of the image
-    @type orig_shape: Tuple[int, int] (height, width)
+    @type orig_shape: tuple[int, int](height, width)
     @return: The modified masks
     @rtype: np.ndarray
     """
@@ -143,7 +143,7 @@ def point_prompt(
 
 
 def adjust_bboxes_to_image_border(
-    boxes: np.ndarray, image_shape: Tuple[int, int], threshold: int = 20
+    boxes: np.ndarray, image_shape: tuple[int, int], threshold: int = 20
 ) -> np.ndarray:
     """
     Source: https://github.com/ultralytics/ultralytics/blob/main/ultralytics/models/fastsam/utils.py#L6 (Ultralytics)
@@ -152,7 +152,7 @@ def adjust_bboxes_to_image_border(
     @param boxes: Bounding boxes
     @type boxes: np.ndarray
     @param image_shape: Image shape
-    @type image_shape: Tuple[int, int]
+    @type image_shape: tuple[int, int]
     @param threshold: Pixel threshold
     @type threshold: int
     @return: Adjusted bounding boxes
@@ -173,7 +173,7 @@ def bbox_iou(
     box1: np.ndarray,
     boxes: np.ndarray,
     iou_thres: float = 0.9,
-    image_shape: Tuple[int, int] = (640, 640),
+    image_shape: tuple[int, int] = (640, 640),
     raw_output: bool = False,
 ) -> np.ndarray:
     """
@@ -187,7 +187,7 @@ def bbox_iou(
     @param iou_thres: IoU threshold
     @type iou_thres: float
     @param image_shape: Image shape (height, width)
-    @type image_shape: Tuple[int, int]
+    @type image_shape: tuple[int, int]
     @param raw_output: If True, return the raw IoU values instead of the indices
     @type raw_output: bool
     @return: Indices of boxes with IoU > thres, or the raw IoU values if raw_output is True
@@ -221,10 +221,10 @@ def bbox_iou(
 
 
 def decode_fastsam_output(
-    outputs: List[np.ndarray],
-    strides: List[int],
-    anchors: List[Optional[np.ndarray]],
-    img_shape: Tuple[int, int],
+    outputs: list[np.ndarray],
+    strides: list[int],
+    anchors: list[np.ndarray | None],
+    img_shape: tuple[int, int],
     conf_thres: float = 0.5,
     iou_thres: float = 0.45,
     num_classes: int = 1,
@@ -232,13 +232,13 @@ def decode_fastsam_output(
     """Decode the output of the FastSAM model.
 
     @param outputs: List of FastSAM outputs
-    @type outputs: List[np.ndarray]
+    @type outputs: list[np.ndarray]
     @param strides: List of strides
-    @type strides: List[int]
+    @type strides: list[int]
     @param anchors: List of anchors
-    @type anchors: List[Optional[np.ndarray]]
+    @type anchors: list[np.ndarray | None]
     @param img_shape: Image shape
-    @type img_shape: Tuple[int, int]
+    @type img_shape: tuple[int, int]
     @param conf_thres: Confidence threshold
     @type conf_thres: float
     @param iou_thres: IoU threshold
@@ -320,7 +320,7 @@ def process_masks(
     parsed_results: np.ndarray,
     mask_coeffs: np.ndarray,
     protos: np.ndarray,
-    orig_shape: Tuple[int, int],
+    orig_shape: tuple[int, int],
     mask_conf: float,
 ) -> np.ndarray:
     """Process output into full-size masks for all detections.

--- a/depthai_nodes/node/parsers/utils/masks_utils.py
+++ b/depthai_nodes/node/parsers/utils/masks_utils.py
@@ -1,5 +1,3 @@
-from typing import List, Optional, Tuple
-
 import depthai as dai
 import numpy as np
 
@@ -59,9 +57,9 @@ def process_single_mask(
 
 def get_segmentation_outputs(
     output: dai.NNData,
-    mask_output_layer_names: Optional[List[str]] = None,
-    protos_output_layer_name: Optional[str] = None,
-) -> Tuple[List[np.ndarray], np.ndarray, int]:
+    mask_output_layer_names: list[str] | None = None,
+    protos_output_layer_name: str | None = None,
+) -> tuple[list[np.ndarray], np.ndarray, int]:
     """Get the segmentation outputs from the Neural Network data."""
     # Get all the layer names
     layer_names = mask_output_layer_names or output.getAllLayerNames()

--- a/depthai_nodes/node/parsers/utils/mlsd.py
+++ b/depthai_nodes/node/parsers/utils/mlsd.py
@@ -1,11 +1,9 @@
-from typing import List, Tuple
-
 import numpy as np
 
 
 def decode_scores_and_points(
     tpMap: np.ndarray, heat: np.ndarray, topk_n: int
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Decode the scores and points from the neural network output tensors. Used for
     MLSD model.
 
@@ -16,7 +14,7 @@ def decode_scores_and_points(
     @param topk_n: Number of top candidates to keep.
     @type topk_n: int
     @return: Detected points, confidence scores for the detected points, and vector map.
-    @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
+    @rtype: tuple[np.ndarray, np.ndarray, np.ndarray]
     """
     _, _, h, w = tpMap.shape
     displacement = tpMap[0, 1:5]  # shape (4, h, w)
@@ -48,7 +46,7 @@ def get_lines(
     score_thr: float,
     dist_thr: float,
     input_size: int = 512,
-) -> Tuple[np.ndarray, List[float]]:
+) -> tuple[np.ndarray, list[float]]:
     """Get lines from the detected points and scores. The lines are filtered by the
     score threshold and distance threshold. Used for MLSD model.
 
@@ -65,7 +63,7 @@ def get_lines(
     @param input_size: Input size of the model.
     @type input_size: int
     @return: Detected lines and their confidence scores.
-    @rtype: Tuple[np.ndarray, List[float]]
+    @rtype: tuple[np.ndarray, list[float]]
     """
     # Extract coordinates for all points
     ys, xs = pts[:, 0], pts[:, 1]

--- a/depthai_nodes/node/parsers/utils/nms.py
+++ b/depthai_nodes/node/parsers/utils/nms.py
@@ -1,10 +1,8 @@
-from typing import List
-
 import cv2
 import numpy as np
 
 
-def nms(dets: np.ndarray, nms_thresh: float = 0.5) -> List[int]:
+def nms(dets: np.ndarray, nms_thresh: float = 0.5) -> list[int]:
     """Non-maximum suppression.
 
     @param dets: Bounding boxes and confidence scores.
@@ -12,7 +10,7 @@ def nms(dets: np.ndarray, nms_thresh: float = 0.5) -> List[int]:
     @param nms_thresh: Non-maximum suppression threshold.
     @type nms_thresh: float
     @return: Indices of the detections to keep.
-    @rtype: List[int]
+    @rtype: list[int]
     """
     thresh = nms_thresh
     x1 = dets[:, 0]
@@ -60,7 +58,7 @@ def nms_cv2(
     @param nms_thresh: Non-maximum suppression threshold.
     @type nms_thresh: float
     @return: Indices of the detections to keep.
-    @rtype: List[int]
+    @rtype: list[int]
     """
 
     # NMS

--- a/depthai_nodes/node/parsers/utils/ppdet.py
+++ b/depthai_nodes/node/parsers/utils/ppdet.py
@@ -1,5 +1,3 @@
-from typing import Optional, Tuple
-
 import cv2
 import numpy as np
 
@@ -8,14 +6,14 @@ from depthai_nodes.node.parsers.utils import (
 )
 
 
-def _get_mini_boxes(contour: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def _get_mini_boxes(contour: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Internal function to get the minimum bounding box of a contour.
 
     @param contour: The contour to get the minimum bounding box of the text.
     @type contour: np.ndarray
     @return: The minimum rotated bounding box defined as [x_center, y_center, width,
         height, angle] and the corners of the box.
-    @rtype: Tuple[np.ndarray, np.ndarray]
+    @rtype: tuple[np.ndarray, np.ndarray]
     """
     bounding_box = cv2.minAreaRect(contour)
     points = sorted(list(cv2.boxPoints(bounding_box)), key=lambda x: x[0])
@@ -106,9 +104,9 @@ def parse_paddle_detection_outputs(
     mask_threshold: float = 0.25,
     bbox_threshold: float = 0.5,
     max_detections: int = 100,
-    width: Optional[int] = None,
-    height: Optional[int] = None,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    width: int | None = None,
+    height: int | None = None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Parse the output of a PaddlePaddle Text Detection model from a mask of text
     probabilities into rotated bounding boxes with additional corners saved as
     keypoints.
@@ -122,9 +120,9 @@ def parse_paddle_detection_outputs(
     @param max_detections: The maximum number of candidate bounding boxes.
     @type max_detections: int
     @param width: The width of the image.
-    @type width: Optional[int]
+    @type width: int | None
     @param height: The height of the image.
-    @type height: Optional[int]
+    @type height: int | None
     @return: A touple containing the rotated bounding boxes, corners and scores.
     @rtype: Touple[np.ndarray, np.ndarray, np.ndarray]
     """

--- a/depthai_nodes/node/parsers/utils/scrfd.py
+++ b/depthai_nodes/node/parsers/utils/scrfd.py
@@ -1,24 +1,22 @@
-from typing import Dict, List, Tuple
-
 import numpy as np
 
 from depthai_nodes.node.parsers.utils.nms import nms
 
 
 def compute_anchor_centers(
-    strides: List[int], input_size: Tuple[int, int], num_anchors: int
-) -> Dict[int, np.ndarray]:
+    strides: list[int], input_size: tuple[int, int], num_anchors: int
+) -> dict[int, np.ndarray]:
     """Compute the anchor centers for a given list of strides, input size, and number of
     anchors.
 
     @param strides: List of strides.
-    @type strides: List[int]
+    @type strides: list[int]
     @param input_size: Input size.
-    @type input_size: Tuple[int, int]
+    @type input_size: tuple[int, int]
     @param num_anchors: Number of anchors.
     @type num_anchors: int
     @return: Dictionary of anchor centers.
-    @rtype: Dict[int, np.ndarray]
+    @rtype: dict[int, np.ndarray]
     """
     anchor_centers_dict = {}
     for stride in strides:
@@ -45,7 +43,7 @@ def distance2bbox(points, distance, max_shape=None):
         bottom).
     @type distance: np.ndarray
     @param max_shape: Shape of the image.
-    @type max_shape: Tuple[int, int]
+    @type max_shape: tuple[int, int]
     @return: Decoded bboxes.
     @rtype: np.ndarray
     """
@@ -70,7 +68,7 @@ def distance2kps(points, distance, max_shape=None):
         bottom).
     @type distance: np.ndarray
     @param max_shape: Shape of the image.
-    @type max_shape: Tuple[int, int]
+    @type max_shape: tuple[int, int]
     @return: Decoded keypoints.
     @rtype: np.ndarray
     """

--- a/depthai_nodes/node/parsers/utils/superanimal.py
+++ b/depthai_nodes/node/parsers/utils/superanimal.py
@@ -7,7 +7,7 @@ def get_top_values(heatmap):
     @param heatmap: Heatmap tensor.
     @type heatmap: np.ndarray
     @return: Y and X coordinates of the top values.
-    @rtype: Tuple[np.ndarray, np.ndarray]
+    @rtype: tuple[np.ndarray, np.ndarray]
     """
     batchsize, ny, nx, num_joints = heatmap.shape
     heatmap_flat = heatmap.reshape(batchsize, nx * ny, num_joints)
@@ -27,7 +27,7 @@ def get_pose_prediction(heatmap, locref, scale_factors):
     @param locref: Locref tensor.
     @type locref: np.ndarray
     @param scale_factors: Scale factors for the x and y axes.
-    @type scale_factors: Tuple[float, float]
+    @type scale_factors: tuple[float, float]
     @return: Pose prediction.
     @rtype: np.ndarray
     """

--- a/depthai_nodes/node/parsers/utils/ufld.py
+++ b/depthai_nodes/node/parsers/utils/ufld.py
@@ -1,18 +1,16 @@
-from typing import List, Tuple
-
 import numpy as np
 
 from depthai_nodes.node.parsers.utils import softmax
 
 
 def decode_ufld(
-    anchors: List[int],
+    anchors: list[int],
     griding_num: int,
     cls_num_per_lane: int,
     input_width: int,
     input_height: int,
     y: np.ndarray,
-) -> List[List[Tuple[int, int]]]:
+) -> list[list[tuple[int, int]]]:
     col_sample = np.linspace(0, input_width - 1, griding_num)
     col_sample_w = col_sample[1] - col_sample[0]
 

--- a/depthai_nodes/node/parsers/utils/xfeat.py
+++ b/depthai_nodes/node/parsers/utils/xfeat.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import numpy as np
 
@@ -213,9 +213,9 @@ def detect_and_compute(
     heatmaps: np.ndarray,
     resize_rate_w: float,
     resize_rate_h: float,
-    input_size: Tuple[int, int],
+    input_size: tuple[int, int],
     top_k: int = 4096,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Detect and compute keypoints.
 
     @param feats: Features.
@@ -229,11 +229,11 @@ def detect_and_compute(
     @param resize_rate_h: Resize rate for height.
     @type resize_rate_h: float
     @param input_size: Input size.
-    @type input_size: Tuple[int, int]
+    @type input_size: tuple[int, int]
     @param top_k: Maximum number of keypoints to keep.
     @type top_k: int
     @return: List of dictionaries containing keypoints, scores, and descriptors.
-    @rtype: List[Dict[str, Any]]
+    @rtype: list[dict[str, Any]]
     """
     norm = np.linalg.norm(feats, axis=1, keepdims=True)
     feats = feats / norm
@@ -287,7 +287,7 @@ def detect_and_compute(
 
 def _match_mkpts(
     feats1: np.ndarray, feats2: np.ndarray, min_cossim: float = 0.62
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Match features.
 
     @param feats1: Features 1.
@@ -297,7 +297,7 @@ def _match_mkpts(
     @param min_cossim: Minimum cosine similarity.
     @type min_cossim: float
     @return: Matched features.
-    @rtype: Tuple[np.ndarray, np.ndarray]
+    @rtype: tuple[np.ndarray, np.ndarray]
     """
     cossim = feats1 @ feats2.T
     cossim_t = feats2 @ feats1.T
@@ -320,18 +320,18 @@ def _match_mkpts(
 
 
 def match(
-    result1: Dict[str, Any], result2: Dict[str, Any], min_cossim: float = -1
-) -> Tuple[np.ndarray, np.ndarray]:
+    result1: dict[str, Any], result2: dict[str, Any], min_cossim: float = -1
+) -> tuple[np.ndarray, np.ndarray]:
     """Match keypoints.
 
     @param result1: Result 1.
-    @type result1: Dict[str, Any]
+    @type result1: dict[str, Any]
     @param result2: Result 2.
-    @type result2: Dict[str, Any]
+    @type result2: dict[str, Any]
     @param min_cossim: Minimum cosine similarity.
     @type min_cossim: float
     @return: Matched keypoints.
-    @rtype: Tuple[np.ndarray, np.ndarray]
+    @rtype: tuple[np.ndarray, np.ndarray]
     """
     indexes1, indexes2 = _match_mkpts(
         result1["descriptors"],

--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -1,6 +1,5 @@
 import time
 from enum import Enum
-from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -53,7 +52,7 @@ def non_max_suppression(
     prediction: np.ndarray,
     conf_thres: float = 0.5,
     iou_thres: float = 0.45,
-    classes: Optional[List] = None,
+    classes: list | None = None,
     num_classes: int = 1,
     agnostic: bool = False,
     multi_label: bool = False,
@@ -63,7 +62,7 @@ def non_max_suppression(
     max_wh: int = 7680,
     kpts_mode: bool = False,
     det_mode: bool = False,
-) -> List[np.ndarray]:
+) -> list[np.ndarray]:
     """Performs Non-Maximum Suppression (NMS) on inference results.
 
     @param prediction: Prediction from the model, shape = (batch_size, boxes, xy+wh+...)
@@ -73,7 +72,7 @@ def non_max_suppression(
     @param iou_thres: Intersection over union threshold.
     @type iou_thres: float
     @param classes: For filtering by classes.
-    @type classes: Optional[List]
+    @type classes: list | None
     @param num_classes: Number of classes.
     @type num_classes: int
     @param agnostic: Runs NMS on all boxes together rather than per class if True.
@@ -93,7 +92,7 @@ def non_max_suppression(
     @param det_mode: Detection only mode. If True, the output will only contain bbox detections.
     @type det_mode: bool
     @return: An array of detections. If det_mode is False, the detections may include kpts or segmentation outputs.
-    @rtype: List[np.ndarray]
+    @rtype: list[np.ndarray]
     """
     bs = prediction.shape[0]  # batch size
 
@@ -190,9 +189,9 @@ def parse_yolo_output(
     out: np.ndarray,
     stride: int,
     num_outputs: int,
-    anchors: Optional[np.ndarray] = None,
+    anchors: np.ndarray | None = None,
     head_id: int = -1,
-    kpts: Optional[np.ndarray] = None,
+    kpts: np.ndarray | None = None,
     det_mode: bool = False,
     subtype: YOLOSubtype = YOLOSubtype.DEFAULT,
 ) -> np.ndarray:
@@ -205,11 +204,11 @@ def parse_yolo_output(
     @param num_outputs: Number of outputs of the model.
     @type num_outputs: int
     @param anchors: Anchors for the given head.
-    @type anchors: Optional[np.ndarray]
+    @type anchors: np.ndarray | None
     @param head_id: Head ID.
     @type head_id: int
     @param kpts: A single output of keypoints for the given channel.
-    @type kpts: Optional[np.ndarray]
+    @type kpts: np.ndarray | None
     @param det_mode: Detection only mode.
     @type det_mode: bool
     @param subtype: YOLO version.
@@ -308,8 +307,8 @@ def parse_yolo_output(
 
 
 def parse_kpts(
-    kpts: np.ndarray, n_keypoints: int, img_shape: Tuple[int, int]
-) -> List[Tuple[float, float, float]]:
+    kpts: np.ndarray, n_keypoints: int, img_shape: tuple[int, int]
+) -> list[tuple[float, float, float]]:
     """Parse keypoints.
 
     @param kpts: Result keypoints.
@@ -317,9 +316,9 @@ def parse_kpts(
     @param n_keypoints: Number of keypoints.
     @type n_keypoints: int
     @param img_shape: Image shape of the model input in (height, width) format.
-    @type img_shape: Tuple[int, int]
+    @type img_shape: tuple[int, int]
     @return: Parsed keypoints.
-    @rtype: List[Tuple[float, float, float]]
+    @rtype: list[tuple[float, float, float]]
     """
     h, w = img_shape
     kps = []
@@ -337,8 +336,8 @@ def _apply_conf_and_topk(
     cls_ids: np.ndarray,
     conf_threshold: float,
     max_det: int,
-    auxiliary: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+    auxiliary: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray | None]:
     """Apply confidence threshold and top-k filtering.
 
     @param boxes: Bounding boxes array (A, 4).
@@ -353,9 +352,9 @@ def _apply_conf_and_topk(
     @type max_det: int
     @param auxiliary: generic parameter for task-specific data (mask coefficients for
         segmentation and keypoints for pose) to be filtered according to the detections
-    @type auxiliary: Optional[np.ndarray]
+    @type auxiliary: np.ndarray | None
     @return: Tuple of (results array (K, 6), filtered auxiliary or None).
-    @rtype: Tuple[np.ndarray, Optional[np.ndarray]]
+    @rtype: tuple[np.ndarray, np.ndarray | None]
     """
     keep = conf >= conf_threshold
 
@@ -395,8 +394,8 @@ def decode_yolo26(
     raw: np.ndarray,
     conf_threshold: float,
     max_det: int,
-    extra_raw: Optional[np.ndarray] = None,
-) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+    extra_raw: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray | None]:
     """Decode YOLO26 output for detection, segmentation, or pose.
 
     YOLO26 end2end output is already decoded (xyxy in pixels) with a pre-computed
@@ -413,9 +412,9 @@ def decode_yolo26(
     @type max_det: int
     @param extra_raw: Optional auxiliary tensor (N, A, M) such as mask coefficients or
         keypoints. When provided the kept rows are returned as the second element.
-    @type extra_raw: Optional[np.ndarray]
+    @type extra_raw: np.ndarray | None
     @return: Tuple of (detection results (K, 6), kept auxiliary data (K, M) or None).
-    @rtype: Tuple[np.ndarray, Optional[np.ndarray]]
+    @rtype: tuple[np.ndarray, np.ndarray | None]
     """
     det_results = raw[0]  # (A, 5+nc)
     extra = extra_raw[0] if extra_raw is not None else None
@@ -431,10 +430,10 @@ def decode_yolo26(
 
 
 def decode_yolo_output(
-    yolo_outputs: List[np.ndarray],
-    strides: List[int],
-    anchors: Optional[np.ndarray] = None,
-    kpts: Optional[List[np.ndarray]] = None,
+    yolo_outputs: list[np.ndarray],
+    strides: list[int],
+    anchors: np.ndarray | None = None,
+    kpts: list[np.ndarray] | None = None,
     conf_thres: float = 0.5,
     iou_thres: float = 0.45,
     num_classes: int = 1,
@@ -445,13 +444,13 @@ def decode_yolo_output(
     """Decode the output of an YOLO instance segmentation or pose estimation model.
 
     @param yolo_outputs: List of YOLO outputs.
-    @type yolo_outputs: List[np.ndarray]
+    @type yolo_outputs: list[np.ndarray]
     @param strides: List of strides.
-    @type strides: List[int]
+    @type strides: list[int]
     @param anchors: An optional array of anchors.
-    @type anchors: Optional[np.ndarray]
+    @type anchors: np.ndarray | None
     @param kpts: An optional list of keypoints.
-    @type kpts: Optional[List[np.ndarray]]
+    @type kpts: list[np.ndarray] | None
     @param conf_thres: Confidence threshold.
     @type conf_thres: float
     @param iou_thres: Intersection over union threshold.

--- a/depthai_nodes/node/parsers/utils/yunet.py
+++ b/depthai_nodes/node/parsers/utils/yunet.py
@@ -1,5 +1,4 @@
 from itertools import product
-from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -18,19 +17,19 @@ def manual_product(*args):
 
 
 def generate_anchors(
-    input_size: Tuple[int, int],
-    min_sizes: Optional[List[List[int]]] = None,
-    strides: Optional[List[int]] = None,
+    input_size: tuple[int, int],
+    min_sizes: list[list[int]] | None = None,
+    strides: list[int] | None = None,
 ):
     """Generate a set of default bounding boxes, known as anchors.
     The code is taken from https://github.com/Kazuhito00/YuNet-ONNX-TFLite-Sample/tree/main
 
     @param input_size: A tuple representing the width and height of the input image.
-    @type input_size: Tuple[int, int]
+    @type input_size: tuple[int, int]
     @param min_sizes: A list of lists, where each inner list contains the minimum sizes of the anchors for different feature maps. If None then '[[10, 16, 24], [32, 48], [64, 96], [128, 192, 256]]' will be used. Defaults to None.
-    @type min_sizes Optional[List[List[int]]]
+    @type min_sizes list[list[int]] | None
     @param strides: Strides for each feature map layer. If None then '[8, 16, 32, 64]' will be used. Defaults to None.
-    @type strides: Optional[List[int]]
+    @type strides: list[int] | None
     @return: Anchors.
     @rtype: np.ndarray
     """
@@ -68,11 +67,11 @@ def generate_anchors(
 
 
 def decode_detections(
-    input_size: Tuple[int, int],
+    input_size: tuple[int, int],
     loc: np.ndarray,
     conf: np.ndarray,
     iou: np.ndarray,
-    variance: Optional[List[float]] = None,
+    variance: list[float] | None = None,
 ):
     """
     Decodes the output of an object detection model by converting the model's predictions (localization, confidence, and IoU scores) into bounding boxes, keypoints, and scores.
@@ -87,13 +86,12 @@ def decode_detections(
     @param iou: The predicted IoU (Intersection over Union) scores.
     @type iou: np.ndarray
     @param variance: A list of variances used to decode the bounding box predictions. If None then [0.1,0.2] will be used. Defaults to None.
-    @type variance: Optional[List[float]]
+    @type variance: list[float] | None
     @return: A tuple of bboxes, keypoints, and scores.
         - bboxes: NumPy array of shape (N, 4) containing the decoded bounding boxes in the format [x_min, y_min, width, height].
         - keypoints: A NumPy array of shape (N, 10) containing the decoded keypoint coordinates for each anchor.
         - scores: A NumPy array of shape (N, 1) containing the combined scores for each anchor.
-    @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
-
+    @rtype: tuple[np.ndarray, np.ndarray, np.ndarray]
     """
 
     w, h = input_size
@@ -155,7 +153,7 @@ def prune_detections(
         - bboxes: NumPy array of shape (N, 4) containing the decoded bounding boxes in the format [x_min, y_min, width, height].
         - keypoints: A NumPy array of shape (N, 10) containing the decoded keypoint coordinates for each anchor.
         - scores: A NumPy array of shape (N, 1) containing the combined scores for each anchor.
-    @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
+    @rtype: tuple[np.ndarray, np.ndarray, np.ndarray]
     """
 
     keep_indices = np.where(scores.squeeze() > conf_threshold)
@@ -166,7 +164,7 @@ def format_detections(
     bboxes: np.ndarray,
     keypoints: np.ndarray,
     scores: np.ndarray,
-    input_size: Tuple[int, int],
+    input_size: tuple[int, int],
 ):
     """Format detections into a list of dictionaries.
 
@@ -182,7 +180,7 @@ def format_detections(
         - bboxes: NumPy array of shape (N, 4) containing the decoded bounding boxes in the format [x_min, y_min, width, height].
         - keypoints: A NumPy array of shape (N, 10) containing the decoded keypoint coordinates for each anchor.
         - scores: A NumPy array of shape (N, 1) containing the combined scores for each anchor.
-    @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
+    @rtype: tuple[np.ndarray, np.ndarray, np.ndarray]
     """
 
     w, h = input_size
@@ -200,13 +198,13 @@ def format_detections(
 
 
 def decode_and_prune_detections(
-    input_size: Tuple[int, int],
+    input_size: tuple[int, int],
     loc: np.ndarray,
     conf: np.ndarray,
     iou: np.ndarray,
     conf_threshold: float,
     anchors: np.ndarray,
-    variance: Optional[List[float]] = None,
+    variance: list[float] | None = None,
 ):
     """Optimized function that combines decode_detections and prune_detections. Performs
     early pruning to avoid processing low-confidence detections.

--- a/depthai_nodes/node/parsers/xfeat.py
+++ b/depthai_nodes/node/parsers/xfeat.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -24,9 +24,9 @@ class XFeatBaseParser(BaseParser):
         Name of the output layer containing keypoints.
     output_layer_heatmaps : str
         Name of the output layer containing heatmaps.
-    original_size : Tuple[float, float]
+    original_size : tuple[float, float]
         Original image size.
-    input_size : Tuple[float, float]
+    input_size : tuple[float, float]
         Input image size.
     max_keypoints : int
         Maximum number of keypoints to keep.
@@ -47,8 +47,8 @@ class XFeatBaseParser(BaseParser):
         output_layer_feats: str = "",
         output_layer_keypoints: str = "",
         output_layer_heatmaps: str = "",
-        original_size: Tuple[float, float] = None,
-        input_size: Tuple[float, float] = (640, 352),
+        original_size: tuple[float, float] = None,
+        input_size: tuple[float, float] = (640, 352),
         max_keypoints: int = 4096,
     ) -> None:
         """Initializes the parser node."""
@@ -67,22 +67,22 @@ class XFeatBaseParser(BaseParser):
         )
 
     @property
-    def reference_input(self) -> Optional[dai.Node.Input]:
+    def reference_input(self) -> dai.Node.Input | None:
         """Returns the reference input."""
         return self.input
 
     @property
-    def target_input(self) -> Optional[dai.Node.Input]:
+    def target_input(self) -> dai.Node.Input | None:
         """Returns the target input."""
         return self._target_input
 
     @reference_input.setter
-    def reference_input(self, reference_input: Optional[dai.Node.Input]):
+    def reference_input(self, reference_input: dai.Node.Input | None):
         """Sets the reference input."""
         self.input = reference_input
 
     @target_input.setter
-    def target_input(self, target_input: Optional[dai.Node.Input]):
+    def target_input(self, target_input: dai.Node.Input | None):
         """Sets the target input."""
         self._target_input = target_input
 
@@ -125,11 +125,11 @@ class XFeatBaseParser(BaseParser):
             f"Output layer containing heatmaps set to '{self.output_layer_heatmaps}'"
         )
 
-    def setOriginalSize(self, original_size: Tuple[int, int]) -> None:
+    def setOriginalSize(self, original_size: tuple[int, int]) -> None:
         """Sets the original image size.
 
         @param original_size: Original image size.
-        @type original_size: Tuple[int, int]
+        @type original_size: tuple[int, int]
         """
         if not isinstance(original_size, tuple) or len(original_size) != 2:
             raise ValueError("Original image size must be a tuple of two ints!")
@@ -139,11 +139,11 @@ class XFeatBaseParser(BaseParser):
         self.original_size = original_size
         self._logger.debug(f"Original image size set to {self.original_size}")
 
-    def setInputSize(self, input_size: Tuple[int, int]) -> None:
+    def setInputSize(self, input_size: tuple[int, int]) -> None:
         """Sets the input image size.
 
         @param input_size: Input image size.
-        @type input_size: Tuple[int, int]
+        @type input_size: tuple[int, int]
         """
         if not isinstance(input_size, tuple) or len(input_size) != 2:
             raise ValueError("Input image size must be a tuple of two ints!")
@@ -166,12 +166,12 @@ class XFeatBaseParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "XFeatBaseParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: XFeatBaseParser
         """
@@ -217,7 +217,7 @@ class XFeatBaseParser(BaseParser):
 
     def extractTensors(
         self, output: dai.NNData
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Extracts the tensors from the output. It returns the features, keypoints, and
         heatmaps. It also handles the reshaping of the tensors by requesting the NCHW
         storage order.
@@ -225,7 +225,7 @@ class XFeatBaseParser(BaseParser):
         @param output: Output from the Neural Network node.
         @type output: dai.NNData
         @return: Tuple of features, keypoints, and heatmaps.
-        @rtype: Tuple[np.ndarray, np.ndarray, np.ndarray]
+        @rtype: tuple[np.ndarray, np.ndarray, np.ndarray]
         """
         feats = output.getTensor(
             self.output_layer_feats,
@@ -259,9 +259,9 @@ class XFeatMonoParser(XFeatBaseParser):
         Name of the output layer containing keypoints.
     output_layer_heatmaps : str
         Name of the output layer containing heatmaps.
-    original_size : Tuple[float, float]
+    original_size : tuple[float, float]
         Original image size.
-    input_size : Tuple[float, float]
+    input_size : tuple[float, float]
         Input image size.
     max_keypoints : int
         Maximum number of keypoints to keep.
@@ -291,8 +291,8 @@ class XFeatMonoParser(XFeatBaseParser):
         output_layer_feats: str = "feats",
         output_layer_keypoints: str = "keypoints",
         output_layer_heatmaps: str = "heatmaps",
-        original_size: Tuple[float, float] = None,
-        input_size: Tuple[float, float] = (640, 352),
+        original_size: tuple[float, float] = None,
+        input_size: tuple[float, float] = (640, 352),
         max_keypoints: int = 4096,
     ) -> None:
         """Initializes the XFeatParser node.
@@ -304,9 +304,9 @@ class XFeatMonoParser(XFeatBaseParser):
         @param output_layer_heatmaps: Name of the output layer containing heatmaps.
         @type output_layer_heatmaps: str
         @param original_size: Original image size.
-        @type original_size: Tuple[float, float]
+        @type original_size: tuple[float, float]
         @param input_size: Input image size.
-        @type input_size: Tuple[float, float]
+        @type input_size: tuple[float, float]
         @param max_keypoints: Maximum number of keypoints to keep.
         @type max_keypoints: int
         """
@@ -412,9 +412,9 @@ class XFeatStereoParser(XFeatBaseParser):
         Name of the output layer from which the keypoints are extracted.
     output_layer_heatmaps : str
         Name of the output layer from which the heatmaps are extracted.
-    original_size : Tuple[float, float]
+    original_size : tuple[float, float]
         Original image size.
-    input_size : Tuple[float, float]
+    input_size : tuple[float, float]
         Input image size.
     max_keypoints : int
         Maximum number of keypoints to keep.
@@ -440,8 +440,8 @@ class XFeatStereoParser(XFeatBaseParser):
         output_layer_feats: str = "feats",
         output_layer_keypoints: str = "keypoints",
         output_layer_heatmaps: str = "heatmaps",
-        original_size: Tuple[float, float] = None,
-        input_size: Tuple[float, float] = (640, 352),
+        original_size: tuple[float, float] = None,
+        input_size: tuple[float, float] = (640, 352),
         max_keypoints: int = 4096,
     ) -> None:
         """Initializes the XFeatParser node.
@@ -453,9 +453,9 @@ class XFeatStereoParser(XFeatBaseParser):
         @param output_layer_heatmaps: Name of the output layer containing heatmaps.
         @type output_layer_heatmaps: str
         @param original_size: Original image size.
-        @type original_size: Tuple[float, float]
+        @type original_size: tuple[float, float]
         @param input_size: Input image size.
-        @type input_size: Tuple[float, float]
+        @type input_size: tuple[float, float]
         @param max_keypoints: Maximum number of keypoints to keep.
         @type max_keypoints: int
         """

--- a/depthai_nodes/node/parsers/yolo.py
+++ b/depthai_nodes/node/parsers/yolo.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import cv2
 import depthai as dai
@@ -32,7 +32,7 @@ class YOLOExtendedParser(BaseParser):
         Confidence score threshold for detected faces.
     n_classes : int
         Number of classes in the model.
-    label_names : Optional[List[str]]
+    label_names : list[str] | None
         Names of the classes.
     iou_threshold : float
         Intersection over union threshold.
@@ -40,11 +40,11 @@ class YOLOExtendedParser(BaseParser):
         Mask confidence threshold.
     n_keypoints : int
         Number of keypoints in the model.
-    anchors : Optional[List[List[List[float]]]]
+    anchors : list[list[list[float]]] | None
         Anchors for the YOLO model (optional).
-    keypoint_label_names : Optional[List[str]]
+    keypoint_label_names : list[str] | None
         Labels for the keypoints.
-    keypoint_edges : Optional[List[Tuple[int, int]]]
+    keypoint_edges : list[tuple[int, int]] | None
         Keypoint connection pairs for visualizing the skeleton. Example: [(0,1), (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint 1, keypoint 1 is connected to keypoint 2, etc.
     subtype : str
         Version of the YOLO model.
@@ -65,15 +65,15 @@ class YOLOExtendedParser(BaseParser):
         self,
         conf_threshold: float = 0.5,
         n_classes: int = 1,
-        label_names: Optional[List[str]] = None,
+        label_names: list[str] | None = None,
         iou_threshold: float = 0.5,
         mask_conf: float = 0.5,
         n_keypoints: int = 17,
         max_det: int = 300,
-        anchors: Optional[List[List[List[float]]]] = None,
+        anchors: list[list[list[float]]] | None = None,
         subtype: str = "",
-        keypoint_label_names: Optional[List[str]] = None,
-        keypoint_edges: Optional[List[Tuple[int, int]]] = None,
+        keypoint_label_names: list[str] | None = None,
+        keypoint_edges: list[tuple[int, int]] | None = None,
     ):
         """Initialize the parser node.
 
@@ -82,7 +82,7 @@ class YOLOExtendedParser(BaseParser):
         @param n_classes: The number of classes in the model
         @type n_classes: int
         @param label_names: The names of the classes
-        @type label_names: Optional[List[str]]
+        @type label_names: list[str] | None
         @param iou_threshold: The intersection over union threshold
         @type iou_threshold: float
         @param mask_conf: The mask confidence threshold
@@ -90,15 +90,15 @@ class YOLOExtendedParser(BaseParser):
         @param n_keypoints: The number of keypoints in the model
         @type n_keypoints: int
         @param anchors: The anchors for the YOLO model
-        @type anchors: Optional[List[List[List[float]]]]
+        @type anchors: list[list[list[float]]] | None
         @param subtype: The version of the YOLO model
         @type subtype: str
         @param keypoint_label_names: The labels for the keypoints
-        @type keypoint_label_names: Optional[List[str]]
+        @type keypoint_label_names: list[str] | None
         @param keypoint_edges: Connection pairs of the keypoints. Example: [(0,1),
             (1,2), (2,3), (3,0)] shows that keypoint 0 is connected to keypoint 1,
             keypoint 1 is connected to keypoint 2, etc.
-        @type keypoint_edges: Optional[List[Tuple[int, int]]]
+        @type keypoint_edges: list[tuple[int, int]] | None
         """
         super().__init__()
 
@@ -125,11 +125,11 @@ class YOLOExtendedParser(BaseParser):
             f"YOLOExtendedParser initialized with conf_threshold={self.conf_threshold}, n_classes={self.n_classes}, label_names={self.label_names}, iou_threshold={self.iou_threshold}, mask_conf={self.mask_conf}, n_keypoints={self.n_keypoints}, max_det={self.max_det}, anchors={self.anchors}, subtype='{self.subtype}', keypoint_label_names={self.keypoint_label_names}, keypoint_edges={self.keypoint_edges}"
         )
 
-    def setOutputLayerNames(self, output_layer_names: List[str]) -> None:
+    def setOutputLayerNames(self, output_layer_names: list[str]) -> None:
         """Sets the output layer names for the parser.
 
         @param output_layer_names: The output layer names for the parser.
-        @type output_layer_names: List[str]
+        @type output_layer_names: list[str]
         """
         if not isinstance(output_layer_names, list):
             raise ValueError("Output layer names must be a list.")
@@ -214,11 +214,11 @@ class YOLOExtendedParser(BaseParser):
         self.n_keypoints = n_keypoints
         self._logger.debug(f"Number of keypoints set to {self.n_keypoints}")
 
-    def setAnchors(self, anchors: List[List[List[float]]]) -> None:
+    def setAnchors(self, anchors: list[list[list[float]]]) -> None:
         """Sets the anchors for the YOLO model.
 
         @param anchors: The anchors for the YOLO model.
-        @type anchors: List[List[List[float]]]
+        @type anchors: list[list[list[float]]]
         """
         for anchor in anchors:
             if not isinstance(anchor, list):
@@ -249,11 +249,11 @@ class YOLOExtendedParser(BaseParser):
 
         self._logger.debug(f"Subtype set to {self.subtype}")
 
-    def setLabelNames(self, label_names: List[str]) -> None:
+    def setLabelNames(self, label_names: list[str]) -> None:
         """Sets the names of the classes.
 
         @param label_names: The names of the classes.
-        @type label_names: List[str]
+        @type label_names: list[str]
         """
         if not isinstance(label_names, list):
             raise ValueError("Label names must be a list.")
@@ -263,11 +263,11 @@ class YOLOExtendedParser(BaseParser):
         self.label_names = label_names
         self._logger.debug(f"Label names set to {self.label_names}")
 
-    def setKeypointLabelNames(self, keypoint_label_names: List[str]) -> None:
+    def setKeypointLabelNames(self, keypoint_label_names: list[str]) -> None:
         """Sets the label names for the keypoints.
 
         @param keypoint_label_names: The labels for the keypoints.
-        @type keypoint_label_names: List[str]
+        @type keypoint_label_names: list[str]
         """
         if not isinstance(keypoint_label_names, list):
             raise ValueError("Keypoint labels must be a list.")
@@ -277,11 +277,11 @@ class YOLOExtendedParser(BaseParser):
         self.keypoint_label_names = keypoint_label_names
         self._logger.debug(f"Keypoint label names set to {self.keypoint_label_names}")
 
-    def setKeypointEdges(self, keypoint_edges: List[Tuple[int, int]]) -> None:
+    def setKeypointEdges(self, keypoint_edges: list[tuple[int, int]]) -> None:
         """Sets the edges for the keypoints.
 
         @param keypoint_edges: The edges for the keypoints.
-        @type keypoint_edges: List[Tuple[int, int]]
+        @type keypoint_edges: list[tuple[int, int]]
         """
         if not isinstance(keypoint_edges, list) and not isinstance(
             keypoint_edges, tuple
@@ -300,12 +300,12 @@ class YOLOExtendedParser(BaseParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ):
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: YOLOExtendedParser
         """

--- a/depthai_nodes/node/parsers/yunet.py
+++ b/depthai_nodes/node/parsers/yunet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -25,7 +25,7 @@ class YuNetParser(DetectionParser):
         Non-maximum suppression threshold.
     max_det : int
         Maximum number of detections to keep.
-    input_size : Tuple[int, int]
+    input_size : tuple[int, int]
         Input size (width, height).
     loc_output_layer_name: str
         Name of the output layer containing the location predictions.
@@ -46,7 +46,7 @@ class YuNetParser(DetectionParser):
         conf_threshold: float = 0.8,
         iou_threshold: float = 0.3,
         max_det: int = 5000,
-        input_size: Tuple[int, int] = None,
+        input_size: tuple[int, int] = None,
         loc_output_layer_name: str = None,
         conf_output_layer_name: str = None,
         iou_output_layer_name: str = None,
@@ -60,7 +60,7 @@ class YuNetParser(DetectionParser):
         @param max_det: Maximum number of detections to keep.
         @type max_det: int
         @param input_size: Input size of the model (width, height).
-        @type input_size: Tuple[int, int]
+        @type input_size: tuple[int, int]
         @param loc_output_layer_name: Output layer name for the location predictions.
         @type loc_output_layer_name: str
         @param conf_output_layer_name: Output layer name for the confidence predictions.
@@ -87,7 +87,7 @@ class YuNetParser(DetectionParser):
         self._cached_anchors = None
         self._cached_input_size = None
 
-    def setInputSize(self, input_size: Tuple[int, int]) -> None:
+    def setInputSize(self, input_size: tuple[int, int]) -> None:
         """Sets the input size of the model.
 
         @param input_size: Input size of the model (width, height).
@@ -143,12 +143,12 @@ class YuNetParser(DetectionParser):
 
     def build(
         self,
-        head_config: Dict[str, Any],
+        head_config: dict[str, Any],
     ) -> "YuNetParser":
         """Configures the parser.
 
         @param head_config: The head configuration for the parser.
-        @type head_config: Dict[str, Any]
+        @type head_config: dict[str, Any]
         @return: The parser object with the head configuration set.
         @rtype: YuNetParser
         """
@@ -217,7 +217,7 @@ class YuNetParser(DetectionParser):
                 loc_output_layer_name_candidates = [
                     layer_name
                     for layer_name in output_layer_names
-                    if layer_name.startswith(("loc"))
+                    if layer_name.startswith("loc")
                 ]
                 if len(loc_output_layer_name_candidates) == 0:
                     raise ValueError(
@@ -244,7 +244,7 @@ class YuNetParser(DetectionParser):
                 conf_output_layer_name_candidates = [
                     layer_name
                     for layer_name in output_layer_names
-                    if layer_name.startswith(("conf"))
+                    if layer_name.startswith("conf")
                 ]
                 if len(conf_output_layer_name_candidates) == 0:
                     raise ValueError(
@@ -269,7 +269,7 @@ class YuNetParser(DetectionParser):
                 iou_output_layer_name_candidates = [
                     layer_name
                     for layer_name in output_layer_names
-                    if layer_name.startswith(("iou"))
+                    if layer_name.startswith("iou")
                 ]
                 if len(iou_output_layer_name_candidates) == 0:
                     raise ValueError(

--- a/depthai_nodes/node/parsing_neural_network.py
+++ b/depthai_nodes/node/parsing_neural_network.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Optional, Type, TypeVar, Union, overload
+from typing import TypeVar, overload
 
 import depthai as dai
 
@@ -7,7 +7,7 @@ from depthai_nodes.logging import get_logger
 from depthai_nodes.node.parser_generator import ParserGenerator
 from depthai_nodes.node.parsers import BaseParser
 
-TParser = TypeVar("TParser", bound=Union[BaseParser, dai.DeviceNode])
+TParser = TypeVar("TParser", bound=BaseParser | dai.DeviceNode)
 
 
 class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
@@ -37,8 +37,8 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         super().__init__(*args, **kwargs)
         self._pipeline = self.getParentPipeline()
         self._nn = self._pipeline.create(dai.node.NeuralNetwork)
-        self._parsers: Dict[int, BaseParser] = {}
-        self._internal_sync: Optional[dai.node.Sync] = None
+        self._parsers: dict[int, BaseParser] = {}
+        self._internal_sync: dai.node.Sync | None = None
         self._logger = get_logger(__name__)
         self._logger.debug("ParsingNeuralNetwork initialized")
 
@@ -93,20 +93,20 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         return self._nn.getNumInferenceThreads()
 
     @overload
-    def getParser(self, index: int = 0) -> Union[BaseParser, dai.DeviceNode]:
+    def getParser(self, index: int = 0) -> BaseParser | dai.DeviceNode:
         """Return the parser for the requested model head."""
         ...
 
     @overload
-    def getParser(self, parserType: Type[TParser], index: int = 0) -> TParser:
+    def getParser(self, parserType: type[TParser], index: int = 0) -> TParser:
         """Return the parser for the requested model head."""
         ...
 
-    def getParser(self, *args, **kwargs) -> Union[BaseParser, dai.DeviceNode]:
+    def getParser(self, *args, **kwargs) -> BaseParser | dai.DeviceNode:
         """Return the parser for the requested model head.
 
         @param parserType: Optional expected parser type used for runtime type checking.
-        @type parserType: Type[TParser]
+        @type parserType: type[TParser]
         @param index: Model head index. Defaults to 0.
         @type index: int
         @return: Parser node matching the requested head.
@@ -156,11 +156,11 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         """Set the backend used by the underlying neural-network node."""
         self._nn.setBackend(setBackend)
 
-    def setBackendProperties(self, setBackendProperties: Dict[str, str]) -> None:
+    def setBackendProperties(self, setBackendProperties: dict[str, str]) -> None:
         """Set backend-specific properties on the underlying neural-network node."""
         self._nn.setBackendProperties(setBackendProperties)
 
-    def setBlob(self, blob: Union[Path, dai.OpenVINO.Blob]) -> None:
+    def setBlob(self, blob: Path | dai.OpenVINO.Blob) -> None:
         """Set the blob used by the underlying neural-network node."""
         self._nn.setBlob(blob)
 
@@ -179,7 +179,7 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         self._nn.setModelPath(modelPath)
 
     def setNNArchive(
-        self, nnArchive: dai.NNArchive, numShaves: Optional[int] = None
+        self, nnArchive: dai.NNArchive, numShaves: int | None = None
     ) -> None:
         """Set the active model archive and rebuild parser nodes.
 
@@ -187,7 +187,7 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         @type nnArchive: dai.NNArchive
         @param numShaves: Optional number of shaves allocated to the neural-network
             node.
-        @type numShaves: Optional[int]
+        @type numShaves: int | None
         """
         self._nn_archive = nnArchive
         if numShaves:
@@ -214,19 +214,19 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
 
     def build(
         self,
-        input: Union[dai.Node.Output, dai.node.Camera],
-        nnSource: Union[dai.NNModelDescription, dai.NNArchive, str],
-        fps: Optional[float] = None,
+        input: dai.Node.Output | dai.node.Camera,
+        nnSource: dai.NNModelDescription | dai.NNArchive | str,
+        fps: float | None = None,
     ) -> "ParsingNeuralNetwork":
         """Build the neural-network node and create parser nodes for each head.
 
         @param input: Upstream output or camera feeding frames into the neural-network
             node.
-        @type input: Union[dai.Node.Output, dai.node.Camera]
+        @type input: dai.Node.Output | dai.node.Camera
         @param nnSource: dai.NNModelDescription, dai.NNArchive, or HubAI model slug.
-        @type nnSource: Union[dai.NNModelDescription, dai.NNArchive, str]
+        @type nnSource: dai.NNModelDescription | dai.NNArchive | str
         @param fps: Optional runtime FPS limit for the neural-network node.
-        @type fps: Optional[float]
+        @type fps: float | None
         @return: The configured node instance.
         @rtype: ParsingNeuralNetwork
         """
@@ -290,7 +290,7 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
         if self._internal_sync is not None:
             self._pipeline.remove(self._internal_sync)
 
-    def _getParserNodes(self, nnArchive: dai.NNArchive) -> Dict[int, BaseParser]:
+    def _getParserNodes(self, nnArchive: dai.NNArchive) -> dict[int, BaseParser]:
         parser_generator = self._pipeline.create(ParserGenerator)
         parsers = self._generateParsers(parser_generator, nnArchive)
         for parser in parsers.values():
@@ -302,7 +302,7 @@ class ParsingNeuralNetwork(dai.node.ThreadedHostNode):
 
     def _generateParsers(
         self, parserGenerator: ParserGenerator, nnArchive: dai.NNArchive
-    ) -> Dict[int, BaseParser]:
+    ) -> dict[int, BaseParser]:
         return parserGenerator.build(nnArchive)
 
     def _getModelHeadsLen(self):

--- a/depthai_nodes/node/tiling.py
+++ b/depthai_nodes/node/tiling.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Union
 
 import depthai as dai
 import numpy as np
@@ -10,12 +9,12 @@ from depthai_nodes.node.base_threaded_host_node import BaseThreadedHostNode
 @dataclass
 class TilingCfg:
     overlap: float
-    gridSize: Tuple[int, int]
-    canvasShape: Tuple[int, int]
-    resizeShape: Tuple[int, int]
+    gridSize: tuple[int, int]
+    canvasShape: tuple[int, int]
+    resizeShape: tuple[int, int]
     resizeMode: dai.ImageManipConfig.ResizeMode
     globalDetection: bool
-    gridMatrix: Union[np.ndarray, List, None]
+    gridMatrix: np.ndarray | list | None
 
 
 class Tiling(BaseThreadedHostNode):
@@ -35,7 +34,7 @@ class Tiling(BaseThreadedHostNode):
 
         self._cfg_out = self.createOutput()
         self._cfg_out.setPossibleDatatypes([(dai.DatatypeEnum.MessageGroup, True)])
-        self._tiling_cfg: Optional[TilingCfg] = None
+        self._tiling_cfg: TilingCfg | None = None
         self._logger.debug("Tiling initialized")
 
     @property
@@ -56,33 +55,33 @@ class Tiling(BaseThreadedHostNode):
 
     def updateTilingConfig(
         self,
-        overlap: Optional[float] = None,
-        gridSize: Optional[Tuple[int, int]] = None,
-        canvasShape: Optional[Tuple[int, int]] = None,
-        resizeShape: Optional[Tuple[int, int]] = None,
-        resizeMode: Optional[dai.ImageManipConfig.ResizeMode] = None,
-        globalDetection: Optional[bool] = None,
-        gridMatrix: Optional[Union[np.ndarray, List, None]] = None,
+        overlap: float | None = None,
+        gridSize: tuple[int, int] | None = None,
+        canvasShape: tuple[int, int] | None = None,
+        resizeShape: tuple[int, int] | None = None,
+        resizeMode: dai.ImageManipConfig.ResizeMode | None = None,
+        globalDetection: bool | None = None,
+        gridMatrix: np.ndarray | list | None | None = None,
     ) -> None:
         """Update the tiling configuration used for future trigger messages.
 
         @param overlap: Fractional overlap between adjacent tiles in the range [0, 1).
-        @type overlap: Optional[float]
+        @type overlap: float | None
         @param gridSize: Tile grid as (columns, rows).
-        @type gridSize: Optional[Tuple[int, int]]
+        @type gridSize: tuple[int, int] | None
         @param canvasShape: Shape of the image space the tiling is defined on. Crop
             coordinates are computed in this absolute coordinate system.
-        @type canvasShape: Optional[Tuple[int, int]]
+        @type canvasShape: tuple[int, int] | None
         @param resizeShape: Output size applied to each tile after cropping. This is the
             shape expected by downstream consumers, not necessarily a neural network.
-        @type resizeShape: Optional[Tuple[int, int]]
+        @type resizeShape: tuple[int, int] | None
         @param resizeMode: Resize strategy used when adapting each crop to resizeShape.
-        @type resizeMode: Optional[dai.ImageManipConfig.ResizeMode]
+        @type resizeMode: dai.ImageManipConfig.ResizeMode | None
         @param globalDetection: If True, prepend a config covering the whole canvas.
-        @type globalDetection: Optional[bool]
+        @type globalDetection: bool | None
         @param gridMatrix: Optional grouping matrix for merging neighboring grid cells
             into larger crops.
-        @type gridMatrix: Optional[Union[np.ndarray, List, None]]
+        @type gridMatrix: np.ndarray | list | None | None
         """
         if self._tiling_cfg is None:
             raise RuntimeError("Tiling was not built yet. Call `build()` first.")
@@ -107,32 +106,32 @@ class Tiling(BaseThreadedHostNode):
     def build(
         self,
         overlap: float,
-        gridSize: Tuple[int, int],
-        canvasShape: Tuple[int, int],
-        resizeShape: Tuple[int, int],
+        gridSize: tuple[int, int],
+        canvasShape: tuple[int, int],
+        resizeShape: tuple[int, int],
         resizeMode: dai.ImageManipConfig.ResizeMode,
         globalDetection: bool = False,
-        gridMatrix: Union[np.ndarray, List, None] = None,
+        gridMatrix: np.ndarray | list | None = None,
     ) -> "Tiling":
         """Configure the tiling node and link the trigger stream.
 
         @param overlap: Fractional overlap between adjacent tiles in the range [0, 1).
         @type overlap: float
         @param gridSize: Tile grid as (columns, rows).
-        @type gridSize: Tuple[int, int]
+        @type gridSize: tuple[int, int]
         @param canvasShape: Shape of the image space the tiling is defined on. Crop
             coordinates are computed in this absolute coordinate system.
-        @type canvasShape: Tuple[int, int]
+        @type canvasShape: tuple[int, int]
         @param resizeShape: Output size applied to each tile after cropping. This is the
             shape expected by downstream consumers, not necessarily a neural network.
-        @type resizeShape: Tuple[int, int]
+        @type resizeShape: tuple[int, int]
         @param resizeMode: Resize strategy used when adapting each crop to resizeShape.
         @type resizeMode: dai.ImageManipConfig.ResizeMode
         @param globalDetection: If True, prepend a config covering the whole canvas.
         @type globalDetection: bool
         @param gridMatrix: Optional grouping matrix for merging neighboring grid cells
             into larger crops.
-        @type gridMatrix: Union[np.ndarray, List, None]
+        @type gridMatrix: np.ndarray | list | None
         @return: The configured node instance.
         @rtype: Tiling
         """
@@ -170,7 +169,7 @@ class Tiling(BaseThreadedHostNode):
         self.out.send(cfg_group)
 
     def _createMessageGroup(
-        self, crop_configs: List[dai.ImageManipConfig]
+        self, crop_configs: list[dai.ImageManipConfig]
     ) -> dai.MessageGroup:
         msg_group = dai.MessageGroup()
         for i, cfg in enumerate(crop_configs):
@@ -180,7 +179,7 @@ class Tiling(BaseThreadedHostNode):
     def _computeTilePositions(
         self,
         tiling_cfg: TilingCfg,
-    ) -> List[Tuple[int, int, int, int]]:
+    ) -> list[tuple[int, int, int, int]]:
         tile_dims = self._calculateTiles(
             grid_size=tiling_cfg.gridSize,
             canvas_shape=tiling_cfg.canvasShape,
@@ -270,8 +269,8 @@ class Tiling(BaseThreadedHostNode):
 
     def _calculateTiles(
         self,
-        grid_size: Tuple[int, int],
-        canvas_shape: Tuple[int, int],
+        grid_size: tuple[int, int],
+        canvas_shape: tuple[int, int],
         overlap: float,
     ) -> np.ndarray:
         if not 0 <= overlap < 1:
@@ -289,10 +288,10 @@ class Tiling(BaseThreadedHostNode):
 
     def _generateManipConfigs(
         self,
-        tile_positions: List[Tuple[int, int, int, int]],
-        resize_shape: Tuple[int, int],
+        tile_positions: list[tuple[int, int, int, int]],
+        resize_shape: tuple[int, int],
         resize_mode: dai.ImageManipConfig.ResizeMode,
-    ) -> List[dai.ImageManipConfig]:
+    ) -> list[dai.ImageManipConfig]:
         return [
             self._getManipConfig(tile_info, resize_shape, resize_mode)
             for tile_info in tile_positions
@@ -300,8 +299,8 @@ class Tiling(BaseThreadedHostNode):
 
     def _getManipConfig(
         self,
-        tile_info: Tuple[int, int, int, int],
-        resize_shape: Tuple[int, int],
+        tile_info: tuple[int, int, int, int],
+        resize_shape: tuple[int, int],
         resize_mode: dai.ImageManipConfig.ResizeMode,
     ) -> dai.ImageManipConfig:
         x1, y1, x2, y2 = tile_info

--- a/depthai_nodes/node/utils/detection_config_generator.py
+++ b/depthai_nodes/node/utils/detection_config_generator.py
@@ -29,7 +29,7 @@ def generate_script_content(
     @type padding: float
     @param valid_labels: List of valid label indices to filter detections. If None, all
         detections are processed
-    @type valid_labels: Optional[List[int]]
+    @type valid_labels: list[int] | None
     @return: Generated script content as a string
     @rtype: str
     """

--- a/depthai_nodes/node/utils/nms.py
+++ b/depthai_nodes/node/utils/nms.py
@@ -1,11 +1,9 @@
-from typing import List
-
 import depthai as dai
 import numpy as np
 
 
 def nms_detections(
-    detections: List[dai.ImgDetection],
+    detections: list[dai.ImgDetection],
     conf_thresh=0.3,
     iou_thresh=0.4,
 ):

--- a/depthai_nodes/node/utils/to_planar.py
+++ b/depthai_nodes/node/utils/to_planar.py
@@ -1,10 +1,8 @@
-from typing import Tuple
-
 import cv2
 import numpy as np
 
 
-def to_planar(arr: np.ndarray, shape: Tuple) -> np.ndarray:
+def to_planar(arr: np.ndarray, shape: tuple) -> np.ndarray:
     """Converts the input image `arr` (NumPy array) to the planar format expected by
     depthai. The image is resized to the dimensions specified in `shape`.
 

--- a/depthai_nodes/node/utils/util_constants.py
+++ b/depthai_nodes/node/utils/util_constants.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Union
+from typing import TypeVar
 
 import depthai as dai
 
@@ -12,15 +12,13 @@ from depthai_nodes.message.segmentation import SegmentationMask
 
 GMessage = TypeVar(
     "GMessage",
-    bound=Union[
-        dai.ImgDetections,
-        Keypoints,
-        SegmentationMask,
-        Clusters,
-        Map2D,
-        Lines,
-        Predictions,
-        Classifications,
-    ],
+    bound=dai.ImgDetections
+    | Keypoints
+    | SegmentationMask
+    | Clusters
+    | Map2D
+    | Lines
+    | Predictions
+    | Classifications,
 )
 UNASSIGNED_MASK_LABEL = -1

--- a/depthai_nodes/utils/annotation_helper.py
+++ b/depthai_nodes/utils/annotation_helper.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import List, Optional, Tuple, Union
 
 import depthai as dai
 import numpy as np
@@ -10,8 +9,8 @@ from depthai_nodes.constants import (
 )
 from depthai_nodes.utils.viewport_clipper import ViewportClipper
 
-Point = Tuple[float, float]
-ColorRGBA = Tuple[float, float, float, float]
+Point = tuple[float, float]
+ColorRGBA = tuple[float, float, float, float]
 
 
 class AnnotationHelper:
@@ -20,7 +19,7 @@ class AnnotationHelper:
     After calling the desired drawing methods, call the `build` method to create the `ImgAnnotations` message.
     """
 
-    def __init__(self, viewport_clipper: Optional[ViewportClipper] = None):
+    def __init__(self, viewport_clipper: ViewportClipper | None = None):
         self.annotation: dai.ImgAnnotation = dai.ImgAnnotation()
         if not viewport_clipper:
             viewport_clipper = ViewportClipper(
@@ -30,9 +29,9 @@ class AnnotationHelper:
 
     def draw_line(
         self,
-        pt1: Union[Point, dai.Point2f],
-        pt2: Union[Point, dai.Point2f],
-        color: Union[ColorRGBA, dai.Color] = PRIMARY_COLOR,
+        pt1: Point | dai.Point2f,
+        pt2: Point | dai.Point2f,
+        color: ColorRGBA | dai.Color = PRIMARY_COLOR,
         thickness: float = 2.0,
         clip_to_viewport: bool = False,
     ) -> "AnnotationHelper":
@@ -74,18 +73,16 @@ class AnnotationHelper:
 
     def draw_polyline(
         self,
-        points: Union[List[Point], List[dai.Point2f]],
-        outline_color: Union[ColorRGBA, dai.Color] = PRIMARY_COLOR,
-        fill_color: Union[
-            Optional[ColorRGBA], Optional[dai.Color]
-        ] = TRANSPARENT_PRIMARY_COLOR,
+        points: list[Point] | list[dai.Point2f],
+        outline_color: ColorRGBA | dai.Color = PRIMARY_COLOR,
+        fill_color: (ColorRGBA | None | dai.Color | None) = TRANSPARENT_PRIMARY_COLOR,
         thickness: float = 1.0,
         closed: bool = False,
     ) -> "AnnotationHelper":
         """Draws a polyline.
 
         @param points: List of points of the polyline
-        @type points: List[Point] | List[dai.Point2f]
+        @type points: list[Point] | list[dai.Point2f]
         @param outline_color: Outline color
         @type outline_color: ColorRGBA | dai.Color
         @param fill_color: Fill color (None for no fill)
@@ -118,14 +115,14 @@ class AnnotationHelper:
 
     def draw_points(
         self,
-        points: Union[List[Point], List[dai.Point2f], dai.VectorPoint2f],
-        color: Union[ColorRGBA, dai.Color] = PRIMARY_COLOR,
+        points: list[Point] | list[dai.Point2f] | dai.VectorPoint2f,
+        color: ColorRGBA | dai.Color = PRIMARY_COLOR,
         thickness: float = 2.0,
     ) -> "AnnotationHelper":
         """Draws points.
 
         @param points: List of points to draw
-        @type points: List[Point] | List[dai.Point2f]
+        @type points: list[Point] | list[dai.Point2f]
         @param color: Color of the points
         @type color: ColorRGBA | dai.Color
         @param thickness: Size of the points
@@ -147,10 +144,10 @@ class AnnotationHelper:
 
     def draw_circle(
         self,
-        center: Union[Point, dai.Point2f],
+        center: Point | dai.Point2f,
         radius: float,
-        outline_color: Union[ColorRGBA, dai.Color] = PRIMARY_COLOR,
-        fill_color: Union[Optional[ColorRGBA], Optional[dai.Color]] = None,
+        outline_color: ColorRGBA | dai.Color = PRIMARY_COLOR,
+        fill_color: ColorRGBA | None | dai.Color | None = None,
         thickness: float = 1.0,
     ) -> "AnnotationHelper":
         """Draws a circle.
@@ -186,12 +183,10 @@ class AnnotationHelper:
 
     def draw_rectangle(
         self,
-        top_left: Union[Point, dai.Point2f],
-        bottom_right: Union[Point, dai.Point2f],
-        outline_color: Union[ColorRGBA, dai.Color] = PRIMARY_COLOR,
-        fill_color: Union[
-            Optional[ColorRGBA], Optional[dai.Color]
-        ] = TRANSPARENT_PRIMARY_COLOR,
+        top_left: Point | dai.Point2f,
+        bottom_right: Point | dai.Point2f,
+        outline_color: ColorRGBA | dai.Color = PRIMARY_COLOR,
+        fill_color: (ColorRGBA | None | dai.Color | None) = TRANSPARENT_PRIMARY_COLOR,
         thickness: float = 1.0,
         clip_to_viewport: bool = False,
     ) -> "AnnotationHelper":
@@ -231,9 +226,9 @@ class AnnotationHelper:
     def draw_text(
         self,
         text: str,
-        position: Union[Point, dai.Point2f],
-        color: Union[ColorRGBA, dai.Color] = PRIMARY_COLOR,
-        background_color: Union[Optional[ColorRGBA], Optional[dai.Color]] = None,
+        position: Point | dai.Point2f,
+        color: ColorRGBA | dai.Color = PRIMARY_COLOR,
+        background_color: ColorRGBA | None | dai.Color | None = None,
         size: float = 32,
     ) -> "AnnotationHelper":
         """Draws text.
@@ -269,13 +264,11 @@ class AnnotationHelper:
 
     def draw_rotated_rect(
         self,
-        center: Union[Point, dai.Point2f],
-        size: Union[Tuple[float, float], dai.Size2f],
+        center: Point | dai.Point2f,
+        size: tuple[float, float] | dai.Size2f,
         angle: float,
-        outline_color: Union[ColorRGBA, dai.Color] = PRIMARY_COLOR,
-        fill_color: Union[
-            Optional[ColorRGBA], Optional[dai.Color]
-        ] = TRANSPARENT_PRIMARY_COLOR,
+        outline_color: ColorRGBA | dai.Color = PRIMARY_COLOR,
+        fill_color: (ColorRGBA | None | dai.Color | None) = TRANSPARENT_PRIMARY_COLOR,
         thickness: float = 1.0,
         clip_to_viewport: bool = False,
     ) -> "AnnotationHelper":
@@ -284,7 +277,7 @@ class AnnotationHelper:
         @param center: Center of the rectangle
         @type center: Point | dai.Point2f
         @param size: Size of the rectangle (width, height)
-        @type size: Tuple[float, float] | dai.Size2f
+        @type size: tuple[float, float] | dai.Size2f
         @param angle: Angle of rotation in degrees
         @type angle: float
         @param outline_color: Outline color
@@ -329,10 +322,10 @@ class AnnotationHelper:
 
     def _create_points_annotation(
         self,
-        points: List[dai.Point2f],
+        points: list[dai.Point2f],
         color: dai.Color,
-        fill_color: Optional[dai.Color],
-        type: dai.PointsAnnotationType,
+        fill_color: dai.Color | None,
+        type: dai.PointsAnnotationtype,
     ) -> dai.PointsAnnotation:
         points_annot = dai.PointsAnnotation()
         points_annot.outlineColor = color
@@ -352,7 +345,7 @@ class AnnotationHelper:
 
     def _get_rotated_rect_points(
         self, center: dai.Point2f, size: dai.Size2f, angle: float
-    ) -> List[Point]:
+    ) -> list[Point]:
         angle_rad = np.radians(angle)
 
         # Half-dimensions
@@ -377,8 +370,8 @@ class AnnotationHelper:
         # Convert to list of tuples
         return [tuple(corner) for corner in translated_corners.tolist()]
 
-    def _create_points_vector(self, points: List[dai.Point2f]) -> dai.VectorPoint2f:
+    def _create_points_vector(self, points: list[dai.Point2f]) -> dai.VectorPoint2f:
         return dai.VectorPoint2f(points)
 
-    def _create_size(self, size: Tuple[float, float]):
+    def _create_size(self, size: tuple[float, float]):
         return dai.Size2f(size[0], size[1])

--- a/depthai_nodes/utils/annotation_helper.py
+++ b/depthai_nodes/utils/annotation_helper.py
@@ -325,7 +325,7 @@ class AnnotationHelper:
         points: list[dai.Point2f],
         color: dai.Color,
         fill_color: dai.Color | None,
-        type: dai.PointsAnnotationtype,
+        type: dai.PointsAnnotationType,
     ) -> dai.PointsAnnotation:
         points_annot = dai.PointsAnnotation()
         points_annot.outlineColor = color

--- a/depthai_nodes/utils/viewport_clipper.py
+++ b/depthai_nodes/utils/viewport_clipper.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List, Optional, Tuple
 
 
 class ViewportClipper:
@@ -19,15 +18,15 @@ class ViewportClipper:
         self._min_y = min_y
         self._max_y = max_y
 
-    def clip_rect(self, points: List[Tuple[float, float]]) -> List[Tuple[float, float]]:
+    def clip_rect(self, points: list[tuple[float, float]]) -> list[tuple[float, float]]:
         """Clips a rectangle defined by points to viewport.
 
         Uses Sutherland-Hodgman polygon clipping algorithm.
 
         @param points: List of points defining the polygon vertices
-        @type points: List[Tuple[float, float]]
+        @type points: list[tuple[float, float]]
         @return: List of points defining the clipped polygon vertices
-        @rtype: List[Tuple[float, float]]
+        @rtype: list[tuple[float, float]]
         """
         if not points:
             return []
@@ -45,8 +44,8 @@ class ViewportClipper:
         return clipped
 
     def _clip_against_boundary(
-        self, points: List[Tuple[float, float]], boundary: "_PointLocation"
-    ) -> List[Tuple[float, float]]:
+        self, points: list[tuple[float, float]], boundary: "_PointLocation"
+    ) -> list[tuple[float, float]]:
         if not points:
             return []
         result = []
@@ -71,17 +70,17 @@ class ViewportClipper:
         return result
 
     def _point_inside_boundary(
-        self, point: Tuple[float, float], boundary: "_PointLocation"
+        self, point: tuple[float, float], boundary: "_PointLocation"
     ) -> bool:
         location = self._get_location(point)
         return self._location_inside_boundary(location, boundary)
 
     def _intersect_boundary(
         self,
-        p1: Tuple[float, float],
-        p2: Tuple[float, float],
+        p1: tuple[float, float],
+        p2: tuple[float, float],
         boundary: "_PointLocation",
-    ) -> Optional[Tuple[float, float]]:
+    ) -> tuple[float, float] | None:
         location1 = self._get_location(p1)
         location2 = self._get_location(p2)
 
@@ -101,7 +100,7 @@ class ViewportClipper:
     ) -> bool:
         return not (location & boundary.value)
 
-    def clip_line(self, pt1: Tuple[float, float], pt2: Tuple[float, float]):
+    def clip_line(self, pt1: tuple[float, float], pt2: tuple[float, float]):
         """Clips a line segment to viewport (0,1).
 
         Uses Cohen-Sutherland line clipping algorithm.
@@ -139,8 +138,8 @@ class ViewportClipper:
                 location2 = self._get_location(pt2)
 
     def _calculate_intersection(
-        self, pt1: Tuple[float, float], pt2: Tuple[float, float], location: int
-    ) -> Tuple[float, float]:
+        self, pt1: tuple[float, float], pt2: tuple[float, float], location: int
+    ) -> tuple[float, float]:
         x1, y1 = pt1
         x2, y2 = pt2
         if location & self._PointLocation.TOP.value:
@@ -166,7 +165,7 @@ class ViewportClipper:
             return a1
         return a1 + (a2 - a1) * (b_target - b1) / (b2 - b1)
 
-    def _get_location(self, pt: Tuple[float, float]) -> int:
+    def _get_location(self, pt: tuple[float, float]) -> int:
         x, y = pt
         location = self._PointLocation.INSIDE.value
         if x < self._min_x:

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -2,7 +2,6 @@ import ast
 import os
 import subprocess
 import time
-from typing import List
 
 import pytest
 
@@ -23,7 +22,7 @@ def platform(request):
 
 
 def get_parametrized_values(
-    models: List[str], nn_archive_paths: List[str], platform: str
+    models: list[str], nn_archive_paths: list[str], platform: str
 ):
     test_cases = []
     rvc2_ip = os.getenv("RVC2_IP", "")

--- a/tests/end_to_end/utils.py
+++ b/tests/end_to_end/utils.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from typing import Dict, List, Tuple
 
 import depthai as dai
 import requests
@@ -21,7 +20,7 @@ if not HUBAI_TEAM_SLUG:
 HEADERS = {"Authorization": f"Bearer {API_KEY}"}
 
 
-def get_inputs_from_archive(nn_archive: dai.NNArchive) -> List:
+def get_inputs_from_archive(nn_archive: dai.NNArchive) -> list:
     """Get all inputs from NN archive."""
     try:
         inputs = nn_archive.getConfig().model.inputs
@@ -34,7 +33,7 @@ def get_inputs_from_archive(nn_archive: dai.NNArchive) -> List:
     return inputs
 
 
-def get_input_shape(nn_archive: dai.NNArchive) -> Tuple[int, int]:
+def get_input_shape(nn_archive: dai.NNArchive) -> tuple[int, int]:
     """Get the input shape of the model from the NN archive."""
     inputs = get_inputs_from_archive(nn_archive)
 
@@ -68,7 +67,7 @@ def get_num_inputs(nn_archive: dai.NNArchive) -> int:
     return len(inputs)
 
 
-def get_models() -> List[Dict]:
+def get_models() -> list[dict]:
     """Get all the models from the ZOO that correspond to the HubAI team."""
     url = "https://easyml.cloud.luxonis.com/models/api/v1/models?is_public=true&limit=1000"
 
@@ -92,7 +91,7 @@ def get_models() -> List[Dict]:
     return valid_models
 
 
-def get_model_versions(models: List[Dict]) -> List[Dict]:
+def get_model_versions(models: list[dict]) -> list[dict]:
     """Get all the model versions from the ZOO that correspond to given models."""
     url = "https://easyml.cloud.luxonis.com/models/api/v1/modelVersions?is_public=True&limit=1000"
 
@@ -122,7 +121,7 @@ def get_model_versions(models: List[Dict]) -> List[Dict]:
     return model_versions
 
 
-def get_model_instances(model_versions: List[Dict]) -> List[Dict]:
+def get_model_instances(model_versions: list[dict]) -> list[dict]:
     """Get all the model instances from the ZOO that correspond to the model
     versions."""
     url = "https://easyml.cloud.luxonis.com/models/api/v1/modelInstances?is_public=True&limit=1000"
@@ -157,7 +156,7 @@ def get_model_instances(model_versions: List[Dict]) -> List[Dict]:
     return model_instances
 
 
-def get_model_config_parser(model_instance_id: str) -> Dict:
+def get_model_config_parser(model_instance_id: str) -> dict:
     """Get the model config from the ZOO."""
     url = f"https://easyml.cloud.luxonis.com/models/api/v1/modelInstances/{model_instance_id}/config"
     response = requests.get(url, headers=HEADERS)
@@ -169,7 +168,7 @@ def get_model_config_parser(model_instance_id: str) -> Dict:
     return response.json()
 
 
-def get_model_slugs_from_zoo() -> List[str]:
+def get_model_slugs_from_zoo() -> list[str]:
     """Get all the model slugs from the ZOO."""
     model_slugs = []
     models = get_models()
@@ -181,7 +180,7 @@ def get_model_slugs_from_zoo() -> List[str]:
     return model_slugs
 
 
-def find_slugs_from_zoo(parser: str) -> List[str]:
+def find_slugs_from_zoo(parser: str) -> list[str]:
     """Find all model slugs that have the required parser."""
     models = get_models()
     model_versions = get_model_versions(models)

--- a/tests/stability_tests/check_messages.py
+++ b/tests/stability_tests/check_messages.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Any, Dict, List
+from typing import Any
 
 import depthai as dai
 import numpy as np
@@ -17,14 +17,14 @@ from depthai_nodes import (
 from .utils import extract_main_slug
 
 
-def load_expected_output(model: str, parser: str) -> Dict[str, Any]:
+def load_expected_output(model: str, parser: str) -> dict[str, Any]:
     model = extract_main_slug(model)
     with open(f"nn_datas/{parser}/{model}_output.pkl", "rb") as f:
         return pickle.load(f)
 
 
 def check_classification_msg(
-    message: Classifications, expected_output: Dict[str, Any], verbose: bool = False
+    message: Classifications, expected_output: dict[str, Any], verbose: bool = False
 ):
     """
     Expected output format:
@@ -51,7 +51,7 @@ def check_classification_msg(
 
 
 def check_classification_sequence_msg(
-    message: Classifications, expected_output: Dict[str, Any], verbose: bool = False
+    message: Classifications, expected_output: dict[str, Any], verbose: bool = False
 ):
     """
     Expected output format:
@@ -78,7 +78,7 @@ def check_classification_sequence_msg(
 
 
 def check_embeddings_msg(
-    message: dai.NNData, expected_output: Dict[str, Any], verbose: bool = False
+    message: dai.NNData, expected_output: dict[str, Any], verbose: bool = False
 ):
     """
     Expected output format:
@@ -108,7 +108,7 @@ def check_embeddings_msg(
 
 def check_segmentation_msg(
     message: SegmentationMask,
-    expected_output: Dict[str, Any],
+    expected_output: dict[str, Any],
     threshold: float = 0.9,
     verbose: bool = False,
 ):
@@ -150,7 +150,7 @@ def check_segmentation_msg(
 
 def check_keypoints_msg(
     message: Keypoints,
-    expected_output: Dict[str, Any],
+    expected_output: dict[str, Any],
     verbose: bool = False,
 ):
     """
@@ -183,7 +183,7 @@ def check_keypoints_msg(
 
 
 def check_image_msg(
-    message: dai.ImgFrame, expected_output: Dict[str, Any], verbose: bool = False
+    message: dai.ImgFrame, expected_output: dict[str, Any], verbose: bool = False
 ):
     """
     Expected output format:
@@ -210,7 +210,7 @@ def check_image_msg(
 
 
 def check_cluster_msg(
-    message: Clusters, expected_output: Dict[str, Any], verbose: bool = False
+    message: Clusters, expected_output: dict[str, Any], verbose: bool = False
 ):
     """
     Expected output format:
@@ -244,7 +244,7 @@ def check_cluster_msg(
 
 
 def check_map_msg(
-    message: Map2D, expected_output: Dict[str, Any], verbose: bool = False
+    message: Map2D, expected_output: dict[str, Any], verbose: bool = False
 ):
     """
     Expected output format:
@@ -272,7 +272,7 @@ def check_map_msg(
 
 def check_detection_msg(
     message: dai.ImgDetections,
-    expected_output: Dict[str, Any],
+    expected_output: dict[str, Any],
     verbose: bool = False,
 ):
     """
@@ -301,7 +301,7 @@ def check_detection_msg(
     ), f"The message is not dai.ImgDetections. Got {type(message)}."
 
     predicted_detections = []
-    expected_detections: List[Dict[str, Any]] = expected_output["detections"]
+    expected_detections: list[dict[str, Any]] = expected_output["detections"]
 
     for detection in message.detections:
         d = {
@@ -386,7 +386,7 @@ def check_detection_msg(
 
 
 def check_line_msg(
-    message: Lines, expected_output: Dict[str, Any], verbose: bool = False
+    message: Lines, expected_output: dict[str, Any], verbose: bool = False
 ):
     """
     Expected output format:
@@ -407,7 +407,7 @@ def check_line_msg(
         message, Lines
     ), f"The message is not a Lines. Got {type(message)}."
 
-    expected_lines: List[Dict[str, Any]] = expected_output["lines"]
+    expected_lines: list[dict[str, Any]] = expected_output["lines"]
     predicted_lines = []
     for line in message.lines:
         line_dict = {
@@ -439,7 +439,7 @@ def check_line_msg(
 
 
 def check_regression_msg(
-    message: Predictions, expected_output: Dict[str, Any], verbose: bool = False
+    message: Predictions, expected_output: dict[str, Any], verbose: bool = False
 ):
     """
     Expected output format:

--- a/tests/stability_tests/run_parser_test.py
+++ b/tests/stability_tests/run_parser_test.py
@@ -1,6 +1,5 @@
 import ast
 import pickle
-from typing import List
 
 import depthai as dai
 import pytest
@@ -30,8 +29,8 @@ def parser_generator():
 
 
 def get_parametrized_values(
-    models: List[str], parsers: List[str], duration: int
-) -> List[List[str]]:
+    models: list[str], parsers: list[str], duration: int
+) -> list[list[str]]:
     test_cases = []
 
     if duration:

--- a/tests/stability_tests/utils.py
+++ b/tests/stability_tests/utils.py
@@ -1,5 +1,4 @@
 import os
-from typing import List, Tuple
 
 import depthai as dai
 from b2sdk.api import B2Api
@@ -23,7 +22,7 @@ def extract_main_slug(model_slug: str) -> str:
     return model_slug.split("/")[1].split(":")[0]
 
 
-def get_inputs_from_archive(nn_archive: dai.NNArchive) -> List:
+def get_inputs_from_archive(nn_archive: dai.NNArchive) -> list:
     """Get all inputs from NN archive."""
     try:
         inputs = nn_archive.getConfig().model.inputs
@@ -36,7 +35,7 @@ def get_inputs_from_archive(nn_archive: dai.NNArchive) -> List:
     return inputs
 
 
-def get_input_shape(nn_archive: dai.NNArchive) -> Tuple[int, int]:
+def get_input_shape(nn_archive: dai.NNArchive) -> tuple[int, int]:
     """Get the input shape of the model from the NN archive."""
     inputs = get_inputs_from_archive(nn_archive)
 

--- a/tests/unittests/test_messages/test_copy_message.py
+++ b/tests/unittests/test_messages/test_copy_message.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Callable, List, Tuple
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -21,7 +21,7 @@ def equal_attributes(obj1, obj2):
         return obj1 == obj2
     elif isinstance(obj1, np.ndarray):
         return np.array_equal(obj1, obj2)
-    elif isinstance(obj1, (List, Tuple)):
+    elif isinstance(obj1, (list, tuple)):
         return len(obj1) == len(obj2) and all(
             equal_attributes(a, b) for a, b in zip(obj1, obj2)
         )
@@ -46,7 +46,7 @@ def equal_attributes(obj1, obj2):
     "message_creator",
     message_creators.__all__,
 )
-def test_message_copying(message_creator: Tuple[str, Callable]):
+def test_message_copying(message_creator: tuple[str, Callable]):
     creator_function = getattr(message_creators, message_creator)
 
     msg = creator_function()

--- a/tests/unittests/test_nodes/test_host_nodes/test_apply_colormap_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_apply_colormap_node.py
@@ -1,5 +1,5 @@
 import time
-from typing import Callable
+from collections.abc import Callable
 
 import cv2
 import depthai as dai

--- a/tests/unittests/test_nodes/test_host_nodes/test_depth_merger_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_depth_merger_node.py
@@ -129,7 +129,7 @@ def test_img_detection(
         ran_once = True
         if modified_duration is not None and time.time() - last_log_time > LOG_INTERVAL:
             print(
-                f"Test running... {time.time()-start_time:.1f}s elapsed, {modified_duration-time.time()+start_time:.1f}s remaining"
+                f"Test running... {time.time() - start_time:.1f}s elapsed, {modified_duration - time.time() + start_time:.1f}s remaining"
             )
             last_log_time = time.time()
         output_2d.send(img_detection)
@@ -176,7 +176,7 @@ def test_img_detections(
         ran_once = True
         if modified_duration is not None and time.time() - last_log_time > LOG_INTERVAL:
             print(
-                f"Test running... {time.time()-start_time:.1f}s elapsed, {modified_duration-time.time()+start_time:.1f}s remaining"
+                f"Test running... {time.time() - start_time:.1f}s elapsed, {modified_duration - time.time() + start_time:.1f}s remaining"
             )
             last_log_time = time.time()
         output_2d.send(img_detections)

--- a/tests/unittests/test_nodes/test_host_nodes/test_generate_script_content.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_generate_script_content.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 import depthai as dai
 import pytest
 
@@ -19,12 +17,10 @@ def resize_height():
 class ImageManipConfig(dai.ImageManipConfig):
     def __init__(self):
         super().__init__()
-        self._output_size: Optional[tuple[int, int]] = None
-        self._crop_rotated_rect: Optional[dai.RotatedRect] = None
+        self._output_size: tuple[int, int] | None = None
+        self._crop_rotated_rect: dai.RotatedRect | None = None
 
-    def setOutputSize(
-        self, w, h, mode: Optional[dai.ImageManipConfig.ResizeMode] = None
-    ):
+    def setOutputSize(self, w, h, mode: dai.ImageManipConfig.ResizeMode | None = None):
         self._output_size = w, h
         if mode:
             return super().setOutputSize(w, h, mode)
@@ -62,7 +58,7 @@ class Node:
     OUTPUT_FRAMES_KEY = "manip_img"
 
     class Input:
-        def __init__(self, items: List):
+        def __init__(self, items: list):
             self._items = items
 
         def get(self):
@@ -106,7 +102,7 @@ class Node:
         raise Warning(msg)
 
 
-def create_node(preview: List[Frame], detections: List[dai.ImgDetections]):
+def create_node(preview: list[Frame], detections: list[dai.ImgDetections]):
     return Node(
         preview=Node.Input(preview),
         detections=Node.Input(detections),
@@ -133,9 +129,9 @@ def create_node(preview: List[Frame], detections: List[dai.ImgDetections]):
 )
 def detections(request):
     detections_params = request.param
-    detections_list: List[dai.ImgDetections] = []
+    detections_list: list[dai.ImgDetections] = []
     for detection_param in detections_params:
-        detections: List[dai.ImgDetection] = []
+        detections: list[dai.ImgDetection] = []
         for label, ymin, ymax, xmin, xmax, conf in detection_param:
             detection = dai.ImgDetection()
             detection.label = label
@@ -152,7 +148,7 @@ def detections(request):
 
 
 @pytest.fixture
-def frames(detections: List[dai.ImgDetections]):
+def frames(detections: list[dai.ImgDetections]):
     return [Frame(i) for i, _ in enumerate(detections)]
 
 
@@ -162,12 +158,12 @@ def node(frames, detections):
 
 
 @pytest.fixture
-def node_input_frames(node) -> List[Frame]:
+def node_input_frames(node) -> list[Frame]:
     return node.inputs[Node.INPUT_FRAMES_KEY].items
 
 
 @pytest.fixture
-def node_input_detections(node) -> List[dai.ImgDetections]:
+def node_input_detections(node) -> list[dai.ImgDetections]:
     return node.inputs[Node.INPUT_DETECTIONS_KEY].items
 
 
@@ -207,7 +203,7 @@ def test_output_size(node, resize):
 @pytest.mark.parametrize("padding", [0, 0.1, 0.2, -0.1, -0.2])
 def test_crop(node, node_input_detections, padding, resize_width, resize_height):
     ANGLE = 0
-    expected_rects: List[dai.RotatedRect] = []
+    expected_rects: list[dai.RotatedRect] = []
     for input_dets in node_input_detections:
         for detection in input_dets.detections:
             rect = dai.RotatedRect()
@@ -281,11 +277,11 @@ def run_script(node, script):
     )
 
 
-def get_output_frames(node: Node) -> List[Frame]:
+def get_output_frames(node: Node) -> list[Frame]:
     return node.outputs[Node.OUTPUT_FRAMES_KEY].items
 
 
 def get_output_config(
     node: Node,
-) -> List[ImageManipConfig]:
+) -> list[ImageManipConfig]:
     return node.outputs[Node.OUTPUT_CONFIG_KEY].items

--- a/tests/unittests/test_nodes/test_host_nodes/test_img_frame_overlay_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_img_frame_overlay_node.py
@@ -68,7 +68,7 @@ def test_processing(
         ran_once = True
         if duration is not None and time.time() - last_log_time > LOG_INTERVAL:
             print(
-                f"Test running... {time.time()-start_time:.1f}s elapsed, {duration-time.time()+start_time:.1f}s remaining"
+                f"Test running... {time.time() - start_time:.1f}s elapsed, {duration - time.time() + start_time:.1f}s remaining"
             )
             last_log_time = time.time()
         q_background.send(img_frame1)

--- a/tests/utils/messages/creators/classifications.py
+++ b/tests/utils/messages/creators/classifications.py
@@ -1,20 +1,18 @@
-from typing import List
-
 import depthai_nodes.message.creators as creators
 
 from .constants import CLASSIFICATION
 
 
 def create_classifications(
-    classes: List[str] = CLASSIFICATION["classes"],
-    scores: List[float] = CLASSIFICATION["scores"],
+    classes: list[str] = CLASSIFICATION["classes"],
+    scores: list[float] = CLASSIFICATION["scores"],
 ):
     return creators.create_classification_message(classes=classes, scores=scores)
 
 
 def create_classifications_sequence(
-    classes: List[str] = CLASSIFICATION["classes"],
-    scores: List[float] = [
+    classes: list[str] = CLASSIFICATION["classes"],
+    scores: list[float] = [
         CLASSIFICATION["scores"],
     ]
     * CLASSIFICATION["sequence_num"],

--- a/tests/utils/messages/creators/clusters.py
+++ b/tests/utils/messages/creators/clusters.py
@@ -1,11 +1,9 @@
-from typing import List, Union
-
 import depthai_nodes.message.creators as creators
 
 from .constants import COLLECTIONS
 
 
 def create_clusters(
-    clusters: List[List[List[Union[float, int]]]] = COLLECTIONS["clusters"],
+    clusters: list[list[list[float | int]]] = COLLECTIONS["clusters"],
 ):
     return creators.create_cluster_message(clusters=clusters)

--- a/tests/utils/messages/creators/detections.py
+++ b/tests/utils/messages/creators/detections.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import List
 
 import depthai as dai
 import numpy as np
@@ -8,7 +7,7 @@ from .constants import DETECTIONS
 
 
 def create_img_detection(
-    bbox: List[float] = DETECTIONS["bboxes"][0],
+    bbox: list[float] = DETECTIONS["bboxes"][0],
     label: int = DETECTIONS["labels"][0],
     score: float = DETECTIONS["scores"][0],
 ):
@@ -38,7 +37,7 @@ def create_img_detections(
 
     @param dets: List of detection dicts, each containing "bbox" ([xmin, ymin, xmax,
         ymax]), "label" (int), and "confidence" (float).
-    @type dets: List[Dict]
+    @type dets: list[dict]
     @return: The created dai.ImgDetections object.
     @rtype: dai.ImgDetections
     """

--- a/tests/utils/messages/creators/lines.py
+++ b/tests/utils/messages/creators/lines.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import numpy as np
 
 import depthai_nodes.message.creators as creators
@@ -9,7 +7,7 @@ from .constants import COLLECTIONS, SCORES
 
 def create_lines(
     lines: np.ndarray = COLLECTIONS["lines"],
-    scores: List[float] = SCORES,
+    scores: list[float] = SCORES,
 ):
     return creators.create_line_detection_message(
         lines=np.array(lines), scores=np.array(scores)

--- a/tests/utils/messages/creators/regression.py
+++ b/tests/utils/messages/creators/regression.py
@@ -1,9 +1,7 @@
-from typing import List
-
 import depthai_nodes.message.creators as creators
 
 from .constants import SCORES
 
 
-def create_regression(predictions: List[float] = SCORES):
+def create_regression(predictions: list[float] = SCORES):
     return creators.create_regression_message(predictions=predictions)

--- a/tests/utils/nodes/mocks/host_node.py
+++ b/tests/utils/nodes/mocks/host_node.py
@@ -1,5 +1,3 @@
-from typing import List, Optional, Tuple
-
 import depthai as dai
 
 from .input import InputMock
@@ -19,7 +17,7 @@ class HostNodeMock(NodeMock):
         self._output = OutputMock()
         self._parent_pipeline = None
         self._input = InputMock()
-        self._linked_args: Optional[Tuple[OutputMock, ...]] = None
+        self._linked_args: tuple[OutputMock, ...] | None = None
         self._sendProcessingToPipeline = False
         self._pipeline = PipelineMock()
 
@@ -40,7 +38,7 @@ class HostNodeMock(NodeMock):
     def output(self, output):
         self._output = output
 
-    def createOutput(self, possibleDatatypes: List[Tuple[dai.DatatypeEnum, bool]]):
+    def createOutput(self, possibleDatatypes: list[tuple[dai.DatatypeEnum, bool]]):
         return self._output
 
     def sendProcessingToPipeline(self, send: bool):

--- a/tests/utils/nodes/mocks/neural_network.py
+++ b/tests/utils/nodes/mocks/neural_network.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import depthai as dai
 
 from .input import InputMock
@@ -16,7 +14,7 @@ class NeuralNetworkMock:
     def build(
         self,
         input: InputMock,
-        model: Union[dai.NNModelDescription, dai.NNArchive],
+        model: dai.NNModelDescription | dai.NNArchive,
         fps: float,
     ):
         self._nn_archive = model

--- a/tests/utils/nodes/mocks/output.py
+++ b/tests/utils/nodes/mocks/output.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 import depthai as dai
 
 from .queue import OutputQueueMock
@@ -9,13 +7,13 @@ class OutputMock:
     """Output class to simulate the depthai output node."""
 
     def __init__(self):
-        self._datatypes: List[Tuple[dai.DatatypeEnum, bool]] = []
-        self._queues: List[OutputQueueMock] = []
+        self._datatypes: list[tuple[dai.DatatypeEnum, bool]] = []
+        self._queues: list[OutputQueueMock] = []
 
-    def setPossibleDatatypes(self, datatypes: List[Tuple[dai.DatatypeEnum, bool]]):
+    def setPossibleDatatypes(self, datatypes: list[tuple[dai.DatatypeEnum, bool]]):
         self._datatypes = datatypes
 
-    def getPossibleDatatypes(self) -> List[Tuple[dai.DatatypeEnum, bool]]:
+    def getPossibleDatatypes(self) -> list[tuple[dai.DatatypeEnum, bool]]:
         return self._datatypes
 
     def send(self, message):

--- a/tests/utils/nodes/mocks/pipeline.py
+++ b/tests/utils/nodes/mocks/pipeline.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple, Type
-
 import depthai as dai
 
 from .device import DeviceMock
@@ -30,7 +28,7 @@ class PipelineMock:
     def remove(self, node):
         self._nodes.remove(node)
 
-    def create(self, node_type: Type[ThreadedHostNodeMock]):
+    def create(self, node_type: type[ThreadedHostNodeMock]):
         from depthai_nodes.node.parsers.base_parser import BaseParser
 
         if issubclass(node_type, BaseParser):
@@ -67,7 +65,7 @@ class PipelineMock:
                     return self._input
 
                 def createOutput(
-                    self, possibleDatatypes: List[Tuple[dai.DatatypeEnum, bool]] = None
+                    self, possibleDatatypes: list[tuple[dai.DatatypeEnum, bool]] = None
                 ):
                     self._out = OutputMock()
                     return self._out
@@ -148,7 +146,7 @@ class PipelineMock:
                     self._is_running = is_running
 
                 def createOutput(
-                    self, possibleDatatypes: List[Tuple[dai.DatatypeEnum, bool]] = None
+                    self, possibleDatatypes: list[tuple[dai.DatatypeEnum, bool]] = None
                 ):
                     self._out = OutputMock()
                     return self._out


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Since the package is now at Python3.10 we can remove the old type annotations.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME: Codex 

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES
