### PR TITLE
Add RF-DETR instance segmentation parsing

### DIFF
--- a/depthai_nodes/node/parsers/rf_detr.py
+++ b/depthai_nodes/node/parsers/rf_detr.py
@@ -1,13 +1,15 @@
 from typing import Any
 
-import cv2
 import depthai as dai
 import numpy as np
 
 from depthai_nodes.message.creators import create_detection_message
 from depthai_nodes.node.parsers.base_parser import BaseParser
-from depthai_nodes.node.parsers.utils import xyxy_to_xywh
-from depthai_nodes.node.parsers.utils.masks_utils import crop_mask
+from depthai_nodes.node.parsers.utils import sigmoid, xyxy_to_xywh
+from depthai_nodes.node.parsers.utils.bbox_format_converters import xywh_to_xyxy
+from depthai_nodes.node.parsers.utils.masks_utils import (
+    process_single_mask_rfdetr,
+)
 
 
 class RFDETRParser(BaseParser):
@@ -71,7 +73,7 @@ class RFDETRParser(BaseParser):
         self.output_layer_names: list[str] = []
         self.input_shape: tuple[int, int] | None = None
         self._logger.debug(
-            f"RFDETRParser initialized with conf_threshold={conf_threshold}, max_det={max_det}"
+            f"RFDETRParser initialized with conf_threshold={conf_threshold}, max_det={max_det}, mask_conf={mask_conf}"
         )
 
     @property
@@ -122,10 +124,10 @@ class RFDETRParser(BaseParser):
         self._logger.debug(f"Label names updated to: {label_names}")
 
     def setMaskConfidence(self, mask_conf: float) -> None:
-        """Set mask confidence threshold.
+        """Sets the mask confidence threshold.
 
