### PR TITLE
unify the representation of invalid depth with DepthAI

### DIFF
--- a/depthai_nodes/node/host_spatials_calc.py
+++ b/depthai_nodes/node/host_spatials_calc.py
@@ -86,6 +86,7 @@ class HostSpatialsCalc:
         averagingMethod: Callable = np.mean,
     ) -> dict[str, float]:
         """Calculate spatial coordinates from the depth frame within the ROI.
+        Returns x=0, y=0, z=0 in case of no valid depth inside the ROI.
 
         @param depthData: Depth frame used for coordinate estimation.
         @type depthData: dai.ImgFrame
@@ -111,9 +112,9 @@ class HostSpatialsCalc:
         valid_depths = depthROI[inRange]
         if valid_depths.size == 0:
             return {
-                "x": np.nan,
-                "y": np.nan,
-                "z": np.nan,
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
             }
         else:
             averageDepth = averagingMethod(valid_depths)

--- a/depthai_nodes/node/host_spatials_calc.py
+++ b/depthai_nodes/node/host_spatials_calc.py
@@ -85,8 +85,8 @@ class HostSpatialsCalc:
         roi: list[int],
         averagingMethod: Callable = np.mean,
     ) -> dict[str, float]:
-        """Calculate spatial coordinates from the depth frame within the ROI.
-        Returns x=0, y=0, z=0 in case of no valid depth inside the ROI.
+        """Calculate spatial coordinates from the depth frame within the ROI. Returns
+        x=0, y=0, z=0 in case of no valid depth inside the ROI.
 
         @param depthData: Depth frame used for coordinate estimation.
         @type depthData: dai.ImgFrame


### PR DESCRIPTION
 In DepthAI repo the effective convention is: {"x": 0.0, "y": 0.0, "z": 0.0}
or more generally:
spatialCoordinates.z <= 0
means “invalid / no spatial depth”.
Evidence in the codebase:
•
Point3f defaults to all zero: Point3f.hpp
•
DepthStats::calculateDepth() returns 0 when there are no valid depth pixels: SpatialUtils.cpp •
Spatial coordinates are then computed from that z; if z == 0, x and y also become 0: SpatialUtils.cpp •
Transform code treats spatialCoordinates.z <= 0 as invalid/no depth for keypoints: SpatialKeypoint.hpp •
Object tracking treats spatial position as valid only when z >= 1.0f: ObjectTrackerImpl.cpp •
StereoDepth docs say invalid depth values are set to 0: StereoDepth.hpp So for compatibility with the rest of DepthAI behavior, your Python node should return zeros, not NaNs:

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spatial calculations now return numeric zero values when no valid depth is detected within the selected region, improving consistency for downstream results.
  * Updated the behavior documentation to reflect the new output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->