### PR TITLE
Zsh mac

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -192,6 +192,5 @@ jobs:
               exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION -os mac --basic-sanity --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end_mac.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
             fi
           else
-            exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait --basic-sanity --reservation-name $RESERVATION_NAME -os mac --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end
-            _mac.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} 3.8.0 ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
+            exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait --basic-sanity --reservation-name $RESERVATION_NAME -os mac --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end_mac.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} 3.8.0 ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
           fi

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Run Test
         run: |
-          cp -n tests/end_to_end/run_end_to_end_mac.sh depthai-nodes/tests/end_to_end/run_end_to_end.sh
+          cp -n tests/end_to_end/run_end_to_end_mac.sh depthai-nodes/tests/end_to_end/run_end_to_end_mac.sh
           cd depthai-nodes
           python3 -m venv venv
           . venv/bin/activate

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Run Test
         run: |
-          #cp -n tests/end_to_end/run_end_to_end_mac.sh depthai-nodes/tests/end_to_end/run_end_to_end.sh
+          cp -n tests/end_to_end/run_end_to_end_mac.sh depthai-nodes/tests/end_to_end/run_end_to_end.sh
           cd depthai-nodes
           python3 -m venv venv
           . venv/bin/activate

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Run Test
         run: |
-          cp -n tests/end_to_end/run_end_to_end.sh depthai-nodes/tests/end_to_end/run_end_to_end.sh
+          cp -n tests/end_to_end/run_end_to_end_mac.sh depthai-nodes/tests/end_to_end/run_end_to_end_mac.sh
           cd depthai-nodes
           python3 -m venv venv
           . venv/bin/activate

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Run Test
         run: |
-          cp -n tests/end_to_end/run_end_to_end_mac.sh depthai-nodes/tests/end_to_end/run_end_to_end_mac.sh
+          #cp -n tests/end_to_end/run_end_to_end_mac.sh depthai-nodes/tests/end_to_end/run_end_to_end.sh
           cd depthai-nodes
           python3 -m venv venv
           . venv/bin/activate

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -187,10 +187,11 @@ jobs:
                 ADDITIONAL_OPTIONS="${{ github.event.inputs.additional_options }}"
             fi
             if [[ "${{ github.event.inputs.bom_mode }}" == 'true' ]]; then
-              exec hil_runner --hold-reservation $ADDITIONAL_OPTIONS -os mac --basic-sanity --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
+              exec hil_runner --hold-reservation $ADDITIONAL_OPTIONS -os mac --basic-sanity --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end_mac.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
             else
-              exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION -os mac --basic-sanity --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
+              exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait $RESERVATION_OPTION -os mac --basic-sanity --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end_mac.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} ${{ github.event.inputs.depthai-version }} ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
             fi
           else
-            exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait --basic-sanity --reservation-name $RESERVATION_NAME -os mac --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} 3.8.0 ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
+            exec hil_runner --models 'oak4_s or oak4_pro or oak4_d' --wait --basic-sanity --reservation-name $RESERVATION_NAME -os mac --sync-workspace --commands "cd /tmp/depthai-nodes && ./tests/end_to_end/run_end_to_end
+            _mac.sh ${{ secrets.HUBAI_API_KEY }} ${{ secrets.HUBAI_TEAM_SLUG }} 3.8.0 ${{secrets.LUXONIS_EXTRA_INDEX_URL}} rvc4"
           fi

--- a/tests/end_to_end/run_end_to_end.sh
+++ b/tests/end_to_end/run_end_to_end.sh
@@ -49,6 +49,7 @@ export FLAGS
 export DEPTHAI_NODES_LEVEL="debug"
 export DEPTHAI_DEBUG="0"
 
+rm -rf venv
 python3.12 -m venv venv
 # shellcheck disable=SC1091
 source venv/bin/activate

--- a/tests/end_to_end/run_end_to_end.sh
+++ b/tests/end_to_end/run_end_to_end.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 set -euo pipefail
 
 # ============================================

--- a/tests/end_to_end/run_end_to_end.sh
+++ b/tests/end_to_end/run_end_to_end.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 set -euo pipefail
 
 # ============================================

--- a/tests/end_to_end/run_end_to_end_mac.sh
+++ b/tests/end_to_end/run_end_to_end_mac.sh
@@ -69,7 +69,7 @@ cd "$PROJECT_ROOT"
 
 # ---- Create and activate virtual environment
 
-python3.12 -m venv venv
+/opt/homebrew/bin/python3.12 -m venv --copies venv
 
 source venv/bin/activate
 

--- a/tests/end_to_end/run_end_to_end_mac.sh
+++ b/tests/end_to_end/run_end_to_end_mac.sh
@@ -69,7 +69,7 @@ cd "$PROJECT_ROOT"
 
 # ---- Create and activate virtual environment
 
-/opt/homebrew/bin/python3.12 -m venv --copies venv
+/opt/homebrew/bin/python3.12 -m venv venv
 
 source venv/bin/activate
 