-        RF-DETR Seg outputs mask logits. The parser applies sigmoid to the mask logits,
-        so this value is interpreted as a normal probability threshold.
+        @param mask_conf: The mask confidence threshold.
+        @type mask_conf: float
         """
         if not isinstance(mask_conf, float):
             raise ValueError("Mask confidence threshold must be a float.")
@@ -190,80 +192,6 @@ class RFDETRParser(BaseParser):
         )
         return self
 
-    @staticmethod
-    def _sigmoid(x: np.ndarray) -> np.ndarray:
-        """Apply sigmoid activation function.
-
-        @param x: Input array.
-        @type x: np.ndarray
-        @return: Sigmoid of input.
-        @rtype: np.ndarray
-        """
-        x = np.asarray(x, dtype=np.float32)
-        result = np.empty_like(x, dtype=np.float32)
-
-        positive_mask = x >= 0
-        result[positive_mask] = 1.0 / (1.0 + np.exp(-x[positive_mask]))
-
-        exp_x = np.exp(x[~positive_mask])
-        result[~positive_mask] = exp_x / (1.0 + exp_x)
-
-        return result
-
-    @staticmethod
-    def _box_cxcywh_to_xyxy(boxes: np.ndarray) -> np.ndarray:
-        """Convert boxes from (cx, cy, w, h) format to (xmin, ymin, xmax, ymax) format.
-
-        Boxes are expected to be in normalized coordinates [0, 1].
-
-        @param boxes: Boxes in cxcywh format, shape (..., 4)
-        @type boxes: np.ndarray
-        @return: Boxes in xyxy format, shape (..., 4)
-        @rtype: np.ndarray
-        """
-        cx, cy, w, h = boxes[..., 0], boxes[..., 1], boxes[..., 2], boxes[..., 3]
-        xmin = cx - w / 2
-        ymin = cy - h / 2
-        xmax = cx + w / 2
-        ymax = cy + h / 2
-        return np.stack([xmin, ymin, xmax, ymax], axis=-1)
-
-    def _process_mask(
-        self,
-        mask_logits: np.ndarray,
-        bbox: np.ndarray,
-        input_shape: tuple[int, int],
-    ) -> np.ndarray:
-        """Process a single RF-DETR Seg mask.
-
-        @param mask_logits: Mask logits in [H, W] format.
-        @type mask_logits: np.ndarray
-        @param bbox: Bounding box in normalized cxcywh format.
-        @type bbox: np.ndarray
-        @param input_shape: Target input shape in (height, width) format.
-        @type input_shape: tuple[int, int]
-        @return: Binary mask resized to input shape.
-        @rtype: np.ndarray
-        """
-
-        if mask_logits.ndim != 2:
-            raise ValueError(
-                f"Expected mask logits of shape (H, W), got {mask_logits.shape}."
-            )
-
-        mask_h, mask_w = mask_logits.shape
-
-        scaled_bbox = bbox * np.array([mask_w, mask_h, mask_w, mask_h])
-        mask = self._sigmoid(mask_logits)
-        mask = crop_mask(mask, scaled_bbox)
-        mask = (mask > self.mask_conf).astype(np.uint8)
-
-        return cv2.resize(
-            mask,
-            (input_shape[1], input_shape[0]),
-            interpolation=cv2.INTER_NEAREST,
-        )
-
     def run(self):
         self._logger.debug("RFDETRParser run started")
 
@@ -299,7 +227,7 @@ class RFDETRParser(BaseParser):
                     np.float32
                 )
 
-            prob = self._sigmoid(logits_tensor)
+            prob = sigmoid(logits_tensor)
 
             scores = np.max(prob, axis=2).squeeze()  # (num_queries,)
             labels = np.argmax(prob, axis=2).squeeze()  # (num_queries,)
@@ -336,7 +264,7 @@ class RFDETRParser(BaseParser):
                 masks = masks_tensor.squeeze()[sorted_idx][:effective_max_det]
 
             # Convert boxes from cxcywh (normalized) to xyxy (normalized)
-            boxes = np.clip(self._box_cxcywh_to_xyxy(boxes_cxcywh), 0, 1)
+            boxes = np.clip(xywh_to_xyxy(boxes_cxcywh), 0, 1)
 
             # Filter detections by confidence threshold
             confidence_mask = scores > self.conf_threshold
@@ -360,10 +288,11 @@ class RFDETRParser(BaseParser):
                 final_mask = np.full(self.input_shape, 255, dtype=np.uint8)
 
                 for i, (mask_logits, bbox) in enumerate(zip(masks, boxes_cxcywh)):
-                    resized_mask = self._process_mask(
-                        mask_logits,
-                        bbox,
-                        self.input_shape,
+                    resized_mask = process_single_mask_rfdetr(
+                        mask_logits=mask_logits,
+                        mask_conf=self.mask_conf,
+                        bbox=bbox,
+                        input_shape=self.input_shape,
                     )
                     final_mask[resized_mask > 0] = i
 

--- a/depthai_nodes/node/parsers/rf_detr.py
+++ b/depthai_nodes/node/parsers/rf_detr.py
@@ -124,9 +124,8 @@ class RFDETRParser(BaseParser):
     def setMaskConfidence(self, mask_conf: float) -> None:
         """Set mask confidence threshold.
 
-        RF-DETR Seg outputs mask logits. The parser applies sigmoid to the
-        mask logits, so this value is interpreted as a normal probability
-        threshold.
+        RF-DETR Seg outputs mask logits. The parser applies sigmoid to the mask logits,
+        so this value is interpreted as a normal probability threshold.
         """
         if not isinstance(mask_conf, float):
             raise ValueError("Mask confidence threshold must be a float.")

--- a/depthai_nodes/node/parsers/rf_detr.py
+++ b/depthai_nodes/node/parsers/rf_detr.py
@@ -294,7 +294,8 @@ class RFDETRParser(BaseParser):
                         bbox=bbox,
                         input_shape=self.input_shape,
                     )
-                    final_mask[resized_mask > 0] = i
+                    foreground = resized_mask > 0
+                    final_mask[(final_mask == 255) & foreground] = i
 
             boxes = xyxy_to_xywh(boxes)
 

--- a/depthai_nodes/node/parsers/rf_detr.py
+++ b/depthai_nodes/node/parsers/rf_detr.py
@@ -1,11 +1,13 @@
 from typing import Any
 
+import cv2
 import depthai as dai
 import numpy as np
 
 from depthai_nodes.message.creators import create_detection_message
 from depthai_nodes.node.parsers.base_parser import BaseParser
 from depthai_nodes.node.parsers.utils import xyxy_to_xywh
+from depthai_nodes.node.parsers.utils.masks_utils import crop_mask
 
 
 class RFDETRParser(BaseParser):
@@ -23,6 +25,8 @@ class RFDETRParser(BaseParser):
         Maximum number of detections to keep.
     label_names : list[str] | None
         List of label names for detected objects.
+    mask_conf : float
+        Confidence threshold for binarizing instance segmentation masks.
     output_layer_names : list[str]
         Names of the output layers (boxes, logits, and optionally masks).
 
@@ -38,11 +42,15 @@ class RFDETRParser(BaseParser):
     RF-DETR: https://github.com/roboflow/rf-detr
     """
 
