### PR TITLE
Fix/ImgDetectionFilter segmentation mask reindexing

### DIFF
--- a/depthai_nodes/node/img_detections_filter.py
+++ b/depthai_nodes/node/img_detections_filter.py
@@ -185,18 +185,19 @@ class ImgDetectionsFilter(BaseHostNode):
         msg_new = copy_message(msg)
         assert isinstance(msg_new, (dai.ImgDetections, dai.SpatialImgDetections))
 
-        filtered_detections, filtered_out_ixs = self._filter_step(
-            detections=msg.detections
-        )
+        indexed_detections = list(enumerate(msg.detections))
+        filtered_detections = self._filter_step(detections=indexed_detections)
         nms_detections_out = self._nms_step(detections=filtered_detections)
         sorted_detections = self._sorting_step(detections=nms_detections_out)
         # Take first K step
-        msg_new.detections = sorted_detections[: self._cfg.first_k]
+        final_detections = sorted_detections[: self._cfg.first_k]
+        msg_new.detections = [detection for _, detection in final_detections]
 
-        # Remove classes of filtered out detections
+        # Reindex segmentation mask instance IDs to match final detections.
         if isinstance(msg, dai.ImgDetections):
             msg_new = self._update_segmentation_mask(
-                msg_new=msg_new, filtered_out_ixs=filtered_out_ixs
+                msg_new=msg_new,
+                kept_original_indices=[ix for ix, _ in final_detections],
             )
 
         self.out.send(msg_new)
@@ -210,60 +211,64 @@ class ImgDetectionsFilter(BaseHostNode):
 
     def _filter_step(
         self,
-        detections: list[dai.ImgDetection | dai.SpatialImgDetection],
-    ) -> tuple[list[dai.ImgDetection | dai.SpatialImgDetection], list[int]]:
+        detections: list[tuple[int, dai.ImgDetection | dai.SpatialImgDetection]],
+    ) -> list[tuple[int, dai.ImgDetection | dai.SpatialImgDetection]]:
         filtered_detections = []
-        filtered_out_ixs: list[int] = []
-        for ix, detection in enumerate(detections):
+        for ix, detection in detections:
             if self._cfg.labels_to_keep is not None:
                 if detection.label not in self._cfg.labels_to_keep:
-                    filtered_out_ixs.append(ix)
                     continue
 
             elif self._cfg.labels_to_reject is not None:
                 if detection.label in self._cfg.labels_to_reject:
-                    filtered_out_ixs.append(ix)
                     continue
 
             if self._cfg.min_confidence is not None:
                 if detection.confidence < self._cfg.min_confidence:
-                    filtered_out_ixs.append(ix)
                     continue
 
             if self._cfg.min_area is not None:
                 area = compute_area(detection)
                 if area < self._cfg.min_area:
-                    filtered_out_ixs.append(ix)
                     continue
 
-            filtered_detections.append(detection)
-        return filtered_detections, filtered_out_ixs
+            filtered_detections.append((ix, detection))
+        return filtered_detections
 
     def _nms_step(
-        self, detections: list[dai.ImgDetection | dai.SpatialImgDetection]
-    ) -> list[dai.ImgDetection | dai.SpatialImgDetection]:
+        self, detections: list[tuple[int, dai.ImgDetection | dai.SpatialImgDetection]]
+    ) -> list[tuple[int, dai.ImgDetection | dai.SpatialImgDetection]]:
         if self._cfg.nms_disabled:
             return detections
-        return nms_detections(
-            detections=detections,
+        detections_only = [detection for _, detection in detections]
+        kept_detections = nms_detections(
+            detections=detections_only,
             conf_thresh=self._cfg.nms_conf_thresh,
             iou_thresh=self._cfg.nms_iou_thresh,
         )
+        by_id = {id(detection): (ix, detection) for ix, detection in detections}
+        return [by_id[id(detection)] for detection in kept_detections]
 
     def _sorting_step(
-        self, detections: list[dai.ImgDetection | dai.SpatialImgDetection]
-    ) -> list[dai.ImgDetection | dai.SpatialImgDetection]:
+        self, detections: list[tuple[int, dai.ImgDetection | dai.SpatialImgDetection]]
+    ) -> list[tuple[int, dai.ImgDetection | dai.SpatialImgDetection]]:
         if not self._cfg.sort_disabled:
             sorted_detections = sorted(
-                detections, key=lambda x: x.confidence, reverse=self._cfg.sort_desc
+                detections,
+                key=lambda indexed_detection: indexed_detection[1].confidence,
+                reverse=self._cfg.sort_desc,
             )
             return sorted_detections
         return detections
 
     @staticmethod
-    def _update_segmentation_mask(msg_new, filtered_out_ixs: list[int]):
+    def _update_segmentation_mask(msg_new, kept_original_indices: list[int]):
         mask = msg_new.getCvSegmentationMask()
         if mask is not None:
-            mask = np.where(np.isin(mask, filtered_out_ixs), 255, mask)
+            lookup_table = np.full(256, 255, dtype=np.uint8)
+            for new_ix, original_ix in enumerate(kept_original_indices):
+                if original_ix < 255 and new_ix < 255:
+                    lookup_table[original_ix] = new_ix
+            mask = lookup_table[mask].astype(np.uint8, copy=False)
             msg_new.setCvSegmentationMask(mask)
         return msg_new

