### PR TITLE
Infer the class count using the anchors per head instead of the output heads

### DIFF
--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -668,9 +668,7 @@ def compute_yolo_detections(
         else:
             n_anchors_per_head = 1
 
-        num_classes_check = (
-            outputs_values[0].shape[1] // n_anchors_per_head
-        ) - 5
+        num_classes_check = (outputs_values[0].shape[1] // n_anchors_per_head) - 5
         if num_classes_check != n_classes:
             raise ValueError(
                 f"The provided number of classes {n_classes} does not match the model's {num_classes_check}."

--- a/depthai_nodes/node/parsers/utils/yolo.py
+++ b/depthai_nodes/node/parsers/utils/yolo.py
@@ -664,12 +664,13 @@ def compute_yolo_detections(
 
         if anchors is not None:
             anchors = np.array(anchors).reshape(len(resolved_strides), -1)
+            n_anchors_per_head = anchors.shape[1] // 2
+        else:
+            n_anchors_per_head = 1
 
         num_classes_check = (
-            outputs_values[0].shape[1] - 5
-            if anchors is None
-            else (outputs_values[0].shape[1] // anchors.shape[0]) - 5
-        )
+            outputs_values[0].shape[1] // n_anchors_per_head
+        ) - 5
         if num_classes_check != n_classes:
             raise ValueError(
                 f"The provided number of classes {n_classes} does not match the model's {num_classes_check}."

--- a/tests/unittests/test_parsers/test_yolo_utils.py
+++ b/tests/unittests/test_parsers/test_yolo_utils.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from depthai_nodes.node.parsers.utils.yolo import (
+    YOLOSubtype,
+    compute_yolo_detections,
+)
+
+
+def test_compute_yolo_detections_uses_anchors_per_head_for_class_count(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "depthai_nodes.node.parsers.utils.yolo.decode_yolo_output",
+        lambda *args, **kwargs: np.zeros((0, 6), dtype=np.float32),
+    )
+
+    outputs_values = [
+        np.zeros((1, 255, 26, 26), dtype=np.float32),
+        np.zeros((1, 255, 13, 13), dtype=np.float32),
+    ]
+    anchors = [
+        [[10.0, 14.0], [23.0, 27.0], [37.0, 58.0]],
+        [[81.0, 82.0], [135.0, 169.0], [344.0, 319.0]],
+    ]
+
+    payload = compute_yolo_detections(
+        subtype=YOLOSubtype.V3T,
+        layer_names=["output1_yolo", "output2_yolo"],
+        outputs_values=outputs_values,
+        strides=[16, 32],
+        conf_threshold=0.25,
+        n_classes=80,
+        iou_threshold=0.45,
+        max_det=300,
+        anchors=anchors,
+        n_keypoints=17,
+        label_names=[f"class_{idx}" for idx in range(80)],
+        keypoint_label_names=None,
+        keypoint_edges=None,
+        input_shape=(416, 416),
+    )
+
+    assert payload["scores"].size == 0
+    assert payload["labels"].size == 0


### PR DESCRIPTION
## Purpose
Bug existed in luxonis-eval where the number output heads were used to infer the class count, and this fails if the number of heads is different than the number of anchors per head.

Reference to comment mentioning equivalent depthai-nodes bug: https://github.com/luxonis/luxonis-eval/pull/17#discussion_r3735892654

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YOLO model parsing to correctly determine class counts across different anchor configurations.
  * Added support for models without anchor data by applying an appropriate default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->