### PR TITLE
Revert crop order changes in 

### DIFF
--- a/depthai_nodes/node/parsers/utils/masks_utils.py
+++ b/depthai_nodes/node/parsers/utils/masks_utils.py
@@ -12,9 +12,7 @@ def probability_to_logit_threshold(probability: float) -> float:
     return float(np.log(probability / (1.0 - probability)))
 
 
-def crop_mask(
-    mask: np.ndarray, bbox: np.ndarray, fill_value: float | int = 0
-) -> np.ndarray:
+def crop_mask(mask: np.ndarray, bbox: np.ndarray) -> np.ndarray:
     """It takes a mask and a bounding box, and returns a mask that is cropped to the
     bounding box.
 
@@ -23,8 +21,6 @@ def crop_mask(
     @param bbox: A numpy array of bbox coordinates in (x_center, y_center, width,
         height) format
     @type bbox: np.ndarray
-    @param fill_value: Value assigned to pixels outside the bounding box.
-    @type fill_value: float | int
     @return: A mask that is cropped to the bounding box
     @rtype: np.ndarray
     """
@@ -37,8 +33,7 @@ def crop_mask(
     r = np.arange(w).reshape(1, w)
     c = np.arange(h).reshape(h, 1)
 
-    inside_bbox = (r >= x1) * (r < x2) * (c >= y1) * (c < y2)
-    return np.where(inside_bbox, mask, fill_value)
+    return mask * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
 
 
 def process_single_mask(
@@ -69,17 +64,20 @@ def process_single_mask(
     logit_threshold = probability_to_logit_threshold(mask_conf)
 
     mask_logits = np.sum(protos * mask_coeff[..., np.newaxis, np.newaxis], axis=0)
-    mask_logits = crop_mask(
-        mask_logits,
-        scaled_bbox,
-        fill_value=logit_threshold,
-    )
+    # Replace logits outside the bounding box with zero before interpolation.
+    mask_logits = crop_mask(mask_logits, scaled_bbox)
     mask_logits = cv2.resize(
         mask_logits,
         (output_shape[1], output_shape[0]),
         interpolation=cv2.INTER_LINEAR,
     )
-    return (mask_logits > logit_threshold).astype(np.uint8)
+    mask = (mask_logits > logit_threshold).astype(np.uint8)
+
+    # Enforce the bounding box because zero-filled pixels can pass thresholding.
+    scaled_output_bbox = bbox * np.array(
+        [output_shape[1], output_shape[0], output_shape[1], output_shape[0]]
+    )
+    return crop_mask(mask, scaled_output_bbox)
 
 
 def get_segmentation_outputs(

--- a/depthai_nodes/node/parsers/utils/masks_utils.py
+++ b/depthai_nodes/node/parsers/utils/masks_utils.py
@@ -12,7 +12,9 @@ def probability_to_logit_threshold(probability: float) -> float:
     return float(np.log(probability / (1.0 - probability)))
 
 
-def crop_mask(mask: np.ndarray, bbox: np.ndarray) -> np.ndarray:
+def crop_mask(
+    mask: np.ndarray, bbox: np.ndarray, fill_value: float | int = 0
+) -> np.ndarray:
     """It takes a mask and a bounding box, and returns a mask that is cropped to the
     bounding box.
 
@@ -21,6 +23,8 @@ def crop_mask(mask: np.ndarray, bbox: np.ndarray) -> np.ndarray:
     @param bbox: A numpy array of bbox coordinates in (x_center, y_center, width,
         height) format
     @type bbox: np.ndarray
+    @param fill_value: Value assigned to pixels outside the bounding box.
+    @type fill_value: float | int
     @return: A mask that is cropped to the bounding box
     @rtype: np.ndarray
     """
@@ -33,7 +37,8 @@ def crop_mask(mask: np.ndarray, bbox: np.ndarray) -> np.ndarray:
     r = np.arange(w).reshape(1, w)
     c = np.arange(h).reshape(h, 1)
 
-    return mask * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
+    inside_bbox = (r >= x1) * (r < x2) * (c >= y1) * (c < y2)
+    return np.where(inside_bbox, mask, fill_value)
 
 
 def process_single_mask(
@@ -61,15 +66,19 @@ def process_single_mask(
     """
     _, mask_h, mask_w = protos.shape  # CHW
     scaled_bbox = bbox * np.array([mask_w, mask_h, mask_w, mask_h])
+    logit_threshold = probability_to_logit_threshold(mask_conf)
 
     mask_logits = np.sum(protos * mask_coeff[..., np.newaxis, np.newaxis], axis=0)
-    mask_logits = crop_mask(mask_logits, scaled_bbox)
+    mask_logits = crop_mask(
+        mask_logits,
+        scaled_bbox,
+        fill_value=logit_threshold,
+    )
     mask_logits = cv2.resize(
         mask_logits,
         (output_shape[1], output_shape[0]),
         interpolation=cv2.INTER_LINEAR,
     )
-    logit_threshold = probability_to_logit_threshold(mask_conf)
     return (mask_logits > logit_threshold).astype(np.uint8)
 
 
@@ -100,7 +109,6 @@ def get_segmentation_outputs(
 def process_single_mask_rfdetr(
     mask_logits: np.ndarray,
     mask_conf: float,
-    bbox: np.ndarray,
     input_shape: tuple[int, int],
 ) -> np.ndarray:
     """Process a single RF-DETR instance segmentation mask.
@@ -109,9 +117,6 @@ def process_single_mask_rfdetr(
     @type mask_logits: np.ndarray
     @param mask_conf: Mask confidence threshold.
     @type mask_conf: float
-    @param bbox: A numpy array of bbox coordinates in (x_center, y_center, width,
-        height) normalized format.
-    @type bbox: np.ndarray
     @param input_shape: Target output mask shape as (height, width).
     @type input_shape: tuple[int, int]
     @return: Processed mask resized to the model input shape.
@@ -128,9 +133,4 @@ def process_single_mask_rfdetr(
         interpolation=cv2.INTER_LINEAR,
     )
     logit_threshold = probability_to_logit_threshold(mask_conf)
-    mask = (resized_mask_logits > logit_threshold).astype(np.uint8)
-
-    scaled_bbox = bbox * np.array(
-        [input_shape[1], input_shape[0], input_shape[1], input_shape[0]]
-    )
-    return crop_mask(mask, scaled_bbox)
+    return (resized_mask_logits > logit_threshold).astype(np.uint8)

--- a/depthai_nodes/node/parsers/utils/masks_utils.py
+++ b/depthai_nodes/node/parsers/utils/masks_utils.py
@@ -59,19 +59,18 @@ def process_single_mask(
     @return: Processed binary mask resized to `output_shape`.
     @rtype: np.ndarray
     """
+    _, mask_h, mask_w = protos.shape  # CHW
+    scaled_bbox = bbox * np.array([mask_w, mask_h, mask_w, mask_h])
+
     mask_logits = np.sum(protos * mask_coeff[..., np.newaxis, np.newaxis], axis=0)
+    mask_logits = crop_mask(mask_logits, scaled_bbox)
     mask_logits = cv2.resize(
         mask_logits,
         (output_shape[1], output_shape[0]),
         interpolation=cv2.INTER_LINEAR,
     )
     logit_threshold = probability_to_logit_threshold(mask_conf)
-    mask = (mask_logits > logit_threshold).astype(np.uint8)
-
-    scaled_bbox = bbox * np.array(
-        [output_shape[1], output_shape[0], output_shape[1], output_shape[0]]
-    )
-    return crop_mask(mask, scaled_bbox)
+    return (mask_logits > logit_threshold).astype(np.uint8)
 
 
 def get_segmentation_outputs(

--- a/depthai_nodes/node/parsers/utils/masks_utils.py
+++ b/depthai_nodes/node/parsers/utils/masks_utils.py
@@ -12,7 +12,9 @@ def probability_to_logit_threshold(probability: float) -> float:
     return float(np.log(probability / (1.0 - probability)))
 
 
-def crop_mask(mask: np.ndarray, bbox: np.ndarray) -> np.ndarray:
+def crop_mask(
+    mask: np.ndarray, bbox: np.ndarray, fill_value: float | int = 0
+) -> np.ndarray:
     """It takes a mask and a bounding box, and returns a mask that is cropped to the
     bounding box.
 
@@ -21,6 +23,8 @@ def crop_mask(mask: np.ndarray, bbox: np.ndarray) -> np.ndarray:
     @param bbox: A numpy array of bbox coordinates in (x_center, y_center, width,
         height) format
     @type bbox: np.ndarray
+    @param fill_value: Value assigned to pixels outside the bounding box.
+    @type fill_value: float | int
     @return: A mask that is cropped to the bounding box
     @rtype: np.ndarray
     """
@@ -33,7 +37,8 @@ def crop_mask(mask: np.ndarray, bbox: np.ndarray) -> np.ndarray:
     r = np.arange(w).reshape(1, w)
     c = np.arange(h).reshape(h, 1)
 
-    return mask * ((r >= x1) * (r < x2) * (c >= y1) * (c < y2))
+    inside_bbox = (r >= x1) * (r < x2) * (c >= y1) * (c < y2)
+    return np.where(inside_bbox, mask, fill_value)
 
 
 def process_single_mask(
@@ -64,20 +69,17 @@ def process_single_mask(
     logit_threshold = probability_to_logit_threshold(mask_conf)
 
     mask_logits = np.sum(protos * mask_coeff[..., np.newaxis, np.newaxis], axis=0)
-    # Replace logits outside the bounding box with zero before interpolation.
-    mask_logits = crop_mask(mask_logits, scaled_bbox)
+    mask_logits = crop_mask(
+        mask_logits,
+        scaled_bbox,
+        fill_value=logit_threshold,
+    )
     mask_logits = cv2.resize(
         mask_logits,
         (output_shape[1], output_shape[0]),
         interpolation=cv2.INTER_LINEAR,
     )
-    mask = (mask_logits > logit_threshold).astype(np.uint8)
-
-    # Enforce the bounding box because zero-filled pixels can pass thresholding.
-    scaled_output_bbox = bbox * np.array(
-        [output_shape[1], output_shape[0], output_shape[1], output_shape[0]]
-    )
-    return crop_mask(mask, scaled_output_bbox)
+    return (mask_logits > logit_threshold).astype(np.uint8)
 
 
 def get_segmentation_outputs(

--- a/depthai_nodes/node/parsers/utils/masks_utils.py
+++ b/depthai_nodes/node/parsers/utils/masks_utils.py
@@ -66,9 +66,15 @@ def process_single_mask(
     """
     _, mask_h, mask_w = protos.shape  # CHW
     scaled_bbox = bbox * np.array([mask_w, mask_h, mask_w, mask_h])
-    logit_threshold = probability_to_logit_threshold(mask_conf)
 
     mask_logits = np.sum(protos * mask_coeff[..., np.newaxis, np.newaxis], axis=0)
+    logit_threshold = probability_to_logit_threshold(mask_conf)
+    # OpenCV interpolation with infinite fill values produces NaNs at crop edges.
+    if mask_conf == 0:
+        logit_threshold = np.finfo(mask_logits.dtype).min
+    if mask_conf == 1:
+        logit_threshold = np.finfo(mask_logits.dtype).max
+
     mask_logits = crop_mask(
         mask_logits,
         scaled_bbox,

--- a/depthai_nodes/node/parsers/utils/masks_utils.py
+++ b/depthai_nodes/node/parsers/utils/masks_utils.py
@@ -70,9 +70,9 @@ def process_single_mask(
     mask_logits = np.sum(protos * mask_coeff[..., np.newaxis, np.newaxis], axis=0)
     logit_threshold = probability_to_logit_threshold(mask_conf)
     # OpenCV interpolation with infinite fill values produces NaNs at crop edges.
-    if mask_conf == 0:
+    if mask_conf <= 0.0:
         logit_threshold = np.finfo(mask_logits.dtype).min
-    if mask_conf == 1:
+    if mask_conf >= 1.0:
         logit_threshold = np.finfo(mask_logits.dtype).max
 
     mask_logits = crop_mask(

--- a/depthai_nodes/node/parsers/utils/rf_detr.py
+++ b/depthai_nodes/node/parsers/utils/rf_detr.py
@@ -66,11 +66,10 @@ def compute_rfdetr_detections(
             )
 
         final_mask = np.full(input_shape, 255, dtype=np.uint8)
-        for i, (mask_logits, bbox) in enumerate(zip(masks, boxes_cxcywh)):
+        for i, mask_logits in enumerate(masks):
             resized_mask = process_single_mask_rfdetr(
                 mask_logits=mask_logits,
                 mask_conf=mask_conf,
-                bbox=bbox,
                 input_shape=input_shape,
             )
             foreground = resized_mask > 0


### PR DESCRIPTION
## Purpose
- Responsible faulty commit: https://github.com/luxonis/depthai-nodes/pull/329/changes/0f8a7b4ffa90a4b7cbe05d2c94c75c2eb29ec977
- Tested the metric consistency state after these changes using LuxonisEval E2E tests for instance segmentation

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved segmentation mask accuracy by preserving threshold behavior outside detected bounding boxes during resizing.
  * Improved mask boundary alignment and consistency, reducing false-positive pixels introduced during interpolation.
  * Corrected edge handling for masks with minimum or maximum confidence thresholds.
  * Updated RF-DETR mask processing to produce correctly sized thresholded masks without applying an additional bounding-box crop.
  * Preserved existing confidence filtering, detection limits, and mask composition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->