--- a/tests/unittests/test_nodes/test_host_nodes/test_img_detections_filter_node.py
+++ b/tests/unittests/test_nodes/test_host_nodes/test_img_detections_filter_node.py
@@ -92,8 +92,8 @@ def test_rejects_labels_and_updates_segmentation_mask(
         output.getCvSegmentationMask(),
         np.array(
             [
-                [0, 255, 2],
-                [2, 255, 0],
+                [0, 255, 1],
+                [1, 255, 0],
             ],
             dtype=np.uint8,
         ),
@@ -122,7 +122,8 @@ def test_sorts_by_confidence_before_taking_top_k(filter_node: ImgDetectionsFilte
             (1, 0.40, (0.10, 0.10, 0.30, 0.30)),
             (2, 0.95, (0.20, 0.20, 0.40, 0.40)),
             (3, 0.70, (0.30, 0.30, 0.50, 0.50)),
-        ]
+        ],
+        mask=np.array([[0, 1, 2]], dtype=np.uint8),
     )
 
     output = process_message(
@@ -132,6 +133,9 @@ def test_sorts_by_confidence_before_taking_top_k(filter_node: ImgDetectionsFilte
 
     assert [det.label for det in output.detections] == [2, 3]
     assert [det.confidence for det in output.detections] == pytest.approx([0.95, 0.70])
+    np.testing.assert_array_equal(
+        output.getCvSegmentationMask(), np.array([[255, 0, 1]], dtype=np.uint8)
+    )
 
 
 def test_disable_sorting_keeps_original_order_before_top_k(
@@ -161,7 +165,8 @@ def test_nms_suppresses_overlapping_detections_of_same_label(
             (1, 0.95, (0.10, 0.10, 0.50, 0.50)),
             (1, 0.80, (0.12, 0.12, 0.48, 0.48)),
             (1, 0.70, (0.60, 0.60, 0.80, 0.80)),
-        ]
+        ],
+        mask=np.array([[0, 1, 2]], dtype=np.uint8),
     )
 
     output = process_message(
@@ -171,6 +176,9 @@ def test_nms_suppresses_overlapping_detections_of_same_label(
 
     assert len(output.detections) == 2
     assert [det.confidence for det in output.detections] == pytest.approx([0.95, 0.70])
+    np.testing.assert_array_equal(
+        output.getCvSegmentationMask(), np.array([[0, 255, 1]], dtype=np.uint8)
+    )
 
 
 def test_nms_keeps_overlapping_detections_of_different_labels(
@@ -189,3 +197,59 @@ def test_nms_keeps_overlapping_detections_of_different_labels(
     )
 
     assert [det.label for det in output.detections] == [1, 2]
+
+
+def test_take_first_k_removes_truncated_detection_masks(
+    filter_node: ImgDetectionsFilter,
+):
+    msg = create_img_detections(
+        [
+            (1, 0.90, (0.10, 0.10, 0.20, 0.20)),
+            (2, 0.80, (0.20, 0.20, 0.30, 0.30)),
+            (3, 0.70, (0.30, 0.30, 0.40, 0.40)),
+        ],
+        mask=np.array([[0, 1, 2, 255]], dtype=np.uint8),
+    )
+
+    output = process_message(filter_node.takeFirstK(2), msg)
+
+    assert [det.label for det in output.detections] == [1, 2]
+    np.testing.assert_array_equal(
+        output.getCvSegmentationMask(), np.array([[0, 1, 255, 255]], dtype=np.uint8)
+    )
+
+
+def test_invalid_mask_ids_become_background(filter_node: ImgDetectionsFilter):
+    msg = create_img_detections(
+        [
+            (1, 0.90, (0.10, 0.10, 0.20, 0.20)),
+            (2, 0.80, (0.20, 0.20, 0.30, 0.30)),
+        ],
+        mask=np.array([[0, 1, 2, 254, 255]], dtype=np.uint8),
+    )
+
+    output = process_message(filter_node, msg)
+
+    np.testing.assert_array_equal(
+        output.getCvSegmentationMask(),
+        np.array([[0, 1, 255, 255, 255]], dtype=np.uint8),
+    )
+
+
+def test_empty_final_detections_makes_mask_background(
+    filter_node: ImgDetectionsFilter,
+):
+    msg = create_img_detections(
+        [
+            (1, 0.90, (0.10, 0.10, 0.20, 0.20)),
+            (2, 0.80, (0.20, 0.20, 0.30, 0.30)),
+        ],
+        mask=np.array([[0, 1, 255]], dtype=np.uint8),
+    )
+
+    output = process_message(filter_node.keepLabels([3]), msg)
+
+    assert output.detections == []
+    np.testing.assert_array_equal(
+        output.getCvSegmentationMask(), np.array([[255, 255, 255]], dtype=np.uint8)
+    )


### PR DESCRIPTION
## Purpose
Reindex segmentation masks in ImgDetectionsFilter to match the new filtered detection list indices.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Added unit tests for this modified behavior. Validated all oak-examples with ImgDetectionsFilter still work as before.

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Pi Coding Agent:GPT-5.5

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved segmentation-mask updates after filtering, sorting, non-maximum suppression, and limiting detections.
  * Preserved correct instance and class labels for retained detections.
  * Handled invalid mask labels and cases with no remaining detections by treating affected areas as background.

* **Tests**
  * Added coverage for mask behavior across detection filtering and truncation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->