### PR TITLE
Feat/native support non default strides

### DIFF
--- a/depthai_nodes/node/parser_generator.py
+++ b/depthai_nodes/node/parser_generator.py
@@ -4,7 +4,7 @@ from depthai_nodes.logging import get_logger
 from depthai_nodes.node.parsers import *
 from depthai_nodes.node.parsers.base_parser import BaseParser
 from depthai_nodes.node.parsers.utils import decode_head
-from depthai_nodes.node.parsers.utils.yolo import YOLOSubtype, resolve_yolo_strides
+from depthai_nodes.node.parsers.utils.yolo import YOLOSubtype
 
 
 class ParserGenerator(dai.node.ThreadedHostNode):
@@ -75,8 +75,6 @@ class ParserGenerator(dai.node.ThreadedHostNode):
             if parser_name in self.DEVICE_PARSERS:
                 if hostOnly:
                     parser_name = self._getHostParserName(parser_name)
-                elif parser_name == "YOLO" and self._has_non_default_yolo_strides(head):
-                    parser_name = self._getHostParserName(parser_name)
                 else:
                     parser = pipeline.create(dai.node.DetectionParser)
                     parser.setNNArchiveHead(head)
@@ -86,10 +84,7 @@ class ParserGenerator(dai.node.ThreadedHostNode):
                 yolo_subtype_str = head.metadata.subtype
                 if yolo_subtype_str is not None:
                     yolo_subtype = YOLOSubtype(yolo_subtype_str.lower())
-                    if (
-                        yolo_subtype in self.DAI_SUPPORTED_YOLO_SUBTYPES
-                        and not self._has_non_default_yolo_strides(head, yolo_subtype)
-                    ):
+                    if yolo_subtype in self.DAI_SUPPORTED_YOLO_SUBTYPES:
                         parser = pipeline.create(dai.node.DetectionParser)
                         parser.setNNArchiveHead(head)
                         if head.metadata.maskOutputs is not None and is_rvc2_device:
@@ -130,50 +125,6 @@ class ParserGenerator(dai.node.ThreadedHostNode):
             parsers[index] = pipeline.create(parser).build(head_config)
 
         return parsers
-
-    @staticmethod
-    def _has_non_default_yolo_strides(
-        head,
-        subtype: YOLOSubtype | None = None,
-    ) -> bool:
-        head_config = decode_head(head)
-        strides = head_config.get("strides")
-        if strides is None:
-            return False
-
-        metadata = getattr(head, "metadata", None)
-
-        if subtype is None:
-            yolo_subtype_str = getattr(metadata, "subtype", None)
-            if yolo_subtype_str is None:
-                subtype = YOLOSubtype.DEFAULT
-            else:
-                try:
-                    subtype = YOLOSubtype(yolo_subtype_str.lower())
-                except ValueError:
-                    return True
-
-        yolo_outputs = getattr(metadata, "yoloOutputs", None)
-        outputs = (
-            yolo_outputs if yolo_outputs is not None else head_config.get("outputs")
-        )
-        num_outputs = len(outputs or [])
-
-        try:
-            resolved_strides = resolve_yolo_strides(
-                strides,
-                subtype,
-                num_outputs,
-            )
-        except ValueError:
-            return True
-
-        default_strides = resolve_yolo_strides(
-            None,
-            subtype,
-            num_outputs,
-        )
-        return resolved_strides != default_strides
 
     def run(self):
         """No-op required by ``dai.node.ThreadedHostNode``."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-depthai>=3.8.0
+depthai>=3.9.0
 opencv-python-headless~=4.10.0
 numpy>=1.22


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- DAI>=3.9 can correctly work with non default number of strides so we can remove the checks from ParsingGenerator

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YOLO extended parsing by consistently using the device parser for supported model subtypes.
  * Removed unnecessary fallback behavior that could route models to host-side parsing.

* **Chores**
  * Updated the minimum required DepthAI version to 3.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->