### PR TITLE
Adding onnx_qnn_session helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We are always listening to the community so feel free to report and feedback, is
 - [📦 Content](#-content)
   - [📨 Message](#-message)
   - [🧩 Node](#-node)
+  - [⚙️ Runtime](#-runtime)
 - [🤝 Contributing](#-contributing)
 
 ## 🛠️ Installation
@@ -51,10 +52,11 @@ pip install .
 
 ## 📦 Content
 
-This library is organized into two primary modules, each focused on a specific aspect of working with DepthAI on the host side:
+This library is organized into three primary modules, each focused on a specific aspect of working with DepthAI on the host side:
 
 - `message` - Custom message types
 - `node` - High-level, modular host-side nodes
+- `runtime` - Runtime integrations
 
 ### 📨 Message
 
@@ -73,6 +75,18 @@ The `node` module provides a collection of ready-to-use host-side nodes that abs
 This modular approach allows you to rapidly prototype and scale complex applications with less effort while keeping your code clean and maintainable.
 
 To read more about the nodes and see simple examples, please refer to the [nodes documentation](./depthai_nodes/node/README.md).
+
+### ⚙️ Runtime
+
+The `runtime` module contains runtime integrations. Its OAK4 QNN helper
+creates ONNX Runtime sessions on the Hexagon DSP when used with the
+`onnxruntime` variant of the `oakapp-base` image:
+
+```python
+from depthai_nodes.runtime import qnn_session
+
+session = qnn_session("model.onnx")
+```
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We are always listening to the community so feel free to report and feedback, is
 - [📦 Content](#-content)
   - [📨 Message](#-message)
   - [🧩 Node](#-node)
-  - [⚙️ Runtime](#-runtime)
+  - [Runtime](#runtime)
 - [🤝 Contributing](#-contributing)
 
 ## 🛠️ Installation
@@ -76,7 +76,7 @@ This modular approach allows you to rapidly prototype and scale complex applicat
 
 To read more about the nodes and see simple examples, please refer to the [nodes documentation](./depthai_nodes/node/README.md).
 
-### ⚙️ Runtime
+### Runtime
 
 The `runtime` module contains runtime integrations. Its OAK4 QNN helper
 creates ONNX Runtime sessions on the Hexagon DSP when used with the

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ creates ONNX Runtime sessions on the Hexagon DSP when used with the
 `onnxruntime` variant of the `oakapp-base` image:
 
 ```python
-from depthai_nodes.runtime import qnn_session
+from depthai_nodes.runtime import onnx_qnn_session
 
-session = qnn_session("model.onnx")
+session = onnx_qnn_session("model.onnx")
 ```
 
 ## 🤝 Contributing

--- a/depthai_nodes/runtime/__init__.py
+++ b/depthai_nodes/runtime/__init__.py
@@ -1,5 +1,5 @@
 """Runtime integrations for DepthAI applications."""
 
-from .qnn import qnn_session
+from .onnx_qnn import onnx_qnn_session
 
-__all__ = ["qnn_session"]
+__all__ = ["onnx_qnn_session"]

--- a/depthai_nodes/runtime/__init__.py
+++ b/depthai_nodes/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime integrations for DepthAI applications."""
+
+from .qnn import qnn_session
+
+__all__ = ["qnn_session"]

--- a/depthai_nodes/runtime/onnx_qnn.py
+++ b/depthai_nodes/runtime/onnx_qnn.py
@@ -14,7 +14,7 @@ _registered = False
 logger = get_logger(__name__)
 
 
-def qnn_session(
+def onnx_qnn_session(
     model_path,
     *,
     fp16=True,

--- a/depthai_nodes/runtime/qnn.py
+++ b/depthai_nodes/runtime/qnn.py
@@ -1,6 +1,7 @@
 """Create ONNX Runtime sessions on the OAK4 Hexagon DSP."""
 
 import hashlib
+import math
 import os
 import tempfile
 import time
@@ -63,7 +64,7 @@ def qnn_session(
         device_wait_s = float(device_wait_s)
     except (TypeError, ValueError) as exc:
         raise ValueError("device_wait_s must be a non-negative number") from exc
-    if device_wait_s < 0:
+    if not math.isfinite(device_wait_s) or device_wait_s < 0:
         raise ValueError("device_wait_s must be a non-negative number")
 
     so = session_options or ort.SessionOptions()

--- a/depthai_nodes/runtime/qnn.py
+++ b/depthai_nodes/runtime/qnn.py
@@ -1,0 +1,172 @@
+"""Create ONNX Runtime sessions on the OAK4 Hexagon DSP."""
+
+import hashlib
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from depthai_nodes.logging import get_logger
+
+_EP_NAME = "QNNExecutionProvider"
+_registered = False
+logger = get_logger(__name__)
+
+
+def qnn_session(
+    model_path,
+    *,
+    fp16=True,
+    cache_context=True,
+    performance_mode="burst",
+    fallback_to_cpu=True,
+    runtime_fallback="ort",
+    device_wait_s=60,
+    ep_options=None,
+    session_options=None,
+    verbose=False,
+):
+    """Create an ONNX Runtime session running on the OAK4 DSP (HTP).
+
+    This helper is intended for the ``onnxruntime`` variant of ``oakapp-base``.
+    That image provides the FastRPC setup, QNN plugin, and required device nodes.
+
+    Args:
+        model_path: path to a .onnx model. Inputs must have static shapes.
+        fp16: run fp32 graphs in fp16 on the HTP (no-op for QDQ int8 models).
+        cache_context: cache the compiled QNN graph (EPContext) next to the
+            model so subsequent session creations skip HTP graph compilation.
+        performance_mode: QNN HTP performance mode (for example, ``burst``).
+        fallback_to_cpu: if False, raise when the DSP is unavailable during
+            session creation or any node cannot be placed on it. If True,
+            return a CPU session when no QNN device is available.
+        runtime_fallback: behavior after a QNN execution error. ``"ort"``
+            keeps ONNX Runtime's automatic fallback behavior; ``"raise"``
+            disables it so the caller can handle the error explicitly.
+        device_wait_s: seconds to wait for a QNN device to appear during
+            startup. Set to 0 to check once.
+        ep_options: extra QNN EP provider options (dict), merged last.
+        session_options: pre-configured ort.SessionOptions to extend.
+        verbose: enable verbose ORT logging.
+
+    Returns:
+        onnxruntime.InferenceSession
+    """
+    import onnxruntime as ort
+
+    model_path = Path(model_path)
+    if not model_path.is_file():
+        raise FileNotFoundError(model_path)
+    if runtime_fallback not in {"ort", "raise"}:
+        raise ValueError("runtime_fallback must be 'ort' or 'raise'")
+    try:
+        device_wait_s = float(device_wait_s)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("device_wait_s must be a non-negative number") from exc
+    if device_wait_s < 0:
+        raise ValueError("device_wait_s must be a non-negative number")
+
+    so = session_options or ort.SessionOptions()
+    if verbose:
+        so.log_severity_level = 0
+
+    qnn_devs, why_not = _qnn_ep_devices(ort, device_wait_s)
+    if not qnn_devs:
+        if not fallback_to_cpu:
+            raise RuntimeError(f"QNN EP unavailable: {why_not}")
+        logger.warning("QNN EP unavailable (%s); falling back to CPU EP", why_not)
+        return ort.InferenceSession(
+            str(model_path), so, providers=["CPUExecutionProvider"]
+        )
+
+    import onnxruntime_qnn
+
+    opts = {
+        "backend_path": onnxruntime_qnn.get_qnn_htp_path(),
+        "htp_performance_mode": performance_mode,
+        "enable_htp_fp16_precision": "1" if fp16 else "0",
+    }
+    if ep_options:
+        opts.update({key: str(value) for key, value in ep_options.items()})
+
+    if not fallback_to_cpu:
+        so.add_session_config_entry("session.disable_cpu_ep_fallback", "1")
+
+    load_path = model_path
+    if cache_context:
+        ctx_path = _context_cache_path(model_path, opts)
+        if ctx_path.is_file():
+            load_path = ctx_path
+        else:
+            so.add_session_config_entry("ep.context_enable", "1")
+            so.add_session_config_entry("ep.context_file_path", str(ctx_path))
+
+    so.add_provider_for_devices(qnn_devs, opts)
+    session = ort.InferenceSession(str(load_path), sess_options=so)
+    if runtime_fallback == "raise":
+        session.disable_fallback()
+    return session
+
+
+def _qnn_ep_devices(ort, device_wait_s):
+    """Register the plugin EP and return its devices and an error reason."""
+    global _registered
+    try:
+        import onnxruntime_qnn
+    except ImportError:
+        return [], (
+            "onnxruntime_qnn is not installed (use the onnxruntime variant "
+            "of the oakapp-base image)"
+        )
+    if not _registered:
+        ort.register_execution_provider_library(
+            _EP_NAME, onnxruntime_qnn.get_library_path()
+        )
+        _registered = True
+    deadline = time.monotonic() + device_wait_s
+    while True:
+        devices = [
+            device for device in ort.get_ep_devices() if device.ep_name == _EP_NAME
+        ]
+        if devices:
+            return devices, ""
+        remaining_s = deadline - time.monotonic()
+        if remaining_s <= 0:
+            return [], (
+                "no NPU EP device was enumerated after "
+                f"{device_wait_s:g}s; make sure the app runs on the "
+                "onnxruntime variant of the oakapp-base image with "
+                "/dev/fastrpc-cdsp and the dma_heap nodes in optional_devices, "
+                "and routes through "
+                "/entrypoint.sh"
+            )
+        time.sleep(min(1.0, remaining_s))
+
+
+def _context_cache_path(model_path, opts):
+    """Return the deterministic EPContext cache path for a model and options."""
+    import onnxruntime as ort
+    import onnxruntime_qnn
+
+    stat = model_path.stat()
+    key = "|".join(
+        [
+            str(model_path.resolve()),
+            str(stat.st_size),
+            str(stat.st_mtime_ns),
+            ort.__version__,
+            onnxruntime_qnn.__version__,
+            str(sorted(opts.items())),
+        ]
+    )
+    digest = hashlib.sha256(key.encode()).hexdigest()[:12]
+
+    cache_dir = os.environ.get("OAK4ORT_CACHE_DIR")
+    if cache_dir:
+        cache_dir = Path(cache_dir)
+    elif os.access(model_path.parent, os.W_OK):
+        cache_dir = model_path.parent / ".oak4ort_cache"
+    else:
+        cache_dir = Path(tempfile.gettempdir()) / "oak4ort_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / f"{model_path.stem}-{digest}_ctx.onnx"

--- a/tests/unittests/test_runtime/test_onnx_qnn.py
+++ b/tests/unittests/test_runtime/test_onnx_qnn.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from depthai_nodes.runtime import qnn, qnn_session
+from depthai_nodes.runtime import onnx_qnn, onnx_qnn_session
 
 
 class FakeSessionOptions:
@@ -50,13 +50,13 @@ class FakeOrt:
 
 
 @pytest.fixture(autouse=True)
-def reset_qnn_registration():
-    qnn._registered = False
+def reset_onnx_qnn_registration():
+    onnx_qnn._registered = False
     yield
-    qnn._registered = False
+    onnx_qnn._registered = False
 
 
-def test_qnn_session_falls_back_to_cpu_without_qnn_plugin(tmp_path, monkeypatch):
+def test_onnx_qnn_session_falls_back_to_cpu_without_qnn_plugin(tmp_path, monkeypatch):
     model_path = tmp_path / "model.onnx"
     model_path.touch()
     ort = FakeOrt([])
@@ -71,9 +71,9 @@ def test_qnn_session_falls_back_to_cpu_without_qnn_plugin(tmp_path, monkeypatch)
 
     monkeypatch.setattr(builtins, "__import__", import_without_qnn)
     logger = MagicMock()
-    monkeypatch.setattr(qnn, "logger", logger)
+    monkeypatch.setattr(onnx_qnn, "logger", logger)
 
-    qnn_session(model_path, device_wait_s=0)
+    onnx_qnn_session(model_path, device_wait_s=0)
 
     args, kwargs, _ = ort.sessions[0]
     assert args[0] == str(model_path)
@@ -86,7 +86,7 @@ def test_qnn_session_falls_back_to_cpu_without_qnn_plugin(tmp_path, monkeypatch)
     )
 
 
-def test_qnn_session_registers_qnn_provider_and_disables_runtime_fallback(
+def test_onnx_qnn_session_registers_qnn_provider_and_disables_runtime_fallback(
     tmp_path, monkeypatch
 ):
     model_path = tmp_path / "model.onnx"
@@ -100,7 +100,7 @@ def test_qnn_session_registers_qnn_provider_and_disables_runtime_fallback(
     monkeypatch.setitem(sys.modules, "onnxruntime", ort)
     monkeypatch.setitem(sys.modules, "onnxruntime_qnn", qnn_plugin)
 
-    session = qnn_session(
+    session = onnx_qnn_session(
         model_path,
         cache_context=False,
         ep_options={"foo": 1},

--- a/tests/unittests/test_runtime/test_qnn.py
+++ b/tests/unittests/test_runtime/test_qnn.py
@@ -1,0 +1,129 @@
+import builtins
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from depthai_nodes.runtime import qnn, qnn_session
+
+
+class FakeSessionOptions:
+    def __init__(self):
+        self.config_entries = []
+        self.provider_devices = []
+
+    def add_session_config_entry(self, key, value):
+        self.config_entries.append((key, value))
+
+    def add_provider_for_devices(self, devices, options):
+        self.provider_devices.append((devices, options))
+
+
+class FakeSession:
+    def __init__(self):
+        self.fallback_disabled = False
+
+    def disable_fallback(self):
+        self.fallback_disabled = True
+
+
+class FakeOrt:
+    SessionOptions = FakeSessionOptions
+    __version__ = "1.0.0"
+
+    def __init__(self, devices):
+        self.devices = devices
+        self.registered_libraries = []
+        self.sessions = []
+
+    def register_execution_provider_library(self, name, path):
+        self.registered_libraries.append((name, path))
+
+    def get_ep_devices(self):
+        return self.devices
+
+    def InferenceSession(self, *args, **kwargs):
+        session = FakeSession()
+        self.sessions.append((args, kwargs, session))
+        return session
+
+
+@pytest.fixture(autouse=True)
+def reset_qnn_registration():
+    qnn._registered = False
+    yield
+    qnn._registered = False
+
+
+def test_qnn_session_falls_back_to_cpu_without_qnn_plugin(tmp_path, monkeypatch):
+    model_path = tmp_path / "model.onnx"
+    model_path.touch()
+    ort = FakeOrt([])
+    monkeypatch.setitem(sys.modules, "onnxruntime", ort)
+
+    real_import = builtins.__import__
+
+    def import_without_qnn(name, *args, **kwargs):
+        if name == "onnxruntime_qnn":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_qnn)
+    logger = MagicMock()
+    monkeypatch.setattr(qnn, "logger", logger)
+
+    qnn_session(model_path, device_wait_s=0)
+
+    args, kwargs, _ = ort.sessions[0]
+    assert args[0] == str(model_path)
+    assert isinstance(args[1], FakeSessionOptions)
+    assert kwargs == {"providers": ["CPUExecutionProvider"]}
+    logger.warning.assert_called_once_with(
+        "QNN EP unavailable (%s); falling back to CPU EP",
+        "onnxruntime_qnn is not installed (use the onnxruntime variant "
+        "of the oakapp-base image)",
+    )
+
+
+def test_qnn_session_registers_qnn_provider_and_disables_runtime_fallback(
+    tmp_path, monkeypatch
+):
+    model_path = tmp_path / "model.onnx"
+    model_path.touch()
+    device = SimpleNamespace(ep_name="QNNExecutionProvider")
+    ort = FakeOrt([device])
+    qnn_plugin = ModuleType("onnxruntime_qnn")
+    qnn_plugin.__version__ = "1.0.0"
+    qnn_plugin.get_library_path = lambda: "/qnn/provider.so"
+    qnn_plugin.get_qnn_htp_path = lambda: "/qnn/htp.so"
+    monkeypatch.setitem(sys.modules, "onnxruntime", ort)
+    monkeypatch.setitem(sys.modules, "onnxruntime_qnn", qnn_plugin)
+
+    session = qnn_session(
+        model_path,
+        cache_context=False,
+        ep_options={"foo": 1},
+        fallback_to_cpu=False,
+        runtime_fallback="raise",
+    )
+
+    assert ort.registered_libraries == [("QNNExecutionProvider", "/qnn/provider.so")]
+    args, kwargs, created_session = ort.sessions[0]
+    assert args == (str(model_path),)
+    assert set(kwargs) == {"sess_options"}
+    options = kwargs["sess_options"]
+    assert options.config_entries == [("session.disable_cpu_ep_fallback", "1")]
+    assert options.provider_devices == [
+        (
+            [device],
+            {
+                "backend_path": "/qnn/htp.so",
+                "htp_performance_mode": "burst",
+                "enable_htp_fp16_precision": "1",
+                "foo": "1",
+            },
+        )
+    ]
+    assert session is created_session
+    assert session.fallback_disabled


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Add `depthai_nodes.runtime.onnx_qnn.onnx_qnn_session()` as the shared OAK4 QNN/ONNX Runtime session helper.
- Expose it as `from depthai_nodes.runtime import onnx_qnn_session`.
- Preserve lazy ORT/QNN imports, QNN device registration, HTP configuration, context caching, startup wait, and optional CPU/runtime fallback behavior.
- Log DSP-to-CPU fallback through the `depthai-nodes` logger.
- Document the runtime module and its requirement for the `onnxruntime` variant of `oakapp-base`.
- Add mocked unit tests for CPU fallback and QNN-provider session configuration.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ONNX Runtime session support using the QNN Execution Provider on OAK4 Hexagon DSP.
  * Added configurable performance, FP16, caching, provider overrides, and CPU fallback options.
  * Added device detection and diagnostics when QNN is unavailable.

* **Documentation**
  * Updated runtime documentation and examples to use the new ONNX QNN session interface.

* **Tests**
  * Added coverage for QNN setup, CPU fallback, provider configuration, and runtime fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->