### PR TITLE
Isolate macOS end-to-end test environment

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install HIL
         run: |
-          python -m pip install --upgrade pip==26.2.1
+          python -m pip install --upgrade pip
           python -m pip --version
            python -m pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple
       - name: Run Test
@@ -139,7 +139,7 @@ jobs:
 
       - name: Install HIL
         run: |
-          python -m pip install --upgrade pip==26.2.1
+          python -m pip install --upgrade pip
           python -m pip --version
            python -m pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple
       - name: Run Test
@@ -195,7 +195,7 @@ jobs:
           cd depthai-nodes
           python3 -m venv venv
           . venv/bin/activate
-          python -m pip install --upgrade pip==26.2.1
+          python -m pip install --upgrade pip
           python -m pip --version
           python -m pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple --no-cache-dir
           JOB=${{ job.check_run_id }}

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -76,6 +76,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: pip
+
+      - name: Install HIL
+        run: |
+          python -m pip install --upgrade pip==26.2.1
+          python -m pip --version
+           python -m pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple
       - name: Run Test
         env:
           SAFE_REF_NAME: ${{ github.ref_name }}
@@ -120,6 +131,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: pip
+
+      - name: Install HIL
+        run: |
+          python -m pip install --upgrade pip==26.2.1
+          python -m pip --version
+           python -m pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple
       - name: Run Test
         env:
           SAFE_REF_NAME: ${{ github.ref_name }}
@@ -173,7 +195,9 @@ jobs:
           cd depthai-nodes
           python3 -m venv venv
           . venv/bin/activate
-          pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple --no-cache-dir
+          python -m pip install --upgrade pip==26.2.1
+          python -m pip --version
+          python -m pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple --no-cache-dir
           JOB=${{ job.check_run_id }}
           export RESERVATION_NAME="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${JOB}"
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
@@ -187,10 +211,10 @@ jobs:
                 ADDITIONAL_OPTIONS="${{ github.event.inputs.additional_options }}"
             fi
             if [[ "${{ github.event.inputs.bom_mode }}" == 'true' ]]; then
-              exec hil_runner --hold-reservation $ADDITIONAL_OPTIONS -os mac --basic-sanity --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
+              exec hil_runner --hold-reservation $ADDITIONAL_OPTIONS -os mac --basic-sanity --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION --sync-workspace --commands "export PATH=\"\$HOME/.local/bin:\$PATH\"; cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
             else
-              exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION -os mac --basic-sanity --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
+              exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION -os mac --basic-sanity --sync-workspace --commands "export PATH=\"\$HOME/.local/bin:\$PATH\"; cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
             fi
           else
-            exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait --basic-sanity --reservation-name $RESERVATION_NAME -os mac --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} 3.8.0 ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
+            exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait --basic-sanity --reservation-name $RESERVATION_NAME -os mac --sync-workspace --commands "export PATH=\"\$HOME/.local/bin:\$PATH\"; cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} 3.8.0 ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
           fi

--- a/tests/end_to_end/run_end_to_end.sh
+++ b/tests/end_to_end/run_end_to_end.sh
@@ -64,25 +64,24 @@ if [[ "$UV_COMMAND" != "uv" || "$UV_ACTUAL_VERSION" != "$UV_REQUIRED_VERSION" ]]
 fi
 
 uv venv --managed-python --clear --python 3.12 venv
-VENV_PYTHON="$PWD/venv/bin/python"
 # shellcheck disable=SC1091
 source venv/bin/activate
 
 echo "Project virtual environment:"
-"$VENV_PYTHON" -c 'import sys; print(f"executable: {sys.executable}"); print(f"prefix: {sys.prefix}"); print(f"base prefix: {sys.base_prefix}")'
+python -c 'import sys; print(f"executable: {sys.executable}"); print(f"prefix: {sys.prefix}"); print(f"base prefix: {sys.base_prefix}")'
 
-uv pip install --python "$VENV_PYTHON" --upgrade pip
-uv pip install --python "$VENV_PYTHON" -e .
-uv pip install --python "$VENV_PYTHON" -r requirements-dev.txt
+uv pip install --upgrade pip
+uv pip install -e .
+uv pip install -r requirements-dev.txt
 
 # Install depthai with required indexes
-uv pip install --python "$VENV_PYTHON" --upgrade \
+uv pip install --upgrade \
   --extra-index-url "https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/" \
   ${LUXONIS_EXTRA_INDEX_URL:+--extra-index-url "$LUXONIS_EXTRA_INDEX_URL"} \
   "depthai==${DEPTHAI_VERSION}"
 
 cd tests/end_to_end
 
-source <("$VENV_PYTHON" setup_camera_ips.py)
+source <(python setup_camera_ips.py)
 export DEPTHAI_NODES_LEVEL=debug
-"$VENV_PYTHON" -u main.py --platform "${PLATFORM}"
+python -u main.py --platform "${PLATFORM}"

