### PR TITLE
YOLO V6 and V6R1 use same postprocessing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tersekmatija @klemen1999
+* @klemen1999

--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -27,8 +27,8 @@ class YOLOSubtype(str, Enum):
     V5 = "yolov5"
     V5U = "yolov5-u"
     V6 = "yolov6"
-    V6R1 = "yolov6r1"
-    V6R2 = "yolov6r2"  # NOTE: used by DAI but internally same as V6
+    V6R1 = "yolov6r1"  # NOTE: Semantically same as V6
+    V6R2 = "yolov6r2"
     V7 = "yolov7"
     V8 = "yolov8"
     V9 = "yolov9"
@@ -316,7 +316,7 @@ def parse_yolo_output(
         out[..., 0:2] = c_xy * stride
         out[..., 2:4] = wh * anchors
     else:
-        if subtype == YOLOSubtype.V6R1:
+        if subtype in [YOLOSubtype.V6R1, YOLOSubtype.V6]:
             c_xy = out[..., 0:2] + grid
             wh = np.exp(out[..., 2:4])
         else:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- `yolov6` subtype should follow the same postprocessing path as `yolov6r1`

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected YOLO V6 bounding-box decoding when anchor data is provided.
  * Clarified subtype handling for YOLO V6 and V6R1 formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->