+    _DET_MODE = 0
+    _SEG_MODE = 1
+
     def __init__(
         self,
         conf_threshold: float = 0.5,
         max_det: int = 300,
         label_names: list[str] | None = None,
+        mask_conf: float = 0.5,
     ) -> None:
         """Initializes the parser node.
 
@@ -52,12 +60,16 @@ class RFDETRParser(BaseParser):
         @type max_det: int
         @param label_names: List of label names for detected objects.
         @type label_names: list[str] | None
+        @param mask_conf: Mask confidence threshold for instance segmentation masks.
+        @type mask_conf: float
         """
         super().__init__()
         self.conf_threshold = conf_threshold
         self.max_det = max_det
         self.label_names = label_names
+        self.mask_conf = mask_conf
         self.output_layer_names: list[str] = []
+        self.input_shape: tuple[int, int] | None = None
         self._logger.debug(
             f"RFDETRParser initialized with conf_threshold={conf_threshold}, max_det={max_det}"
         )
@@ -109,6 +121,22 @@ class RFDETRParser(BaseParser):
         self.label_names = label_names
         self._logger.debug(f"Label names updated to: {label_names}")
 
+    def setMaskConfidence(self, mask_conf: float) -> None:
+        """Set mask confidence threshold.
+
+        RF-DETR Seg outputs mask logits. The parser applies sigmoid to the
+        mask logits, so this value is interpreted as a normal probability
+        threshold.
+        """
+        if not isinstance(mask_conf, float):
+            raise ValueError("Mask confidence threshold must be a float.")
+
+        if mask_conf < 0 or mask_conf > 1:
+            raise ValueError("Mask confidence threshold must be between 0 and 1.")
+
+        self.mask_conf = mask_conf
+        self._logger.debug(f"Mask confidence threshold updated to {mask_conf}")
+
     def setOutputLayerNames(self, output_layer_names: list[str]) -> None:
         """Sets the output layer names for the parser.
 
@@ -133,10 +161,33 @@ class RFDETRParser(BaseParser):
         self.conf_threshold = head_config.get("conf_threshold", self.conf_threshold)
         self.max_det = head_config.get("max_det", self.max_det)
         self.label_names = head_config.get("classes", self.label_names)
+        self.mask_conf = head_config.get("mask_conf", self.mask_conf)
         self.output_layer_names = head_config.get("outputs", self.output_layer_names)
 
+        inputs = head_config.get("model_inputs", [])
+        if inputs:
+            input_shape = inputs[0].get("shape")
+            input_layout = inputs[0].get("layout")
+
+            if input_shape and input_layout:
+                if input_layout == "NCHW":
+                    self.input_shape = (input_shape[2], input_shape[3])
+                elif input_layout == "NHWC":
+                    self.input_shape = (input_shape[1], input_shape[2])
+                else:
+                    raise ValueError(f"Unsupported input layout: {input_layout}")
+
+        if self.output_layer_names and len(self.output_layer_names) not in (2, 3):
+            raise ValueError(
+                f"RFDETRParser expects 2 outputs for detection or 3 outputs for "
+                f"segmentation, got {len(self.output_layer_names)} outputs: "
+                f"{self.output_layer_names}."
+            )
+
         self._logger.debug(
-            f"RFDETRParser built with conf_threshold={self.conf_threshold}, max_det={self.max_det}"
+            f"RFDETRParser built with conf_threshold={self.conf_threshold}, "
+            f"max_det={self.max_det}, mask_conf={self.mask_conf}, "
+            f"input_shape={self.input_shape}, outputs={self.output_layer_names}"
         )
         return self
 
@@ -149,7 +200,16 @@ class RFDETRParser(BaseParser):
         @return: Sigmoid of input.
         @rtype: np.ndarray
         """