--- a/tests/end_to_end/run_end_to_end.sh
+++ b/tests/end_to_end/run_end_to_end.sh
@@ -49,22 +49,40 @@ export FLAGS
 export DEPTHAI_NODES_LEVEL="debug"
 export DEPTHAI_DEBUG="0"
 
-python3.12 -m venv venv
+readonly UV_REQUIRED_VERSION="0.12.5"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv ${UV_REQUIRED_VERSION} is required on the macOS test host" >&2
+  exit 1
+fi
+
+UV_VERSION="$(uv --version)"
+read -r UV_COMMAND UV_ACTUAL_VERSION _ <<< "$UV_VERSION"
+if [[ "$UV_COMMAND" != "uv" || "$UV_ACTUAL_VERSION" != "$UV_REQUIRED_VERSION" ]]; then
+  echo "Expected uv ${UV_REQUIRED_VERSION}, found ${UV_VERSION}" >&2
+  exit 1
+fi
+
+uv venv --managed-python --clear --python 3.12 venv
+VENV_PYTHON="$PWD/venv/bin/python"
 # shellcheck disable=SC1091
 source venv/bin/activate
 
-python -m pip install --upgrade pip
-pip install -e .
-pip install -r requirements-dev.txt
+echo "Project virtual environment:"
+"$VENV_PYTHON" -c 'import sys; print(f"executable: {sys.executable}"); print(f"prefix: {sys.prefix}"); print(f"base prefix: {sys.base_prefix}")'
+
+uv pip install --python "$VENV_PYTHON" --upgrade pip
+uv pip install --python "$VENV_PYTHON" -e .
+uv pip install --python "$VENV_PYTHON" -r requirements-dev.txt
 
 # Install depthai with required indexes
-pip install --upgrade \
+uv pip install --python "$VENV_PYTHON" --upgrade \
   --extra-index-url "https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/" \
   ${LUXONIS_EXTRA_INDEX_URL:+--extra-index-url "$LUXONIS_EXTRA_INDEX_URL"} \
   "depthai==${DEPTHAI_VERSION}"
 
 cd tests/end_to_end
 
-source <(python setup_camera_ips.py)
+source <("$VENV_PYTHON" setup_camera_ips.py)
 export DEPTHAI_NODES_LEVEL=debug
-python -u main.py --platform "${PLATFORM}"
+"$VENV_PYTHON" -u main.py --platform "${PLATFORM}"

--- a/tests/end_to_end/test_e2e.py
+++ b/tests/end_to_end/test_e2e.py
@@ -1,6 +1,7 @@
 import ast
 import os
 import subprocess
+import sys
 import time
 
 import pytest
@@ -71,20 +72,21 @@ def test_pipelines(IP: str, ip_platform: str, nn_archive_path, model):
             f"Testing model {model} from NN archive {nn_archive_path} on device with IP {IP} ({ip_platform})",
             flush=True,
         )
+        command = [sys.executable, "manual.py"]
         if model:
-            subprocess.run(
-                f"python manual.py -m {model} {'-ip' if IP else ''} {IP}",
-                shell=True,
-                check=True,
-                timeout=120,
-            )
+            command.extend(["-m", model])
         else:
-            subprocess.run(
-                f"python manual.py -nn {nn_archive_path} {'-ip' if IP else ''} {IP}",
-                shell=True,
-                check=True,
-                timeout=120,
-            )
+            command.extend(["-nn", nn_archive_path])
+        if IP:
+            command.extend(["-ip", IP])
+
+        print(f"Running manual.py with interpreter: {sys.executable}", flush=True)
+        print(f"Manual test command: {command}", flush=True)
+        subprocess.run(
+            command,
+            check=True,
+            timeout=120,
+        )
     except subprocess.CalledProcessError as e:
         if e.returncode == 5:
             pytest.skip(f"Model {model} not supported on {ip_platform}.")


### PR DESCRIPTION
This change makes the macOS end-to-end test environment deterministic and isolated from the testbed’s pre-existing .hil virtual environment.

  - Uses uv 0.12.5 to create a managed Python 3.12 project virtual environment.
  - Installs and runs depthai-nodes and test dependencies through that environment explicitly.
  - Launches child test processes with sys.executable, avoiding bare python resolution to the .hil interpreter.
  - Pins the outer HIL bootstrap pip version to 26.2.1 and invokes it as python -m pip.

  This prevents the project tests from silently using the testbed’s shared HIL Python environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability with managed Python 3.12 environments.
  * Standardized test execution using the required `uv` version.
  * Improved subprocess handling and interpreter consistency during pipeline tests.
  * Added clearer diagnostics for test environments and command execution.

* **Chores**
  * Updated installation steps for consistent package management.
  * Improved Linux, Windows, and macOS test setup and command availability.
  * Enhanced reservation and environment configuration across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->