### PR TITLE
Fix for full background SegmentationMask

### DIFF
--- a/depthai_nodes/message/segmentation.py
+++ b/depthai_nodes/message/segmentation.py
@@ -115,13 +115,19 @@ class SegmentationMask(dai.Buffer):
     def getVisualizationMessage(self) -> dai.ImgFrame:
         """Returns the default visualization message for segmentation masks."""
         img_frame = dai.ImgFrame()
+        img_frame.setTimestamp(self.getTimestamp())
+        img_frame.setTimestampDevice(self.getTimestampDevice())
+        img_frame.setSequenceNum(self.getSequenceNum())
+        if self.transformation is not None:
+            img_frame.setTransformation(self.transformation)
         mask = self._mask.copy()
 
         unique_values = np.unique(mask[mask >= 0])
         scaled_mask = np.zeros_like(mask, dtype=np.uint8)
 
         if unique_values.size == 0:
-            return img_frame.setCvFrame(scaled_mask, dai.ImgFrame.Type.BGR888i)
+            empty_bgr_mask = cv2.cvtColor(scaled_mask, cv2.COLOR_GRAY2BGR)
+            return img_frame.setCvFrame(empty_bgr_mask, dai.ImgFrame.Type.BGR888i)
 
         min_val, max_val = unique_values.min(), unique_values.max()
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- If `SegmentationMask` was empty (contained only background) then we previously created 1 channel image but assigned it BGR888i type which requires 3 channels. Now we convert the empty mask to 3 channel array first.
- New `ImgFrame` for visualization now containes metadata from the source `ImgFrame`

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved segmentation mask visualization by properly handling empty masks and ensuring timestamps and metadata are correctly preserved in visualization frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->