### PR TITLE
ci: set up isolated Python for Linux and Windows e2e

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -76,6 +76,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: pip
+
+      - name: Install HIL
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip --version
+          python -m pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple
+
       - name: Run Test
         env:
           SAFE_REF_NAME: ${{ github.ref_name }}
@@ -119,6 +131,18 @@ jobs:
        (github.event.inputs.select-os == 'all' || github.event.inputs.select-os == 'windows-only'))
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: pip
+
+      - name: Install HIL
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip --version
+          python -m pip install hil_framework --upgrade --index-url https://__token__:${{ secrets.GITLAB_TOKEN }}@gitlab.luxonis.com/api/v4/projects/213/packages/pypi/simple
 
       - name: Run Test
         env:


### PR DESCRIPTION
Sets up an isolated Python 3.12 environment and installs HIL with the active interpreter for Linux and Windows E2E jobs.