-        return 1 / (1 + np.exp(-x))
+        x = np.asarray(x, dtype=np.float32)
+        result = np.empty_like(x, dtype=np.float32)
+
+        positive_mask = x >= 0
+        result[positive_mask] = 1.0 / (1.0 + np.exp(-x[positive_mask]))
+
+        exp_x = np.exp(x[~positive_mask])
+        result[~positive_mask] = exp_x / (1.0 + exp_x)
+
+        return result
 
     @staticmethod
     def _box_cxcywh_to_xyxy(boxes: np.ndarray) -> np.ndarray:
@@ -169,6 +229,42 @@ class RFDETRParser(BaseParser):
         ymax = cy + h / 2
         return np.stack([xmin, ymin, xmax, ymax], axis=-1)
 
+    def _process_mask(
+        self,
+        mask_logits: np.ndarray,
+        bbox: np.ndarray,
+        input_shape: tuple[int, int],
+    ) -> np.ndarray:
+        """Process a single RF-DETR Seg mask.
+
+        @param mask_logits: Mask logits in [H, W] format.
+        @type mask_logits: np.ndarray
+        @param bbox: Bounding box in normalized cxcywh format.
+        @type bbox: np.ndarray
+        @param input_shape: Target input shape in (height, width) format.
+        @type input_shape: tuple[int, int]
+        @return: Binary mask resized to input shape.
+        @rtype: np.ndarray
+        """
+
+        if mask_logits.ndim != 2:
+            raise ValueError(
+                f"Expected mask logits of shape (H, W), got {mask_logits.shape}."
+            )
+
+        mask_h, mask_w = mask_logits.shape
+
+        scaled_bbox = bbox * np.array([mask_w, mask_h, mask_w, mask_h])
+        mask = self._sigmoid(mask_logits)
+        mask = crop_mask(mask, scaled_bbox)
+        mask = (mask > self.mask_conf).astype(np.uint8)
+
+        return cv2.resize(
+            mask,
+            (input_shape[1], input_shape[0]),
+            interpolation=cv2.INTER_NEAREST,
+        )
+
     def run(self):
         self._logger.debug("RFDETRParser run started")
 
@@ -184,7 +280,8 @@ class RFDETRParser(BaseParser):
 
             if len(layer_names) < 2 or len(layer_names) > 3:
                 raise ValueError(
-                    f"Expected 2 or 3 output layers (boxes, logits, optional masks), got {len(layer_names)} layers."
+                    "Expected 2 or 3 output layers "
+                    f"(boxes, logits, optional masks), got {len(layer_names)} layers."
                 )
 
             # outputs[0]: boxes in cxcywh format (normalized coordinates [0, 1])
@@ -211,22 +308,43 @@ class RFDETRParser(BaseParser):
             sorted_idx = np.argsort(scores)[::-1]
             scores = scores[sorted_idx][: self.max_det]
             labels = labels[sorted_idx][: self.max_det]
-            boxes = boxes_tensor.squeeze()[sorted_idx][: self.max_det]
+            boxes_cxcywh = boxes_tensor.squeeze()[sorted_idx][: self.max_det]
 
+            masks = None
             if masks_tensor is not None:
                 masks = masks_tensor.squeeze()[sorted_idx][: self.max_det]
 
             # Convert boxes from cxcywh (normalized) to xyxy (normalized)
-            boxes = np.clip(self._box_cxcywh_to_xyxy(boxes), 0, 1)
+            boxes = np.clip(self._box_cxcywh_to_xyxy(boxes_cxcywh), 0, 1)
 
             # Filter detections by confidence threshold
             confidence_mask = scores > self.conf_threshold
             scores = scores[confidence_mask]
             labels = labels[confidence_mask]
             boxes = boxes[confidence_mask]
+            boxes_cxcywh = boxes_cxcywh[confidence_mask]
 
-            if masks_tensor is not None:
+            if masks is not None:
                 masks = masks[confidence_mask]
