### PR TITLE
Use YOLO metadata strides in parser

### DIFF
--- a/depthai_nodes/node/parser_generator.py
+++ b/depthai_nodes/node/parser_generator.py
@@ -4,7 +4,7 @@ from depthai_nodes.logging import get_logger
 from depthai_nodes.node.parsers import *
 from depthai_nodes.node.parsers.base_parser import BaseParser
 from depthai_nodes.node.parsers.utils import decode_head
-from depthai_nodes.node.parsers.utils.yolo import YOLOSubtype
+from depthai_nodes.node.parsers.utils.yolo import YOLOSubtype, resolve_yolo_strides
 
 
 class ParserGenerator(dai.node.ThreadedHostNode):
@@ -75,6 +75,8 @@ class ParserGenerator(dai.node.ThreadedHostNode):
             if parser_name in self.DEVICE_PARSERS:
                 if hostOnly:
                     parser_name = self._getHostParserName(parser_name)
+                elif parser_name == "YOLO" and self._has_non_default_yolo_strides(head):
+                    parser_name = self._getHostParserName(parser_name)
                 else:
                     parser = pipeline.create(dai.node.DetectionParser)
                     parser.setNNArchive(nnArchive)
@@ -84,7 +86,10 @@ class ParserGenerator(dai.node.ThreadedHostNode):
                 yolo_subtype_str = head.metadata.subtype
                 if yolo_subtype_str is not None:
                     yolo_subtype = YOLOSubtype(yolo_subtype_str.lower())
-                    if yolo_subtype in self.DAI_SUPPORTED_YOLO_SUBTYPES:
+                    if (
+                        yolo_subtype in self.DAI_SUPPORTED_YOLO_SUBTYPES
+                        and not self._has_non_default_yolo_strides(head, yolo_subtype)
+                    ):
                         parser = pipeline.create(dai.node.DetectionParser)
                         parser.setNNArchive(nnArchive)
                         if head.metadata.maskOutputs is not None and is_rvc2_device:
@@ -113,6 +118,50 @@ class ParserGenerator(dai.node.ThreadedHostNode):
             parsers[index] = pipeline.create(parser).build(head_config)
 
         return parsers
+
+    @staticmethod
+    def _has_non_default_yolo_strides(
+        head,
+        subtype: YOLOSubtype | None = None,
+    ) -> bool:
+        head_config = decode_head(head)
+        strides = head_config.get("strides")
+        if strides is None:
+            return False
+
+        metadata = getattr(head, "metadata", None)
+
+        if subtype is None:
+            yolo_subtype_str = getattr(metadata, "subtype", None)
+            if yolo_subtype_str is None:
+                subtype = YOLOSubtype.DEFAULT
+            else:
+                try:
+                    subtype = YOLOSubtype(yolo_subtype_str.lower())
+                except ValueError:
+                    return True
+
+        yolo_outputs = getattr(metadata, "yoloOutputs", None)
+        outputs = (
+            yolo_outputs if yolo_outputs is not None else head_config.get("outputs")
+        )
+        num_outputs = len(outputs or [])
+
+        try:
+            resolved_strides = resolve_yolo_strides(
+                strides,
+                subtype,
+                num_outputs,
+            )
+        except ValueError:
+            return True
+
+        default_strides = resolve_yolo_strides(
+            None,
+            subtype,
+            num_outputs,
+        )
+        return resolved_strides != default_strides
 
     def run(self):
         """No-op required by ``dai.node.ThreadedHostNode``."""

--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -34,6 +34,52 @@ class YOLOSubtype(str, Enum):
     DEFAULT = ""
 
 
