### PR TITLE
Respect hostOnly in ParserGenerator for YoloExtendedParser

### DIFF
--- a/depthai_nodes/node/parser_generator.py
+++ b/depthai_nodes/node/parser_generator.py
@@ -82,7 +82,7 @@ class ParserGenerator(dai.node.ThreadedHostNode):
                     parser.setNNArchiveHead(head)
                     parsers[index] = parser
                     continue
-            elif parser_name == "YOLOExtendedParser":
+            elif parser_name == "YOLOExtendedParser" and not hostOnly:
                 yolo_subtype_str = head.metadata.subtype
                 if yolo_subtype_str is not None:
                     yolo_subtype = YOLOSubtype(yolo_subtype_str.lower())

--- a/tests/unittests/test_nodes/test_threaded_host_nodes/test_host_parsing_neural_network_node.py
+++ b/tests/unittests/test_nodes/test_threaded_host_nodes/test_host_parsing_neural_network_node.py
@@ -1,9 +1,8 @@
 import depthai as dai
 import pytest
 
-from depthai_nodes.node import HostParsingNeuralNetwork
+from depthai_nodes.node import HostParsingNeuralNetwork, YOLOExtendedParser
 from tests.utils import InputMock, NeuralNetworkMock, PipelineMock
-from tests.utils.nodes.mocks.pipeline import DetectionParserMock
 
 
 def get_model_archive(model_name: str) -> dai.NNArchive:
@@ -31,7 +30,7 @@ def test_yolo(pipeline: PipelineMock):
         input=InputMock(), nnSource=nn_archive, fps=30
     )
     parser = nn.getParser()
-    assert isinstance(parser, DetectionParserMock)
+    assert isinstance(parser, YOLOExtendedParser)
 
 
 def test_unsupported(pipeline: PipelineMock):


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- If `hostOnly` is selected then we should keep using `YOLOExtendedParser` instead of native `YOLO` parser

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parser selection for host-only configurations by skipping unsupported YOLO extended parsing when applicable.
  * Preserved existing parser resolution and configuration behavior for other scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->