+
+            final_mask = None
+            mode = self._SEG_MODE if masks is not None else self._DET_MODE
+
+            if mode == self._SEG_MODE:
+                if self.input_shape is None:
+                    raise ValueError(
+                        "RFDETRParser segmentation mode requires model input shape."
+                    )
+
+                final_mask = np.full(self.input_shape, 255, dtype=np.uint8)
+
+                for i, (mask_logits, bbox) in enumerate(zip(masks, boxes_cxcywh)):
+                    resized_mask = self._process_mask(
+                        mask_logits,
+                        bbox,
+                        self.input_shape,
+                    )
+                    final_mask[resized_mask > 0] = i
 
             boxes = xyxy_to_xywh(boxes)
 
@@ -247,6 +365,7 @@ class RFDETRParser(BaseParser):
                 scores=scores,
                 labels=labels.astype(int),
                 label_names=label_names_list,
+                masks=final_mask,
             )
 
             # Set message metadata

--- a/depthai_nodes/node/parsers/rf_detr.py
+++ b/depthai_nodes/node/parsers/rf_detr.py
@@ -305,13 +305,35 @@ class RFDETRParser(BaseParser):
             labels = np.argmax(prob, axis=2).squeeze()  # (num_queries,)
 
             sorted_idx = np.argsort(scores)[::-1]
-            scores = scores[sorted_idx][: self.max_det]
-            labels = labels[sorted_idx][: self.max_det]
-            boxes_cxcywh = boxes_tensor.squeeze()[sorted_idx][: self.max_det]
+
+            effective_max_det = self.max_det
+            if masks_tensor is not None:
+                # SegmentationMask is uint8 and reserves 255 for background,
+                # so valid instance IDs are 0..254.
+                max_segmentation_instances = 255
+
+                num_valid_instances = int(
+                    np.count_nonzero(
+                        scores[sorted_idx][: self.max_det] > self.conf_threshold
+                    )
+                )
+                if num_valid_instances > max_segmentation_instances:
+                    self._logger.warning(
+                        "RFDETRParser can encode at most 255 instances in "
+                        "SegmentationMask; ignoring "
+                        f"{num_valid_instances - max_segmentation_instances} "
+                        "lowest-scoring instances."
+                    )
+
+                effective_max_det = min(effective_max_det, max_segmentation_instances)
+
+            scores = scores[sorted_idx][:effective_max_det]
+            labels = labels[sorted_idx][:effective_max_det]
+            boxes_cxcywh = boxes_tensor.squeeze()[sorted_idx][:effective_max_det]
 
             masks = None
             if masks_tensor is not None:
-                masks = masks_tensor.squeeze()[sorted_idx][: self.max_det]
+                masks = masks_tensor.squeeze()[sorted_idx][:effective_max_det]
 
             # Convert boxes from cxcywh (normalized) to xyxy (normalized)
             boxes = np.clip(self._box_cxcywh_to_xyxy(boxes_cxcywh), 0, 1)