+def resolve_yolo_strides(
+    strides: list[int] | tuple[int, ...] | None,
+    subtype: YOLOSubtype,
+    num_outputs: int,
+) -> list[int]:
+    """Resolve YOLO strides from metadata or default fallback.
+
+    @param strides: Optional strides from NNArchive head metadata.
+    @type strides: list[int] | tuple[int, ...] | None
+    @param subtype: YOLO subtype.
+    @type subtype: YOLOSubtype
+    @param num_outputs: Number of YOLO output heads.
+    @type num_outputs: int
+    @return: Resolved YOLO strides.
+    @rtype: list[int]
+    """
+    if strides is None:
+        return (
+            [8, 16, 32]
+            if subtype not in [YOLOSubtype.V3UT, YOLOSubtype.V3T, YOLOSubtype.V4T]
+            else [16, 32]
+        )
+
+    if not isinstance(strides, (list, tuple)):
+        raise ValueError("`strides` must be a list or tuple of positive integers.")
+
+    if not strides:
+        raise ValueError("`strides` must not be empty.")
+
+    resolved_strides = list(strides)
+
+    if not all(type(stride) is int for stride in resolved_strides):
+        raise ValueError("All `strides` values must be integers.")
+
+    if not all(stride > 0 for stride in resolved_strides):
+        raise ValueError("All `strides` values must be positive.")
+
+    if len(resolved_strides) != num_outputs:
+        raise ValueError(
+            "Number of `strides` must match number of YOLO outputs. "
+            f"Got {len(resolved_strides)} strides for {num_outputs} outputs."
+        )
+
+    return resolved_strides
+
+
 def make_grid_numpy(ny: int, nx: int, na: int) -> np.ndarray:
     """Create a grid of shape (1, na, ny, nx, 2)
 
@@ -244,9 +290,9 @@ def parse_yolo_output(
             anchors = anchors.reshape(bs, -1, 1, 1, 2)
         else:
             anchors = np.array(anchors).reshape(bs, -1, 1, 1, 2)
-        assert (
-            anchors.shape[1] == na
-        ), f"Anchor shape mismatch at dimension 1: {anchors.shape[1]} vs {na}"
+        assert anchors.shape[1] == na, (
+            f"Anchor shape mismatch at dimension 1: {anchors.shape[1]} vs {na}"
+        )
 
         if subtype in [YOLOSubtype.V3, YOLOSubtype.V3T]:
             c_xy = out[..., 0:2] + grid

--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -65,7 +65,10 @@ def resolve_yolo_strides(
 
     resolved_strides = list(strides)
 
-    if not all(type(stride) is int for stride in resolved_strides):
+    if not all(
+        isinstance(stride, int) and not isinstance(stride, bool)
+        for stride in resolved_strides
+    ):
         raise ValueError("All `strides` values must be integers.")
 
     if not all(stride > 0 for stride in resolved_strides):
@@ -290,9 +293,9 @@ def parse_yolo_output(
             anchors = anchors.reshape(bs, -1, 1, 1, 2)
         else:
             anchors = np.array(anchors).reshape(bs, -1, 1, 1, 2)
-        assert anchors.shape[1] == na, (
-            f"Anchor shape mismatch at dimension 1: {anchors.shape[1]} vs {na}"
-        )
+        assert (
+            anchors.shape[1] == na
+        ), f"Anchor shape mismatch at dimension 1: {anchors.shape[1]} vs {na}"
 
         if subtype in [YOLOSubtype.V3, YOLOSubtype.V3T]:
             c_xy = out[..., 0:2] + grid

--- a/depthai_nodes/node/parsers/yolo.py
+++ b/depthai_nodes/node/parsers/yolo.py
@@ -19,6 +19,7 @@ from depthai_nodes.node.parsers.utils.yolo import (
     decode_yolo26,
     decode_yolo_output,
     parse_kpts,
+    resolve_yolo_strides,
 )
 
 
@@ -42,6 +43,8 @@ class YOLOExtendedParser(BaseParser):
         Number of keypoints in the model.
     anchors : list[list[list[float]]] | None
         Anchors for the YOLO model (optional).
+    strides : list[int] | tuple[int, ...] | None
+        Strides for the YOLO output heads.
     keypoint_label_names : list[str] | None
         Labels for the keypoints.
     keypoint_edges : list[tuple[int, int]] | None
@@ -111,6 +114,7 @@ class YOLOExtendedParser(BaseParser):
         self.n_keypoints = n_keypoints
         self.max_det = max_det
         self.anchors = anchors
+        self.strides: list[int] | tuple[int, ...] | None = None
         self.keypoint_label_names = keypoint_label_names
         self.keypoint_edges = keypoint_edges
         self.input_shape = None
@@ -122,7 +126,7 @@ class YOLOExtendedParser(BaseParser):
             ) from err
 
         self._logger.debug(
-            f"YOLOExtendedParser initialized with conf_threshold={self.conf_threshold}, n_classes={self.n_classes}, label_names={self.label_names}, iou_threshold={self.iou_threshold}, mask_conf={self.mask_conf}, n_keypoints={self.n_keypoints}, max_det={self.max_det}, anchors={self.anchors}, subtype='{self.subtype}', keypoint_label_names={self.keypoint_label_names}, keypoint_edges={self.keypoint_edges}"
+            f"YOLOExtendedParser initialized with conf_threshold={self.conf_threshold}, n_classes={self.n_classes}, label_names={self.label_names}, iou_threshold={self.iou_threshold}, mask_conf={self.mask_conf}, n_keypoints={self.n_keypoints}, max_det={self.max_det}, anchors={self.anchors}, strides={self.strides}, subtype='{self.subtype}', keypoint_label_names={self.keypoint_label_names}, keypoint_edges={self.keypoint_edges}"
         )
 
     def setOutputLayerNames(self, output_layer_names: list[str]) -> None:
@@ -381,6 +385,7 @@ class YOLOExtendedParser(BaseParser):
         self.iou_threshold = head_config.get("iou_threshold", self.iou_threshold)
         self.mask_conf = head_config.get("mask_conf", self.mask_conf)
         self.anchors = head_config.get("anchors", self.anchors)
+        self.strides = head_config.get("strides", self.strides)
         self.n_keypoints = head_config.get("n_keypoints", self.n_keypoints)
         self.max_det = head_config.get("max_det", self.max_det)
         self.label_names = head_config.get("classes", self.label_names)
@@ -407,7 +412,7 @@ class YOLOExtendedParser(BaseParser):
                 self.n_prototypes = head_config.get("n_prototypes", 32)
 
         self._logger.debug(
-            f"YOLOExtendedParser built with conf_threshold={self.conf_threshold}, n_classes={self.n_classes}, label_names={self.label_names}, iou_threshold={self.iou_threshold}, mask_conf={self.mask_conf}, n_keypoints={self.n_keypoints}, anchors={self.anchors}, subtype='{self.subtype}', keypoint_label_names={self.keypoint_label_names}, keypoint_edges={self.keypoint_edges}"
+            f"YOLOExtendedParser built with conf_threshold={self.conf_threshold}, n_classes={self.n_classes}, label_names={self.label_names}, iou_threshold={self.iou_threshold}, mask_conf={self.mask_conf}, n_keypoints={self.n_keypoints}, anchors={self.anchors}, strides={self.strides}, subtype='{self.subtype}', keypoint_label_names={self.keypoint_label_names}, keypoint_edges={self.keypoint_edges}"
         )
 
         return self
@@ -509,11 +514,10 @@ class YOLOExtendedParser(BaseParser):
                     )
                 input_shape = self.input_shape
             else:
-                strides = (
-                    [8, 16, 32]
-                    if self.subtype
-                    not in [YOLOSubtype.V3UT, YOLOSubtype.V3T, YOLOSubtype.V4T]
-                    else [16, 32]
+                strides = resolve_yolo_strides(
+                    self.strides,
+                    self.subtype,
+                    num_outputs=len(outputs_values),
                 )
                 input_shape = tuple(
                     dim * strides[0] for dim in outputs_values[0].shape[2:4]


### PR DESCRIPTION
## Purpose

Support YOLO-like models with non-default head stride layouts, including `n_heads = 4`.

Previously, `YOLOExtendedParser` used hard-coded fallback strides depending on the YOLO subtype. This meant archives with 4 output heads could be parsed with only the legacy 3-stride fallback, silently ignoring the extra stride scale.

This change lets the parser consume stride metadata exported in NNArchives, while preserving the existing fallback behavior for older archives.

## Specification

* Added metadata-driven stride resolution for `YOLOExtendedParser`.
* The parser now reads `strides` from the NNArchive head metadata when present.
* Legacy fallback behavior is preserved when `strides` is not present:

  * default YOLO fallback: `[8, 16, 32]`
  * tiny YOLO fallback: `[16, 32]`
* Explicit metadata strides are validated:

  * must be a list or tuple
  * must not be empty
  * values must be positive integers
  * number of strides must match the number of YOLO outputs

## Dependencies & Potential Impact

Paired with the `luxonis-train` PR that exports `metadata.strides` for YOLO-like detection heads.

Backward compatibility is preserved for existing NNArchives without stride metadata. Archives that provide invalid explicit stride metadata will now fail fast with a clear error instead of being parsed with an incorrect stride configuration.

## Deployment Plan

No special deployment steps required.

Rollback is straightforward: revert this parser change and the parser will return to the previous hard-coded fallback behavior.

## Testing & Validation

Validated with task-specific NNArchives generated from `luxonis-train` and converted to RVC2 via HubAI.

Cases validated:

* 4 heads: `metadata.strides = [4, 8, 16, 32]`
* 2 heads: `metadata.strides = [16, 32]`
* 3 heads with offset `attach_index`: `metadata.strides = [4, 8, 16]`

Existing `depthai-nodes` E2E validation:

* Ran `tests/end_to_end/test_e2e.py::test_pipelines`
* Used the three generated RVC2 NNArchives above
* Ran on a real RVC2 device
* Result: `3 passed in 44.71s`

Also validated existing YOLO parser coverage:

* YOLO parser/generator/parsing tests passed: `3 passed`

## AI Usage

Assisted-by: ChatGPT

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable YOLO head strides via model configuration, with shared stride resolution during decoding.
  * When strides differ from expected defaults, YOLO heads are routed to the appropriate parsing path for correct results.

* **Bug Fixes**
  * Added stricter stride validation (type, non-empty, positive integers, and expected count match).
  * Improved debug output to include the resolved strides for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->