--- a/tests/end_to_end/run_end_to_end_mac.sh
+++ b/tests/end_to_end/run_end_to_end_mac.sh
@@ -1,0 +1,121 @@
+#!/bin/zsh
+set -euo pipefail
+
+# ============================================
+# Usage:
+#   ./run_end_to_end.zsh \
+#     <HUBAI_API_KEY> \
+#     <HUBAI_TEAM_SLUG> \
+#     <DEPTHAI_VERSION> \
+#     <LUXONIS_EXTRA_INDEX_URL> \
+#     <PLATFORM> \
+#     [ADDITIONAL_PARAMETER...]
+# ============================================
+
+HUBAI_API_KEY="${1:-}"
+HUBAI_TEAM_SLUG="${2:-}"
+DEPTHAI_VERSION="${3:-}"
+LUXONIS_EXTRA_INDEX_URL="${4:-}"
+PLATFORM="${5:-}"
+
+if (( $# >= 5 )); then
+    shift 5
+else
+    shift $#
+fi
+
+# Preserve any additional parameters for the test command
+ADDITIONAL_PARAMETERS=("$@")
+FLAGS="$*"
+
+# ---- Basic validation
+
+[[ -n "$HUBAI_API_KEY" ]] || {
+    echo "[!] HUBAI_API_KEY is required"
+    exit 2
+}
+
+[[ -n "$HUBAI_TEAM_SLUG" ]] || {
+    echo "[!] HUBAI_TEAM_SLUG is required"
+    exit 2
+}
+
+[[ -n "$DEPTHAI_VERSION" ]] || {
+    echo "[!] DEPTHAI_VERSION is required"
+    exit 2
+}
+
+[[ -n "$PLATFORM" ]] || {
+    echo "[!] PLATFORM is required, for example: rvc4"
+    exit 2
+}
+
+# ---- Export environment
+
+export LUXONIS_EXTRA_INDEX_URL
+export DEPTHAI_VERSION
+export HUBAI_TEAM_SLUG
+export HUBAI_API_KEY
+export FLAGS
+export DEPTHAI_NODES_LEVEL="debug"
+export DEPTHAI_DEBUG="0"
+
+# ---- Locate project root
+
+SCRIPT_DIR="${0:A:h}"
+PROJECT_ROOT="$SCRIPT_DIR/../.."
+
+cd "$PROJECT_ROOT"
+
+# ---- Create and activate virtual environment
+
+python3.12 -m venv venv
+
+source venv/bin/activate
+
+python -m pip install --upgrade pip
+python -m pip install -e .
+python -m pip install -r requirements-dev.txt
+
+# ---- Install DepthAI
+
+PIP_ARGUMENTS=(
+    --upgrade
+    --extra-index-url
+    "https://artifacts.luxonis.com/artifactory/luxonis-python-snapshot-local/"
+)
+
+if [[ -n "$LUXONIS_EXTRA_INDEX_URL" ]]; then
+    PIP_ARGUMENTS+=(
+        --extra-index-url
+        "$LUXONIS_EXTRA_INDEX_URL"
+    )
+fi
+
+python -m pip install \
+    "${PIP_ARGUMENTS[@]}" \
+    "depthai==${DEPTHAI_VERSION}"
+
+# ---- Detect camera IPs
+
+cd "$SCRIPT_DIR"
+
+camera_env="$(python setup_camera_ips.py)" || {
+    echo "[!] Failed to detect camera IPs"
+    exit 1
+}
+
+# setup_camera_ips.py outputs export commands.
+# Command substitution waits for Python to finish before eval executes them.
+eval "$camera_env"
+
+echo "RVC2_IP=${RVC2_IP:-}"
+echo "RVC4_IP=${RVC4_IP:-}"
+
+# ---- Run end-to-end tests
+
+export DEPTHAI_NODES_LEVEL=debug
+
+python -u main.py \
+    --platform "$PLATFORM" \
+    "${ADDITIONAL_PARAMETERS[@]}"

--- a/tests/end_to_end/run_end_to_end_mac.sh
+++ b/tests/end_to_end/run_end_to_end_mac.sh
@@ -69,7 +69,7 @@ cd "$PROJECT_ROOT"
 
 # ---- Create and activate virtual environment
 rm -rf venv
-/opt/homebrew/bin/python3.12 -m venv venv
+python3.12 -m venv venv
 
 source venv/bin/activate
 

--- a/tests/end_to_end/run_end_to_end_mac.sh
+++ b/tests/end_to_end/run_end_to_end_mac.sh
@@ -68,7 +68,7 @@ PROJECT_ROOT="$SCRIPT_DIR/../.."
 cd "$PROJECT_ROOT"
 
 # ---- Create and activate virtual environment
-
+rm -rf venv
 /opt/homebrew/bin/python3.12 -m venv venv
 
 source venv/bin/activate


### PR DESCRIPTION
run mac tests via zsh script 

remove venvs before starting jobs as hil framework copies venvs created on github runners, leading to compromised environments

use zsh for mac runs as bash packaged with mac os is outdated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS end-to-end test reliability by using a platform-specific test runner.
  * Ensured test runs start with a clean Python virtual environment.
  * Added validation for required test configuration and clearer failure handling.

* **Tests**
  * Added support for configuring platform-specific test parameters, dependencies, camera detection, and optional runtime arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->