--- a/depthai_nodes/node/parsers/utils/activations.py
+++ b/depthai_nodes/node/parsers/utils/activations.py
@@ -32,4 +32,15 @@ def sigmoid(x: np.ndarray) -> np.ndarray:
     @return: A result tensor after applying a sigmoid function on the given input.
     @rtype: np.ndarray
     """
-    return 1 / (1 + np.exp(-x))
+    x = np.asarray(x, dtype=np.float32)
+    result = np.empty_like(x)
+
+    positive = x >= 0
+    negative = ~positive
+
+    result[positive] = 1 / (1 + np.exp(-x[positive]))
+
+    exp_x = np.exp(x[negative])
+    result[negative] = exp_x / (1 + exp_x)
+
+    return result

--- a/depthai_nodes/node/parsers/utils/masks_utils.py
+++ b/depthai_nodes/node/parsers/utils/masks_utils.py
@@ -1,3 +1,4 @@
+import cv2
 import depthai as dai
 import numpy as np
 
@@ -77,3 +78,42 @@ def get_segmentation_outputs(
     ).astype(np.float32)
     protos_len = protos_output.shape[1]
     return masks_outputs_values, protos_output, protos_len
+
+
+def process_single_mask_rfdetr(
+    mask_logits: np.ndarray,
+    mask_conf: float,
+    bbox: np.ndarray,
+    input_shape: tuple[int, int],
+) -> np.ndarray:
+    """Process a single RF-DETR instance segmentation mask.
+
+    @param mask_logits: Mask logits for a single detection.
+    @type mask_logits: np.ndarray
+    @param mask_conf: Mask confidence threshold.
+    @type mask_conf: float
+    @param bbox: A numpy array of bbox coordinates in (x_center, y_center, width,
+        height) normalized format.
+    @type bbox: np.ndarray
+    @param input_shape: Target output mask shape as (height, width).
+    @type input_shape: tuple[int, int]
+    @return: Processed mask resized to the model input shape.
+    @rtype: np.ndarray
+    """
+    if mask_logits.ndim != 2:
+        raise ValueError(
+            f"RF-DETR mask logits should have shape (H, W), got {mask_logits.shape}."
+        )
+
+    mask_h, mask_w = mask_logits.shape
+    scaled_bbox = bbox * np.array([mask_w, mask_h, mask_w, mask_h])
+
+    mask = sigmoid(mask_logits)
+    mask = crop_mask(mask, scaled_bbox)
+    mask = (mask > mask_conf).astype(np.uint8)
+
+    return cv2.resize(
+        mask,
+        (input_shape[1], input_shape[0]),
+        interpolation=cv2.INTER_NEAREST,
+    )


### PR DESCRIPTION
## Purpose

Add RF-DETR instance segmentation support to `RFDETRParser`.

RF-DETR Seg models expose an additional `masks` output next to the existing `dets` and `labels` outputs. Before this change, the parser only produced detection boxes/classes and ignored segmentation masks, so RF-DETR Seg archives could run but would not emit an instance segmentation mask through `create_detection_message`.

## Specification

This PR extends `RFDETRParser` to support both RF-DETR detection and RF-DETR instance segmentation outputs.

Main changes:

* Supports either 2 outputs (`dets`, `labels`) or 3 outputs (`dets`, `labels`, `masks`).
* Adds `mask_conf` parser configuration for binarizing instance masks.
* Reads the model input shape from the NNArchive config and uses it as the final segmentation mask shape.
* Adds RF-DETR Seg mask post-processing:

  * sigmoid
  * crop mask to detection bbox
  * threshold using `mask_conf`
  * resize with `cv2.INTER_NEAREST`
  * compose final `uint8` instance mask with `255` as background
* Passes the composed mask through `create_detection_message(..., masks=final_mask)`.
* Keeps the existing detection-only path backward compatible.

## Dependencies & Potential Impact

This change adds an OpenCV import to `RFDETRParser` for resizing instance masks with `cv2.INTER_NEAREST`.

Potential impact is limited to RF-DETR parsing. Detection-only RF-DETR models should continue to work as before because segmentation logic is only used when the `masks` output is present.

## Deployment Plan

No special deployment steps required.

This should be released as part of the next `depthai-nodes` release. Rollback would be reverting this parser change.

## Testing & Validation

Local checks:

* `python -m py_compile depthai_nodes/node/parsers/rf_detr.py`
* `git diff --check`
* `python -m ruff check depthai_nodes/node/parsers/rf_detr.py`
* `pytest tests/unittests/test_creators/test_detections.py -q`

  * `27 passed`
* `pytest tests/unittests/test_creators/test_segmentation.py -q`

  * `5 passed`
* `pytest tests/unittests/test_creators -q`

  * `125 passed`

Additional smoke tests:

* RF-DETR Seg mask post-processing smoke test.
* RF-DETRParser build/config smoke test for 3-output segmentation config.

RVC4 validation:

* Validated RF-DETR Seg Nano archive on NUC with an RVC4 device and `ParsingNeuralNetwork`.
* Confirmed detections and `cvSegmentationMask` are present in output messages.
* Compared RVC4 outputs against PyTorch `RFDETRSegNano` on the same RVC4 passthrough clean frames.
* Image-level validation over 10 COCO source images / 40 sampled frames:

  * matched detections: `93.7%`
  * mean box IoU: `0.967`
  * mean mask IoU: `0.795`
  * masks present in all sampled frames

## AI Usage

Assisted-by: ChatGPT

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RF-DETR parser now supports instance segmentation outputs, including per-instance mask generation.
  * Added a configurable mask confidence threshold (`mask_conf`) and a `setMaskConfidence()` control for fine-tuning segmentation results.

* **Improvements**
  * Masks are resized to match the model’s expected input resolution for better alignment.
  * Enhanced numerical stability in sigmoid/mask probability computation.
  * Improved segmentation post-processing and confidence filtering for consistent box/label/mask selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->